### PR TITLE
Add processing for Bluesky scheduled posts

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Domain/Constants.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants.cs
@@ -46,6 +46,7 @@ public static class Constants
         public const string BlueskyPostMessage = "BlueskyPostMessage";
         public const string BlueskyProcessRandomPostFired = "BlueskyProcessRandomPostFired";
         public const string BlueskyProcessNewSourceDataFired = "BlueskyProcessNewSourceDataFired";
+        public const string BlueskyProcessScheduledItemFired = "BlueskyProcessScheduledItemFired";
     }
 
     public static class Topics

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessScheduledItemFired.cs
@@ -1,0 +1,240 @@
+// Default URL for triggering event grid function in the local environment.
+// http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
+
+using System.Text.Json;
+using Azure.Messaging.EventGrid;
+using JosephGuadagno.Broadcasting.Data.Repositories;
+using Microsoft.Extensions.Logging;
+using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Extensions.Types;
+using Microsoft.ApplicationInsights;
+using Microsoft.Azure.Functions.Worker;
+
+namespace JosephGuadagno.Broadcasting.Functions.Bluesky;
+
+public class ProcessScheduledItemFired
+{
+  private readonly SourceDataRepository _sourceDataRepository;
+  private readonly IEngagementManager _engagementManager;
+  private readonly TelemetryClient _telemetryClient;
+  private readonly ILogger<ProcessScheduledItemFired> _logger;
+
+  const int MaxPostLength = 300;
+
+  public ProcessScheduledItemFired(
+    SourceDataRepository sourceDataRepository,
+    IEngagementManager engagementManager,
+    TelemetryClient telemetryClient,
+    ILogger<ProcessScheduledItemFired> logger)
+  {
+    _sourceDataRepository = sourceDataRepository;
+    _engagementManager = engagementManager;
+    _telemetryClient = telemetryClient;
+    _logger = logger;
+  }
+
+// Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
+    // Sample Code: https://github.com/Azure-Samples/event-grid-dotnet-publish-consume-events
+    // When debugging locally start ngrok
+    // Create a new EventGrid endpoint in Azure similar to
+    // `https://9ccb49e057a0.ngrok.io/runtime/webhooks/EventGrid?functionName=twitter_process_scheduled_item_fired`
+    [Function(Constants.ConfigurationFunctionNames.BlueskyProcessScheduledItemFired)]
+    [QueueOutput(Constants.Queues.BlueskyPostToSend)]
+    public async Task<string> RunAsync(
+        [EventGridTrigger] EventGridEvent eventGridEvent)
+    {
+        var startedAt = DateTime.UtcNow;
+        _logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
+            Constants.ConfigurationFunctionNames.BlueskyProcessScheduledItemFired, startedAt);
+
+        // Get the Source Data identifier for the event
+        if (eventGridEvent.Data is null)
+        {
+            _logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
+            return null;
+        }
+
+        var eventGridData = eventGridEvent.Data.ToString();
+
+        var tableEvent = JsonSerializer.Deserialize<TableEvent>(eventGridData);
+        if (tableEvent == null)
+        {
+            _logger.LogError("Failed to parse the TableEvent data for event '{Id}'", eventGridEvent.Id);
+            return null;
+        }
+
+        // Determine what type the post is for
+        string postText;
+        switch (tableEvent.TableName)
+        {
+            case SourceSystems.SyndicationFeed:
+            case SourceSystems.YouTube:
+                postText = await GetPostTextForSourceData(tableEvent);
+                break;
+            default:
+                postText = await GetPostTextForSqlTable(tableEvent);
+                break;
+        }
+
+        if (postText is null)
+        {
+            _logger.LogDebug(
+                "Could not generate the Bluesky post for {TableName}, {PartitionKey}, {RowKey}",
+                tableEvent.TableName, tableEvent.PartitionKey, tableEvent.RowKey);
+            return null;
+        }
+
+        _telemetryClient.TrackEvent(Constants.Metrics.BlueskyProcessedScheduledItemFired, new Dictionary<string, string>
+        {
+            {"tableName", tableEvent.TableName},
+            {"partitionKey", tableEvent.PartitionKey},
+            {"rowKey", tableEvent.RowKey},
+            {"text", postText}
+        });
+        _logger.LogDebug("Generated the Bluesky post for {TableName}, {PartitionKey}, {RowKey}",
+            tableEvent.TableName, tableEvent.PartitionKey, tableEvent.RowKey);
+        return postText;
+    }
+    private async Task<string> GetPostTextForSourceData(TableEvent tableEvent)
+    {
+        if (tableEvent is null)
+        {
+            return null;
+        }
+
+        var statusText = "ICYMI: ";
+        var sourceData = await _sourceDataRepository.GetAsync(tableEvent.PartitionKey, tableEvent.RowKey);
+        if (sourceData is null)
+        {
+            _logger.LogWarning("Record for '{PartitionKey}', '{RowKey}' was not found",
+                tableEvent.TableName, tableEvent.PartitionKey);
+            return null;
+        }
+
+        statusText = sourceData.SourceSystem switch
+        {
+            SourceSystems.SyndicationFeed => "Blog Post: ",
+            SourceSystems.YouTube => "Video: ",
+            _ => statusText
+        };
+
+        var url = sourceData.ShortenedUrl ?? sourceData.Url;
+        var postTitle = sourceData.Title;
+        var hashTagList = HashTagList(sourceData.Tags);
+
+        if (statusText.Length + url.Length + postTitle.Length + 3 + hashTagList.Length >= MaxPostLength)
+        {
+            var newLength = MaxPostLength - statusText.Length - url.Length - hashTagList.Length - 1;
+            postTitle = string.Concat(postTitle.AsSpan(0, newLength - 4), "...");
+        }
+
+        var blueskyPost = $"{statusText} {postTitle} {url} {hashTagList}";
+
+        _logger.LogDebug("Composed Bluesky Post '{BlueskyPost}'", blueskyPost);
+        return statusText;
+    }
+
+    private async Task<string> GetPostTextForSqlTable(TableEvent tableEvent)
+    {
+        if (tableEvent is null)
+        {
+            return null;
+        }
+
+        string postText = null;
+        Engagement engagement;
+        switch (tableEvent.TableName)
+        {
+            case SourceSystems.Engagements:
+                engagement = await _engagementManager.GetAsync(tableEvent.PartitionKey.To<int>());
+                postText = GetPostForEngagement(engagement);
+                break;
+            case SourceSystems.Talks:
+                var talk = await _engagementManager.GetTalkAsync(tableEvent.PartitionKey.To<int>());
+                engagement = await _engagementManager.GetAsync(talk.Id);
+                postText = GetPostForTalk(talk, engagement);
+                break;
+        }
+
+        return postText;
+    }
+
+    private string GetPostForEngagement(Engagement engagement)
+    {
+        // TODO: Account for custom images for engagement
+        // TODO: Account for custom message for engagement
+        //  i.e: Join me tomorrow, Join me next week
+        // TODO: Maybe handle timezone?
+        if (engagement is null)
+        {
+            return null;
+        }
+
+        var statusText = $"I'm speaking at {engagement.Name} ({engagement.Url}) starting on {engagement.StartDateTime:f}";
+        var comments = engagement.Comments;
+        statusText += " " + comments;
+
+        if (statusText.Length + comments.Length + 1 >= MaxPostLength)
+        {
+            var newLength = MaxPostLength - statusText.Length - comments.Length - 1;
+            statusText = statusText.Substring(0, newLength - 4) + "...";
+        }
+
+        _logger.LogDebug("Composed BlueskyPost '{StatusText}'", statusText);
+        return statusText;
+    }
+
+    private string GetPostForTalk(Talk talk, Engagement engagement)
+    {
+        if (talk is null)
+        {
+            return null;
+        }
+        // TODO: Account for custom images for talk
+        // TODO: Account for custom message for talk
+        //  i.e: Join me tomorrow, Join me next week, "Up next in room...", "Join me today..."
+        // TODO: Maybe handle timezone?
+
+        var statusText = $"My talk: {talk.Name} ({talk.UrlForTalk})";
+        if (engagement is not null)
+        {
+            statusText += " at " + engagement.Name;
+        }
+        statusText += $" is starting at {talk.StartDateTime:f}";
+        if (talk.TalkLocation is not null)
+        {
+            statusText += $" in room {talk.TalkLocation}";
+        }
+
+        statusText += " Come see it!";
+        if (engagement?.Comments is not null)
+        {
+            statusText += " Comments" + engagement.Comments;
+        }
+
+        if (statusText.Length + 1 >= MaxPostLength)
+        {
+            var newLength = MaxPostLength - statusText.Length - 1;
+            statusText = statusText.Substring(0, newLength - 4) + "...";
+        }
+
+        _logger.LogDebug("Composed Bluesky Posts '{StatusText}'", statusText);
+        return statusText;
+    }
+
+    private string HashTagList(string tags)
+    {
+        if (string.IsNullOrEmpty(tags))
+        {
+            return "#dotnet #csharp #dotnetcore";
+        }
+
+        var tagList = tags.Split(',');
+        var hashTagCategories = tagList.Where(tag => !tag.Contains("Article"));
+
+        return hashTagCategories.Aggregate("",
+            (current, tag) => current + $" #{tag.Replace(" ", "").Replace(".", "")}");
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces an Azure Function, `ProcessScheduledItemFired`, to handle events related to scheduled posts for the Bluesky platform. Key features include:

- Methods to compose posts based on various event types, such as `Engagements`, `Talks`, and other source data (`SyndicationFeed`, `YouTube`, etc.).
- Queue integration for further processing of the generated posts.
- A new `BlueskyProcessScheduledItemFired` constant in `Constants.ConfigurationFunctionNames`.

Resolves #195.

### Checklist

- [X] Ensure code meets the repository's contribution guidelines.
- [X] Verify the Azure Function is registered and deployable.
- [X] Confirm end-to-end processing of scheduled posts works as expected.
- [ ] Add tests for major functionalities introduced.

### Notes for Reviewers

Reviewers are encouraged to focus on function implementation details and ensure the queue outputs align with expected data formats.