### PR TITLE
Replace Application Insights with Azure Monitor and Serilog logging

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/JosephGuadagno.Broadcasting.Api.csproj
+++ b/src/JosephGuadagno.Broadcasting.Api/JosephGuadagno.Broadcasting.Api.csproj
@@ -41,11 +41,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.1.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.46" />
     <PackageReference Include="Scalar.AspNetCore.Microsoft" Version="2.12.46" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -56,8 +55,8 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JosephGuadagno.Broadcasting.Data.Sql\JosephGuadagno.Broadcasting.Data.Sql.csproj" />

--- a/src/JosephGuadagno.Broadcasting.Api/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Program.cs
@@ -1,18 +1,20 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Azure.Monitor.OpenTelemetry.Exporter;
+
+using JosephGuadagno.Broadcasting.Api.Interfaces;
+using JosephGuadagno.Broadcasting.Api.Models;
 using JosephGuadagno.Broadcasting.Data.Repositories;
 using JosephGuadagno.Broadcasting.Data.Sql;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Managers;
 using JosephGuadagno.Broadcasting.Serilog;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Identity.Web;
+using OpenTelemetry.Logs;
 using Scalar.AspNetCore;
 using Serilog;
 using Serilog.Exceptions;
-using ISettings = JosephGuadagno.Broadcasting.Api.Interfaces.ISettings;
-using Settings = JosephGuadagno.Broadcasting.Api.Models.Settings;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -37,15 +39,11 @@ builder.Services.TryAddSingleton<IAzureAdSettings>(azureAdSettings);
 
 builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration);
 
-builder.Services.AddSingleton<ITelemetryInitializer, AzureWebAppRoleEnvironmentTelemetryInitializer>();
-builder.Services.AddApplicationInsightsTelemetry();
-
-// Configure the logger
+// Configure the telemetry and logging
 var fullyQualifiedLogFile = Path.Combine(builder.Environment.ContentRootPath, "logs\\logs.txt");
-ConfigureLogging(builder.Configuration, builder.Services, settings, fullyQualifiedLogFile, "Api");
+ConfigureTelemetryAndLogging(builder.Services, settings.LoggingStorageAccount, fullyQualifiedLogFile, "Api");
 
 // Register DI services
-ConfigureApplication(builder.Services);
 
 // Add in AutoMapper
 builder.Services.AddAutoMapper(config =>
@@ -53,6 +51,8 @@ builder.Services.AddAutoMapper(config =>
     config.LicenseKey = autoMapperSettings.LicenseKey;
     config.AddProfile<JosephGuadagno.Broadcasting.Data.Sql.MappingProfiles.BroadcastingProfile>();
 }, typeof(Program));
+
+ConfigureApplication(builder.Services);
 
 // ASP.NET Core API stuff
 builder.Services.AddControllers();
@@ -104,8 +104,11 @@ app.MapControllers();
 
 app.Run();
 
-void ConfigureLogging(IConfigurationRoot configurationRoot, IServiceCollection services, ISettings configSettings, string logPath, string applicationName)
+void ConfigureTelemetryAndLogging(IServiceCollection services, string logStorageAccount, string logPath, string applicationName)
 {
+
+    builder.Services.AddOpenTelemetry().UseAzureMonitor();
+
     var logger = new LoggerConfiguration()
         .Enrich.FromLogContext()
         .Enrich.WithMachineName()
@@ -120,14 +123,15 @@ void ConfigureLogging(IConfigurationRoot configurationRoot, IServiceCollection s
         .Destructure.ToMaximumCollectionCount(10)
         .WriteTo.Console()
         .WriteTo.File(logPath, rollingInterval: RollingInterval.Day)
-        .WriteTo.AzureTableStorage(configSettings.LoggingStorageAccount, storageTableName:"Logging", keyGenerator:new SerilogKeyGenerator())
+        .WriteTo.AzureTableStorage(logStorageAccount, storageTableName:"Logging", keyGenerator:new SerilogKeyGenerator())
+        .WriteTo.OpenTelemetry()
         .CreateLogger();
     services.AddLogging(loggingBuilder =>
     {
-        loggingBuilder.AddApplicationInsights(configureTelemetryConfiguration: (config) =>
-                config.ConnectionString =
-                    configurationRoot["APPLICATIONINSIGHTS_CONNECTION_STRING"],
-            configureApplicationInsightsLoggerOptions: (_) => { });
+        loggingBuilder.AddOpenTelemetry(options =>
+        {
+            options.AddConsoleExporter();
+        });
         loggingBuilder.AddSerilog(logger);
     });
 }

--- a/src/JosephGuadagno.Broadcasting.AppHost/AppHost.cs
+++ b/src/JosephGuadagno.Broadcasting.AppHost/AppHost.cs
@@ -31,7 +31,7 @@ var db = sql.AddDatabase("JJGNet")
 
 var api = builder.AddProject<JosephGuadagno_Broadcasting_Api>("josephguadagno-broadcasting-api")
     .WithEnvironment("ConnectionStrings__JJGNetDatabaseSqlServer", db)
-    .WithEnvironment("Settings__StorageAccount", tableStorage)
+    .WithEnvironment("Settings__LoggingStorageAccount", tableStorage)
     .WaitFor(blobStorage)
     .WaitFor(queueStorage)
     .WaitFor(blobStorage)
@@ -53,11 +53,11 @@ builder.AddAzureFunctionsProject<JosephGuadagno_Broadcasting_Functions>("Functio
     .WaitFor(blobStorage)
     .WaitFor(queueStorage)
     .WithEnvironment("ConnectionStrings__JJGNetDatabaseSqlServer", db)
-    .WithEnvironment("Settings__StorageAccount", tableStorage);
+    .WithEnvironment("Settings__LoggingStorageAccount", tableStorage);
 
 builder.AddProject<JosephGuadagno_Broadcasting_Web>("josephguadagno-broadcasting-web")
     .WithEnvironment("ConnectionStrings__JJGNetDatabaseSqlServer", db)
-    .WithEnvironment("Settings__StorageAccount", tableStorage)
+    .WithEnvironment("Settings__LoggingStorageAccount", tableStorage)
     .WithReference(api)
     .WaitFor(api);
 

--- a/src/JosephGuadagno.Broadcasting.Data.KeyVault/JosephGuadagno.Broadcasting.Data.KeyVault.csproj
+++ b/src/JosephGuadagno.Broadcasting.Data.KeyVault/JosephGuadagno.Broadcasting.Data.KeyVault.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
       <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-      <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     </ItemGroup>

--- a/src/JosephGuadagno.Broadcasting.Data/JosephGuadagno.Broadcasting.Data.csproj
+++ b/src/JosephGuadagno.Broadcasting.Data/JosephGuadagno.Broadcasting.Data.csproj
@@ -38,7 +38,6 @@
     <PackageReference Include="JosephGuadagno.AzureHelpers.Cosmos" Version="1.0.8" />
     <PackageReference Include="JosephGuadagno.Extensions" Version="1.2.5" />
     <PackageReference Include="JosephGuadagno.Utilities.Web" Version="1.1.7" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />

--- a/src/JosephGuadagno.Broadcasting.Domain/ILoggerExtension.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/ILoggerExtension.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Domain;
+
+public static class ILoggerExtension
+{
+    public static void LogCustomEvent(this ILogger logger, string eventName, Dictionary<string, string>? properties = null)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(eventName);
+
+        string message = "{microsoft.custom_event.name} ";
+        object[] values;
+        if (properties is not null && properties.Count > 0)
+        {
+            foreach (var property in properties)
+            {
+                message += "{" + property.Key + "} ";
+            }
+            values = new[] { eventName }.Concat(properties.Values).ToArray<object>();
+        }
+        else
+        {
+            values = [eventName];
+        }
+        logger.LogInformation(message, values);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
@@ -43,9 +43,6 @@
         <PackageReference Include="JosephGuadagno.AzureHelpers.Cosmos" Version="1.0.8"/>
         <PackageReference Include="JosephGuadagno.Extensions" Version="1.2.5"/>
         <PackageReference Include="linqtotwitter" Version="6.15.0"/>
-        <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0"/>
-        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0"/>
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0"/>
         <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0"/>
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.6.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0"/>
@@ -68,7 +65,6 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0"/>
@@ -77,7 +73,6 @@
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1"/>
         <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
         <PackageReference Include="Serilog.Exceptions" Version="8.4.0"/>
-        <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0"/>
         <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Startup.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Startup.cs
@@ -4,7 +4,8 @@ using System.IO;
 using System.Net.Http;
 using System.Reflection;
 
-using Microsoft.Azure.Functions.Worker;
+using Azure.Monitor.OpenTelemetry.Exporter;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -40,6 +41,8 @@ using LinqToTwitter;
 using LinqToTwitter.OAuth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Azure;
+
+using OpenTelemetry.Logs;
 
 using Serilog;
 using Serilog.Exceptions;
@@ -97,11 +100,7 @@ public class Startup
 
         // Configure the logger
         string loggerFile = Path.Combine(_currentDirectory, $"logs{Path.DirectorySeparatorChar}logs.txt");
-        ConfigureLogging(config, services, settings, loggerFile, "Functions");
-
-        services
-            .AddApplicationInsightsTelemetryWorkerService()
-            .ConfigureFunctionsApplicationInsights();
+        ConfigureTelemetryAndLogging(services, settings.LoggingStorageAccount, loggerFile,"Functions");
 
         // Add in AutoMapper
         var autoMapperSettings = new AutoMapperSettings();
@@ -125,9 +124,11 @@ public class Startup
 
     }
 
-    private void ConfigureLogging(IConfiguration configurationRoot, IServiceCollection services, ISettings appSettings,
-        string logPath, string applicationName)
+    void ConfigureTelemetryAndLogging(IServiceCollection services, string logStorageAccount, string logPath, string applicationName)
     {
+
+        services.AddOpenTelemetry().UseAzureMonitorExporter();
+
         var logger = new LoggerConfiguration()
 #if DEBUG
             .MinimumLevel.Debug()
@@ -147,15 +148,16 @@ public class Startup
             .Destructure.ToMaximumCollectionCount(10)
             .WriteTo.Console()
             .WriteTo.File(logPath, rollingInterval: RollingInterval.Day)
-            .WriteTo.AzureTableStorage(appSettings.LoggingStorageAccount, storageTableName: "Logging",
+            .WriteTo.AzureTableStorage(logStorageAccount, storageTableName: "Logging",
                 keyGenerator: new SerilogKeyGenerator())
+            .WriteTo.OpenTelemetry()
             .CreateLogger();
         services.AddLogging(loggingBuilder =>
         {
-            loggingBuilder.AddApplicationInsights(configureTelemetryConfiguration: (config) =>
-                    config.ConnectionString =
-                        configurationRoot["APPLICATIONINSIGHTS_CONNECTION_STRING"],
-                configureApplicationInsightsLoggerOptions: (_) => { });
+            loggingBuilder.AddOpenTelemetry(options =>
+            {
+                options.AddConsoleExporter();
+            });
             loggingBuilder.AddSerilog(logger);
         });
     }
@@ -221,7 +223,7 @@ public class Startup
     {
         var twitterSettings = new InMemoryCredentialStore();
         config.Bind("Twitter", twitterSettings);
-        services.TryAddSingleton<InMemoryCredentialStore>(twitterSettings);
+        services.TryAddSingleton(twitterSettings);
 
         services.TryAddSingleton<IAuthorizer>(s =>
         {

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewRandomPost.cs
@@ -2,17 +2,17 @@
 
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Bluesky;
 
-public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedSourceManager, TelemetryClient telemetryClient, ILogger<ProcessNewRandomPost> logger)
+public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedSourceManager, ILogger<ProcessNewRandomPost> logger)
 {
     [Function(ConfigurationFunctionNames.BlueskyProcessRandomPostFired)]
     [QueueOutput(Queues.BlueskyPostToSend)]
@@ -58,12 +58,13 @@ public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedS
             }
 
             // Return
-            telemetryClient.TrackEvent(Metrics.BlueskyProcessedRandomPost, new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 {"title", sourceData.Title},
                 {"url", sourceData.Url},
                 {"post", postText}
-            });
+            };
+            logger.LogCustomEvent(Metrics.BlueskyProcessedRandomPost, properties);
             logger.LogDebug("Picked a random post {Title}", sourceData.Title);
             return blueskyPostMessage;
         }

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSyndicationDataFired.cs
@@ -1,12 +1,11 @@
 ﻿using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
-using JosephGuadagno.Broadcasting.Managers;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -14,7 +13,6 @@ namespace JosephGuadagno.Broadcasting.Functions.Bluesky;
 
 public class ProcessNewSyndicationDataFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewSyndicationDataFired> logger)
 {
     [Function(ConfigurationFunctionNames.BlueskyProcessNewSyndicationDataFired)]
@@ -68,13 +66,14 @@ public class ProcessNewSyndicationDataFired(
             }
 
             // Return
-            telemetryClient.TrackEvent(Metrics.BlueskyProcessedNewSyndicationData, new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 {"post", postText},
                 {"title", syndicationFeedSource.Title},
                 {"url", syndicationFeedSource.Url},
                 {"id", syndicationFeedSource.Id.ToString()}
-            });
+            };
+            logger.LogCustomEvent(Metrics.BlueskyProcessedNewSyndicationData, properties);
             logger.LogDebug("Posted to Bluesky: {Title}", syndicationFeedSource.Title);
             return blueskyPostMessage;
         }

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewYouTubeDataFired.cs
@@ -1,11 +1,11 @@
 ﻿using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -13,7 +13,6 @@ namespace JosephGuadagno.Broadcasting.Functions.Bluesky;
 
 public class ProcessNewYouTubeDataFired(
     IYouTubeSourceManager youtubeSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewYouTubeDataFired> logger)
 {
     [Function(ConfigurationFunctionNames.BlueskyProcessNewYouTubeDataFired)]
@@ -67,13 +66,14 @@ public class ProcessNewYouTubeDataFired(
             }
 
             // Return
-            telemetryClient.TrackEvent(Metrics.BlueskyProcessedNewYouTubeData, new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 {"post", postText},
                 {"title", youTubeSource.Title},
                 {"url", youTubeSource.Url},
                 {"id", youTubeSource.Id.ToString()}
-            });
+            };
+            logger.LogCustomEvent(Metrics.BlueskyProcessedNewYouTubeData, properties);
             logger.LogDebug("Posted to Bluesky: {Title}", youTubeSource.Title);
             return blueskyPostMessage;
         }

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessScheduledItemFired.cs
@@ -5,7 +5,6 @@ using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +15,6 @@ public class ProcessScheduledItemFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IYouTubeSourceManager youTubeSourceManager,
     IEngagementManager engagementManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessScheduledItemFired> logger)
 {
     const int MaxPostLength = 300;
@@ -77,13 +75,14 @@ public class ProcessScheduledItemFired(
                     return null;
             }
 
-            telemetryClient.TrackEvent(Metrics.BlueskyProcessedScheduledItemFired,
-                new Dictionary<string, string>
-                {
-                    { "tableName", scheduledItem.ItemTableName },
-                    { "id", scheduledItem.ItemPrimaryKey.ToString() },
-                    { "text", blueSkyPostText }
-                });
+
+            var properties = new Dictionary<string, string>
+            {
+                { "tableName", scheduledItem.ItemTableName },
+                { "id", scheduledItem.ItemPrimaryKey.ToString() },
+                { "text", blueSkyPostText }
+            };
+            logger.LogCustomEvent(Metrics.BlueskyProcessedScheduledItemFired, properties);
             logger.LogDebug("Generated the BlueSky post text for {TableName}, {PrimaryKey}",
                 scheduledItem.ItemTableName, scheduledItem.ItemPrimaryKey);
             return blueSkyPostText;

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/SendPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/SendPost.cs
@@ -1,15 +1,16 @@
 ﻿using idunno.Bluesky;
 using idunno.Bluesky.RichText;
+
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Interfaces;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Bluesky;
 
-public class SendPost(IBlueskyManager blueskyManager, TelemetryClient telemetryClient, ILogger<SendPost> logger)
+public class SendPost(IBlueskyManager blueskyManager,ILogger<SendPost> logger)
 {
     [Function(ConfigurationFunctionNames.BlueskyPostMessage)]
     public async Task Run(
@@ -50,11 +51,12 @@ public class SendPost(IBlueskyManager blueskyManager, TelemetryClient telemetryC
             if (response is not null)
             {
                 logger.LogDebug("Posting to bluesky: {Text}", postBuilder.Text);
-                telemetryClient.TrackEvent(Metrics.BlueskyPostSent, new Dictionary<string, string>
+                var properties = new Dictionary<string, string>
                 {
-                    {"message", postBuilder.Text},
+                    {"message", postBuilder.Text?? string.Empty},
                     {"cid", response.Cid.ToString()}
-                });
+                };
+                logger.LogCustomEvent(Metrics.BlueskyPostSent, properties);
                 return;
             }
             logger.LogError("Failed to post to Bluesky. Response was null");

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadAllSpeakingEngagements.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadAllSpeakingEngagements.cs
@@ -1,9 +1,9 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Interfaces;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -15,8 +15,7 @@ public class LoadAllSpeakingEngagements(
     ISpeakingEngagementsReader speakerEngagementsReader,
     IEngagementManager engagementManager,
     IFeedCheckManager feedCheckManager,
-    ILogger<LoadAllSpeakingEngagements> logger,
-    TelemetryClient telemetryClient)
+    ILogger<LoadAllSpeakingEngagements> logger)
 {
     [Function(ConfigurationFunctionNames.CollectorsSpeakingEngagementsLoadAll)]
     public async Task<IActionResult> RunAsync(
@@ -68,7 +67,7 @@ public class LoadAllSpeakingEngagements(
                         { "StartDateTime", engagement.StartDateTime.ToString("o") },
                         { "EndDateTime", engagement.EndDateTime.ToString("o") }
                     };
-                    telemetryClient.TrackEvent(Metrics.SpeakingEngagementAddedOrUpdated, properties);
+                    logger.LogCustomEvent(Metrics.SpeakingEngagementAddedOrUpdated, properties);
                     savedCount++;
                 }
                 catch (Exception e)

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs
@@ -1,9 +1,9 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Interfaces;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -14,8 +14,7 @@ public class LoadNewSpeakingEngagements(
     ISpeakingEngagementsReader speakerEngagementsReader,
     IEngagementManager engagementManager,
     IFeedCheckManager feedCheckManager,
-    ILogger<LoadNewSpeakingEngagements> logger,
-    TelemetryClient telemetryClient)
+    ILogger<LoadNewSpeakingEngagements> logger)
 {
     [Function(ConfigurationFunctionNames.CollectorsSpeakingEngagementsLoadNew)]
     public async Task<IActionResult> RunAsync(
@@ -66,7 +65,7 @@ public class LoadNewSpeakingEngagements(
                         { "StartDateTime", engagement.StartDateTime.ToString("o") },
                         { "EndDateTime", engagement.EndDateTime.ToString("o") }
                     };
-                    telemetryClient.TrackEvent(Metrics.SpeakingEngagementAddedOrUpdated, properties);
+                    logger.LogCustomEvent(Metrics.SpeakingEngagementAddedOrUpdated, properties);
                     savedCount++;
                 }
                 catch (Exception e)

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
@@ -1,3 +1,4 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
@@ -5,7 +6,6 @@ using JosephGuadagno.Broadcasting.Functions.Interfaces;
 using JosephGuadagno.Broadcasting.SyndicationFeedReader.Interfaces;
 using JosephGuadagno.Extensions.Types;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -19,8 +19,7 @@ public class LoadAllPosts(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IFeedCheckManager feedCheckManager,
     IUrlShortener urlShortener,
-    ILogger<LoadAllPosts> logger,
-    TelemetryClient telemetryClient)
+    ILogger<LoadAllPosts> logger)
 {
     [Function(ConfigurationFunctionNames.CollectorsFeedLoadAllPosts)]
     public async Task<IActionResult> RunAsync(
@@ -66,11 +65,11 @@ public class LoadAllPosts(
                 try
                 {
                     var savedItem = await syndicationFeedSourceManager.SaveAsync(item);
-                    telemetryClient.TrackEvent(Metrics.PostAddedOrUpdated,
-                        new Dictionary<string, string>
-                        {
-                            { "Id", savedItem.Id.ToString() }, { "Url", savedItem.Url }, { "Title", savedItem.Title }
-                        });
+                    var properties = new Dictionary<string, string>
+                    {
+                        { "Id", savedItem.Id.ToString() }, { "Url", savedItem.Url }, { "Title", savedItem.Title }
+                    };
+                    logger.LogCustomEvent(Metrics.PostAddedOrUpdated, properties);
                     savedCount++;
                 }
                 catch (Exception e)

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
@@ -1,10 +1,10 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Functions.Interfaces;
 using JosephGuadagno.Broadcasting.SyndicationFeedReader.Interfaces;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -18,8 +18,7 @@ public class LoadNewPosts(
     IFeedCheckManager feedCheckManager,
     IUrlShortener urlShortener,
     IEventPublisher eventPublisher,
-    ILogger<LoadNewPosts> logger,
-    TelemetryClient telemetryClient)
+    ILogger<LoadNewPosts> logger)
 {
 
     [Function(ConfigurationFunctionNames.CollectorsFeedLoadNewPosts)]
@@ -63,11 +62,12 @@ public class LoadNewPosts(
                 {
                     var savedItem = await syndicationFeedSourceManager.SaveAsync(item);
                     eventsToPublish.Add(savedItem);
-                    telemetryClient.TrackEvent(Metrics.PostAddedOrUpdated,
-                        new Dictionary<string, string>
+
+                    var properties = new Dictionary<string, string>
                         {
                             { "Id", savedItem.Id.ToString() }, { "Url", savedItem.Url }, { "Title", savedItem.Title }
-                        });
+                        };
+                    logger.LogCustomEvent(Metrics.PostAddedOrUpdated, properties);
                     savedCount++;
                 }
                 catch (Exception e)

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
@@ -1,10 +1,10 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Functions.Interfaces;
 using JosephGuadagno.Broadcasting.YouTubeReader.Interfaces;
 using JosephGuadagno.Extensions.Types;
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -18,8 +18,7 @@ public class LoadAllVideos(
     IYouTubeSourceManager youTubeSourceManager,
     IFeedCheckManager feedCheckManager,
     IUrlShortener urlShortener,
-    ILogger<LoadAllVideos> logger,
-    TelemetryClient telemetryClient)
+    ILogger<LoadAllVideos> logger)
 {
 
     [Function(ConfigurationFunctionNames.CollectorsYouTubeLoadAllVideos)]
@@ -68,12 +67,12 @@ public class LoadAllVideos(
                 {
                     var savedItem = await youTubeSourceManager.SaveAsync(item);
 
-                    telemetryClient.TrackEvent(Metrics.VideoAddedOrUpdated,
-                        new Dictionary<string, string>
-                        {
-                            { "Id", savedItem.Id.ToString() }, { "VideoId", savedItem.VideoId },
-                            { "Url", savedItem.Url }, { "Title", savedItem.Title }
-                        });
+                    var properties = new Dictionary<string, string>
+                    {
+                        { "Id", savedItem.Id.ToString() }, { "VideoId", savedItem.VideoId },
+                        { "Url", savedItem.Url }, { "Title", savedItem.Title }
+                    };
+                    logger.LogCustomEvent(Metrics.VideoAddedOrUpdated, properties);
                     savedCount++;
                 }
                 catch (Exception e)

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
@@ -1,9 +1,9 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Functions.Interfaces;
 using JosephGuadagno.Broadcasting.YouTubeReader.Interfaces;
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -17,8 +17,7 @@ public class LoadNewVideos(
     IYouTubeSourceManager youTubeSourceManager,
     IUrlShortener urlShortener,
     IEventPublisher eventPublisher,
-    ILogger<LoadNewVideos> logger,
-    TelemetryClient telemetryClient)
+    ILogger<LoadNewVideos> logger)
 {
 
     [Function(ConfigurationFunctionNames.CollectorsYouTubeLoadNewVideos)]
@@ -64,12 +63,12 @@ public class LoadNewVideos(
                     var savedItem = await youTubeSourceManager.SaveAsync(item);
 
                     eventsToPublish.Add(savedItem);
-                    telemetryClient.TrackEvent(Metrics.VideoAddedOrUpdated,
-                        new Dictionary<string, string>
-                        {
-                            { "Id", savedItem.Id.ToString() }, { "VideoId", savedItem.VideoId },
-                            { "Url", savedItem.Url }, { "Title", savedItem.Title }
-                        });
+                    var properties = new Dictionary<string, string>
+                    {
+                        { "Id", savedItem.Id.ToString() }, { "VideoId", savedItem.VideoId },
+                        { "Url", savedItem.Url }, { "Title", savedItem.Title }
+                    };
+                    logger.LogCustomEvent(Metrics.VideoAddedOrUpdated, properties);
                     savedCount++;
 
                 }

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/PostPageStatus.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/PostPageStatus.cs
@@ -1,49 +1,39 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Managers.Facebook.Interfaces;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Facebook;
 
-public class PostPageStatus
+public class PostPageStatus(IFacebookManager facebookManager, ILogger<PostPageStatus> logger)
 {
-    private readonly IFacebookManager _facebookManager;
-    private readonly TelemetryClient _telemetryClient;
-    private readonly ILogger<PostPageStatus> _logger;
-
-    public PostPageStatus(IFacebookManager facebookManager, TelemetryClient telemetryClient, ILogger<PostPageStatus> logger)
-    {
-        _facebookManager = facebookManager;
-        _telemetryClient = telemetryClient;
-        _logger = logger;
-    }
-        
     [Function(ConfigurationFunctionNames.FacebookPostPageStatus)]
     public async Task Run(
         [QueueTrigger(Queues.FacebookPostStatusToPage)]
         Domain.Models.Messages.FacebookPostStatus facebookPostStatus)
     {
         var startedAt = DateTime.UtcNow;
-        _logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
+        logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookPostPageStatus, startedAt);
 
         try
         {
-            var pageId = await _facebookManager.PostMessageAndLinkToPage(facebookPostStatus.StatusText, facebookPostStatus.LinkUri);
+            var pageId = await facebookManager.PostMessageAndLinkToPage(facebookPostStatus.StatusText, facebookPostStatus.LinkUri);
 
             if (!string.IsNullOrEmpty(pageId))
             {
-                _telemetryClient.TrackEvent(Metrics.FacebookPostPageStatus, new Dictionary<string, string>
+                var properties = new Dictionary<string, string>
                 {
                     {"statusText", facebookPostStatus.StatusText}, 
                     {"url", facebookPostStatus.LinkUri},
-                });
+                };
+                logger.LogCustomEvent(Metrics.FacebookPostPageStatus, properties);
             }
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Failed to post status. Exception: {ExceptionMessage}", e.Message);
+            logger.LogError(e, "Failed to post status. Exception: {ExceptionMessage}", e.Message);
             throw;
         }
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSyndicationDataFired.cs
@@ -1,12 +1,12 @@
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -14,7 +14,6 @@ namespace JosephGuadagno.Broadcasting.Functions.Facebook;
 
 public class ProcessNewSyndicationDataFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewSyndicationDataFired> logger)
 {
     // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
@@ -53,13 +52,14 @@ public class ProcessNewSyndicationDataFired(
         var status = ComposeStatus(syndicationFeedSource);
         
         // Done
-        telemetryClient.TrackEvent(Metrics.FacebookProcessedNewSyndicationData, new Dictionary<string, string>
+        var properties = new Dictionary<string, string>
         {
             {"post", status.StatusText},
             {"title", syndicationFeedSource.Title},
             {"url", syndicationFeedSource.Url},
             {"id", syndicationFeedSource.Id.ToString()}
-        });
+        };
+        logger.LogCustomEvent(Metrics.FacebookProcessedNewSyndicationData, properties);
         logger.LogDebug("Done composing Facebook status for '{Id}' with title of '{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
         return status;
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewYouTubeDataFired.cs
@@ -1,12 +1,12 @@
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -14,7 +14,6 @@ namespace JosephGuadagno.Broadcasting.Functions.Facebook;
 
 public class ProcessNewYouTubeDataFired(
     IYouTubeSourceManager youtubeSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewYouTubeDataFired> logger)
 {
     // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
@@ -54,13 +53,14 @@ public class ProcessNewYouTubeDataFired(
         var status = ComposeStatus(youTubeSource);
         
         // Done
-        telemetryClient.TrackEvent(Metrics.FacebookProcessedNewYouTubeData, new Dictionary<string, string>
+        var properties = new Dictionary<string, string>
         {
             {"post", status.StatusText},
             {"title", youTubeSource.Title},
             {"url", youTubeSource.Url},
             {"id", youTubeSource.Id.ToString()}
-        });
+        };
+        logger.LogCustomEvent(Metrics.FacebookProcessedNewYouTubeData, properties);
         logger.LogDebug("Done composing Facebook status for '{Id}' with title of '{Title}'", youTubeSource.Id, youTubeSource.Title);
         return status;
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessScheduledItemFired.cs
@@ -5,7 +5,6 @@ using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +15,6 @@ public class ProcessScheduledItemFired(
     IEngagementManager engagementManager,
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IYouTubeSourceManager youTubeSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessScheduledItemFired> logger)
 {
     const int MaxFacebookStatusText = 2000;
@@ -76,14 +74,14 @@ public class ProcessScheduledItemFired(
                     return null;
             }
 
-            telemetryClient.TrackEvent(Metrics.FacebookProcessedScheduledItemFired,
-                new Dictionary<string, string>
-                {
-                    { "tableName", scheduledItem.ItemTableName },
-                    { "id", scheduledItem.ItemPrimaryKey.ToString() },
-                    { "text", facebookPostStatus.StatusText },
-                    { "url", facebookPostStatus.LinkUri }
-                });
+            var properties = new Dictionary<string, string>
+            {
+                { "tableName", scheduledItem.ItemTableName },
+                { "id", scheduledItem.ItemPrimaryKey.ToString() },
+                { "text", facebookPostStatus.StatusText },
+                { "url", facebookPostStatus.LinkUri }
+            };
+            logger.LogCustomEvent(Metrics.FacebookProcessedScheduledItemFired, properties);
             logger.LogDebug("Generated the Facebook status for {TableName}, {PrimaryKey}",
                 scheduledItem.ItemTableName, scheduledItem.ItemPrimaryKey);
             return facebookPostStatus;

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/RefreshTokens.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/RefreshTokens.cs
@@ -4,7 +4,6 @@ using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Managers.Facebook.Interfaces;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -15,16 +14,14 @@ public class RefreshTokens(
     IFacebookApplicationSettings facebookApplicationSettings,
     ITokenRefreshManager tokenRefreshManager,
     IKeyVault keyVault,
-    ILoggerFactory loggerFactory,
-    TelemetryClient telemetryClient)
+    ILogger<RefreshTokens> logger)
 {
-    private readonly ILogger<RefreshTokens> _logger = loggerFactory.CreateLogger<RefreshTokens>();
 
     [Function(ConfigurationFunctionNames.FacebookTokenRefresh)]
     public async Task Run([TimerTrigger("%facebook_refresh_tokens_cron_settings%")] TimerInfo myTimer)
     {
         var startedAt = DateTime.UtcNow;
-        _logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
+        logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookTokenRefresh, startedAt);
 
         await RefreshToken(Managers.Facebook.Constants.TokenTypes.LongLived, facebookApplicationSettings.LongLivedAccessToken);
@@ -35,13 +32,13 @@ public class RefreshTokens(
     {
         if (string.IsNullOrWhiteSpace(token))
         {
-            _logger.LogError("Token is null or empty. Cannot refresh the token");
+            logger.LogError("Token is null or empty. Cannot refresh the token");
             return;
         }
         
         const string azureKeyVaultSecretName = "jjg-net-facebook-{token-name}-access-token";
         
-        // Check the Long Lived Token - Refresh it if needed
+        // Check the Long-Lived Token - Refresh it if needed
         var tokenInfo = await tokenRefreshManager.GetByNameAsync(tokenType.DisplayName()) ??
                                 new TokenRefresh
                                 {
@@ -54,7 +51,7 @@ public class RefreshTokens(
         if (tokenInfo.Expires < DateTime.UtcNow || tokenInfo.Expires.AddDays(-5) < DateTime.UtcNow)
         {
             // Refresh the token
-            _logger.LogDebug("{DisplayName} is expired or will expire soon. Refreshing the token", tokenType.DisplayName());
+            logger.LogDebug("{DisplayName} is expired or will expire soon. Refreshing the token", tokenType.DisplayName());
             try
             {
                 var newToken = await facebookManager.RefreshToken(token);
@@ -71,23 +68,24 @@ public class RefreshTokens(
                 await tokenRefreshManager.SaveAsync(tokenInfo);
                 
                 // Update logs and telemetry
-                _logger.LogInformation("{DisplayName} refreshed successfully. Expires on {Expires:f}",
+                logger.LogInformation("{DisplayName} refreshed successfully. Expires on {Expires:f}",
                     tokenType.DisplayName(), tokenInfo.Expires);
                 var eventName = "{DisplayName}TokenRefreshed".Replace("{DisplayName}", tokenType.DisplayName());
-                telemetryClient.TrackEvent(eventName, new Dictionary<string, string>
+                var properties = new Dictionary<string, string>
                 {
                     {"Expires", tokenInfo.Expires.ToString("O")},
                     {"TokenType", tokenType.DisplayName()}
-                });
+                };
+                logger.LogCustomEvent(eventName, properties);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error refreshing the {DisplayName} Token", tokenType.DisplayName());
+                logger.LogError(e, "Error refreshing the {DisplayName} Token", tokenType.DisplayName());
             }
         }
         else
         {
-            _logger.LogDebug("{DisplayName} is still valid until {Expires:f}", tokenType.DisplayName(), tokenInfo.Expires);
+            logger.LogDebug("{DisplayName} is still valid until {Expires:f}", tokenType.DisplayName(), tokenInfo.Expires);
         }
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
@@ -42,13 +42,11 @@
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.1.1" />
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="JosephGuadagno.AzureHelpers.Cosmos" Version="1.0.8" />
     <PackageReference Include="JosephGuadagno.Extensions" Version="1.2.5" />
     <PackageReference Include="linqtotwitter" Version="6.15.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
@@ -58,6 +56,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
@@ -71,19 +70,20 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostImage.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostImage.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net;
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -11,7 +11,6 @@ namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 public class PostImage(
     ILinkedInManager linkedInManager,
     HttpClient httpClient,
-    TelemetryClient telemetryClient,
     ILogger<PostImage> logger)
 {
     [Function(ConfigurationFunctionNames.LinkedInPostImage)]
@@ -36,13 +35,14 @@ public class PostImage(
 
             if (!string.IsNullOrEmpty(linkedInShareId))
             {
-                telemetryClient.TrackEvent(Metrics.LinkedInPostImage, new Dictionary<string, string>
+                var properties = new Dictionary<string, string>
                 {
                     {"linkedInShareId", linkedInShareId},
                     {"imageUrl", linkedInPostImage.ImageUrl},
                     {"title", linkedInPostImage.Title}, 
                     {"url", linkedInPostImage.ImageUrl}
-                });
+                };
+                logger.LogCustomEvent(Metrics.LinkedInPostImage, properties);
             }
         }
         catch (Exception exception)

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostLink.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostLink.cs
@@ -1,13 +1,13 @@
-﻿using JosephGuadagno.Broadcasting.Domain.Constants;
+﻿using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 
-public class PostLink(ILinkedInManager linkedInManager, TelemetryClient telemetryClient)
+public class PostLink(ILinkedInManager linkedInManager, ILogger<PostLink> logger)
 {
     [Function(ConfigurationFunctionNames.LinkedInPostLink)]
     public async Task Run(
@@ -19,14 +19,14 @@ public class PostLink(ILinkedInManager linkedInManager, TelemetryClient telemetr
         
         if (!string.IsNullOrEmpty(linkedInShareId))
         {
-            telemetryClient.TrackEvent(Metrics.LinkedInPostLink, new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 {"linkedInShareId", linkedInShareId},
-                
                 {"title", linkedInPostLink.Title},
                 {"text", linkedInPostLink.Text}, 
                 {"url", linkedInPostLink.LinkUrl}
-            });
+            };
+            logger.LogCustomEvent(Metrics.LinkedInPostLink, properties);
         }
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostText.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostText.cs
@@ -1,13 +1,13 @@
-﻿using JosephGuadagno.Broadcasting.Domain.Constants;
+﻿using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 
-public class PostText(ILinkedInManager linkedInManager, TelemetryClient telemetryClient, ILogger<PostText> logger)
+public class PostText(ILinkedInManager linkedInManager, ILogger<PostText> logger)
 {
     [Function(ConfigurationFunctionNames.LinkedInPostText)]
     public async Task Run(
@@ -18,11 +18,12 @@ public class PostText(ILinkedInManager linkedInManager, TelemetryClient telemetr
         
         if (!string.IsNullOrEmpty(linkedInShareId))
         {
-            telemetryClient.TrackEvent(Metrics.LinkedInPostText, new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 {"linkedInShareId", linkedInShareId},
                 {"text", linkedInPostText.Text}
-            });
+            };
+            logger.LogCustomEvent(Metrics.LinkedInPostText, properties);
         }
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs
@@ -1,13 +1,13 @@
 ﻿using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +16,6 @@ namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 public class ProcessNewSyndicationDataFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     ILinkedInApplicationSettings linkedInApplicationSettings,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewSyndicationDataFired> logger)
 {
     // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
@@ -54,13 +53,14 @@ public class ProcessNewSyndicationDataFired(
         var status = ComposeStatus(syndicationFeedSource);
         
         // Done
-        telemetryClient.TrackEvent(Metrics.LinkedInProcessedNewSyndicationData, new Dictionary<string, string>
+        var properties = new Dictionary<string, string>
         {
             {"post", status.Text},
             {"title", syndicationFeedSource.Title},
             {"url", syndicationFeedSource.Url},
             {"id", syndicationFeedSource.Id.ToString()}
-        });
+        };
+        logger.LogCustomEvent(Metrics.LinkedInProcessedNewSyndicationData, properties);
         logger.LogDebug("Done composing LinkedIn status for '{Id}' with title of '{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
         return status;
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewYouTubeDataFired.cs
@@ -1,13 +1,13 @@
 ﻿using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +16,6 @@ namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 public class ProcessNewYouTubeDataFired(
     IYouTubeSourceManager youtubeSourceManager,
     ILinkedInApplicationSettings linkedInApplicationSettings,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewYouTubeDataFired> logger)
 {
     // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
@@ -54,13 +53,14 @@ public class ProcessNewYouTubeDataFired(
         var status = ComposeStatus(youTubeSource);
         
         // Done
-        telemetryClient.TrackEvent(Metrics.LinkedInProcessedNewYouTubeData, new Dictionary<string, string>
+        var properties = new Dictionary<string, string>
         {
             {"post", status.Text},
             {"title", youTubeSource.Title},
             {"url", youTubeSource.Url},
             {"id", youTubeSource.Id.ToString()}
-        });
+        };
+        logger.LogCustomEvent(Metrics.LinkedInProcessedNewSyndicationData, properties);
         logger.LogDebug("Done composing LinkedIn status for '{Id}' with title of '{Title}'", youTubeSource.Id, youTubeSource.Title);
         return status;
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessScheduledItemFired.cs
@@ -3,13 +3,11 @@ using Azure.Messaging.EventGrid;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
-using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Abstractions;
 
 namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 
@@ -19,7 +17,6 @@ public class ProcessScheduledItemFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IYouTubeSourceManager youTubeSourceManager,
     ILinkedInApplicationSettings linkedInApplicationSettings,
-    ITelemetryClient telemetryClient,
     ILogger<ProcessScheduledItemFired> logger)
 {
 
@@ -84,15 +81,15 @@ public class ProcessScheduledItemFired(
             linkedInPost.AuthorId = linkedInApplicationSettings.AuthorId;
             linkedInPost.AccessToken = linkedInApplicationSettings.AccessToken;
 
-            telemetryClient.TrackEvent(Metrics.LinkedInProcessedScheduledItemFired,
-                new Dictionary<string, string>
-                {
-                    { "tableName", scheduledItem.ItemTableName },
-                    { "id", scheduledItem.ItemPrimaryKey.ToString() },
-                    { "text", linkedInPost.Text },
-                    { "url", linkedInPost.LinkUrl },
-                    { "title", linkedInPost.Title }
-                });
+            var properties = new Dictionary<string, string>
+            {
+                { "tableName", scheduledItem.ItemTableName },
+                { "id", scheduledItem.ItemPrimaryKey.ToString() },
+                { "text", linkedInPost.Text },
+                { "url", linkedInPost.LinkUrl },
+                { "title", linkedInPost.Title }
+            };
+            logger.LogCustomEvent(Metrics.LinkedInProcessedScheduledItemFired, properties);
             logger.LogDebug("Generated the LinkedIn post text for {TableName}, {PrimaryKey}",
                 scheduledItem.ItemTableName, scheduledItem.ItemPrimaryKey);
             return linkedInPost;

--- a/src/JosephGuadagno.Broadcasting.Functions/Maintenance/ClearOldLogs.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Maintenance/ClearOldLogs.cs
@@ -1,14 +1,14 @@
 using System.Net;
 using Azure;
 using Azure.Data.Tables;
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Maintenance;
 
-public class ClearOldLogs(TelemetryClient telemetryClient, ILogger<ClearOldLogs> logger)
+public class ClearOldLogs(ILogger<ClearOldLogs> logger)
 {
     [Function(ConfigurationFunctionNames.MaintenanceClearOldLogs)]
     public async Task RunAsync(
@@ -49,7 +49,7 @@ public class ClearOldLogs(TelemetryClient telemetryClient, ILogger<ClearOldLogs>
         }
         
         // Return
-        telemetryClient.TrackEvent(Metrics.ClearOldLogs, new Dictionary<string, string>
+        logger.LogCustomEvent(Metrics.ClearOldLogs, new Dictionary<string, string>
         {
             {"DeletedCount", numberOfItemsDeleted.ToString()},
             {"FailedCount", numberOfItemsDeletedFailed.ToString()}

--- a/src/JosephGuadagno.Broadcasting.Functions/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Program.cs
@@ -1,4 +1,7 @@
 using System.Reflection;
+
+using Azure.Monitor.OpenTelemetry.Exporter;
+
 using JosephGuadagno.Broadcasting.Data;
 using JosephGuadagno.Broadcasting.Data.KeyVault;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
@@ -29,14 +32,17 @@ using JosephGuadagno.Broadcasting.YouTubeReader.Models;
 using JosephGuadagno.Utilities.Web.Shortener.Models;
 using LinqToTwitter;
 using LinqToTwitter.OAuth;
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+
+using OpenTelemetry.Logs;
+
 using Serilog;
 using Serilog.Exceptions;
 
@@ -87,13 +93,9 @@ if (endpoints != null)
 }
 builder.Services.TryAddSingleton<IEventPublisherSettings>(eventPublisherSettings);
 
-// Configure the logger
+// Configure the telemetry and logging
 string loggerFile = Path.Combine(currentDirectory, $"logs{Path.DirectorySeparatorChar}logs.txt");
-ConfigureLogging(builder.Configuration, builder.Services, settings, loggerFile, "Functions");
-
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+ConfigureTelemetryAndLogging(builder.Services, settings.LoggingStorageAccount, loggerFile, "Functions");
 
 // Add in AutoMapper
 var autoMapperSettings = new AutoMapperSettings();
@@ -119,8 +121,12 @@ builder.Services.AddScoped<ISpeakingEngagementsReader, SpeakingEngagementsReader
 
 builder.Build().Run();
 
-void ConfigureLogging(IConfiguration configurationRoot, IServiceCollection services, ISettings appSettings, string logPath, string applicationName)
+void ConfigureTelemetryAndLogging(IServiceCollection services, string logStorageAccount, string logPath, string applicationName)
 {
+
+    services.AddOpenTelemetry()
+        .UseFunctionsWorkerDefaults()
+        .UseAzureMonitorExporter();
 
     var logger = new LoggerConfiguration()
         #if DEBUG
@@ -141,15 +147,16 @@ void ConfigureLogging(IConfiguration configurationRoot, IServiceCollection servi
         .Destructure.ToMaximumCollectionCount(10)
         .WriteTo.Console()
         .WriteTo.File(logPath, rollingInterval: RollingInterval.Day)
-        .WriteTo.AzureTableStorage(appSettings.LoggingStorageAccount, storageTableName: "Logging",
+        .WriteTo.AzureTableStorage(logStorageAccount, storageTableName: "Logging",
             keyGenerator: new SerilogKeyGenerator())
+        .WriteTo.OpenTelemetry()
         .CreateLogger();
     services.AddLogging(loggingBuilder =>
     {
-        loggingBuilder.AddApplicationInsights(configureTelemetryConfiguration: (config) =>
-                config.ConnectionString =
-                    configurationRoot["APPLICATIONINSIGHTS_CONNECTION_STRING"],
-            configureApplicationInsightsLoggerOptions: (_) => { });
+        loggingBuilder.AddOpenTelemetry(options =>
+        {
+            options.AddConsoleExporter();
+        });
         loggingBuilder.AddSerilog(logger);
     });
 }
@@ -219,7 +226,7 @@ void ConfigureTwitter(IServiceCollection services, IConfiguration config)
 {
     var twitterSettings = new InMemoryCredentialStore();
     config.Bind("Twitter", twitterSettings);
-    services.TryAddSingleton<InMemoryCredentialStore>(twitterSettings);
+    services.TryAddSingleton(twitterSettings);
 
     services.TryAddSingleton<IAuthorizer>(s =>
     {

--- a/src/JosephGuadagno.Broadcasting.Functions/Publishers/RandomPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Publishers/RandomPosts.cs
@@ -1,6 +1,6 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -10,8 +10,7 @@ public class RandomPosts(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IRandomPostSettings randomPostSettings,
     IEventPublisher eventPublisher,
-    ILogger<RandomPosts> logger,
-    TelemetryClient telemetryClient)
+    ILogger<RandomPosts> logger)
 {
 
     [Function(ConfigurationFunctionNames.PublishersRandomPosts)]
@@ -48,7 +47,7 @@ public class RandomPosts(
             return;
         }
         
-        telemetryClient.TrackEvent(Metrics.RandomPostFired, new Dictionary<string, string>
+        logger.LogCustomEvent(Metrics.RandomPostFired, new Dictionary<string, string>
         {
             {"title", syndicationFeedSource.Title},
             {"url", syndicationFeedSource.Url},

--- a/src/JosephGuadagno.Broadcasting.Functions/Publishers/ScheduledItems.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Publishers/ScheduledItems.cs
@@ -1,8 +1,8 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -12,8 +12,7 @@ public class ScheduledItems(
     IScheduledItemManager scheduledItemManager,
     IEventPublisher eventPublisher,
     IFeedCheckManager feedCheckManager,
-    ILogger<ScheduledItems> logger,
-    TelemetryClient telemetryClient)
+    ILogger<ScheduledItems> logger)
 {
     [Function(ConfigurationFunctionNames.PublishersScheduledItems)]
     public async Task RunAsync([TimerTrigger("%publishers_scheduled_items_cron_settings%")] TimerInfo myTimer, ILogger log)
@@ -56,7 +55,7 @@ public class ScheduledItems(
                 var wasSent = await scheduledItemManager.SentScheduledItemAsync(scheduledItem.Id);
                 if (wasSent)
                 {
-                    telemetryClient.TrackEvent(Metrics.ScheduledItemFired, scheduledItem.ToDictionary());
+                    logger.LogCustomEvent(Metrics.ScheduledItemFired, scheduledItem.ToDictionary());
                 }
                 else
                 {

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewRandomPost.cs
@@ -1,16 +1,16 @@
 ﻿using System.Text.Json;
 using Azure.Messaging.EventGrid;
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Twitter;
 
-public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedSourceManager, TelemetryClient telemetryClient, ILogger<ProcessNewRandomPost> logger)
+public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedSourceManager, ILogger<ProcessNewRandomPost> logger)
 {
     [Function(ConfigurationFunctionNames.TwitterProcessRandomPostFired)]
     [QueueOutput(Queues.TwitterTweetsToSend)]
@@ -44,12 +44,13 @@ public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedS
                 $"ICYMI: ({syndicationFeedSource.PublicationDate.Date.ToShortDateString()}): \"{syndicationFeedSource.Title}.\" RTs and feedback are always appreciated! {syndicationFeedSource.ShortenedUrl} {hashtags}";
 
             // Return
-            telemetryClient.TrackEvent(Metrics.TwitterProcessedRandomPost, new Dictionary<string, string>
+            var properties = new Dictionary<string, string>
             {
                 {"title", syndicationFeedSource.Title},
                 {"url", syndicationFeedSource.Url},
                 {"tweet", status}
-            });
+            };
+            logger.LogCustomEvent(Metrics.TwitterProcessedRandomPost, properties);
             logger.LogDebug("Picked a random post {Title}", syndicationFeedSource.Title);
             return status;
         }

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSyndicationDataFired.cs
@@ -1,12 +1,12 @@
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -14,7 +14,6 @@ namespace JosephGuadagno.Broadcasting.Functions.Twitter;
 
 public class ProcessNewSyndicationDataFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewSyndicationDataFired> logger)
 {
 
@@ -60,13 +59,14 @@ public class ProcessNewSyndicationDataFired(
         var status = ComposeTweet(syndicationFeedSource);
 
         // Done
-        telemetryClient.TrackEvent(Metrics.FacebookProcessedNewSyndicationData, new Dictionary<string, string>
+        var properties = new Dictionary<string, string>
         {
             {"post", status},
             {"title", syndicationFeedSource.Title},
             {"url", syndicationFeedSource.Url},
             {"id", syndicationFeedSource.Id.ToString()}
-        });
+        };
+        logger.LogCustomEvent(Metrics.FacebookProcessedNewSyndicationData, properties);
         logger.LogDebug("Done composing Facebook status for '{Id}' with title of '{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
         return status;
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewYouTubeData.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewYouTubeData.cs
@@ -1,12 +1,12 @@
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -14,7 +14,6 @@ namespace JosephGuadagno.Broadcasting.Functions.Twitter;
 
 public class ProcessNewYouTubeDataFired(
     IYouTubeSourceManager youtubeSourceManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessNewYouTubeDataFired> logger)
 {
 
@@ -59,13 +58,14 @@ public class ProcessNewYouTubeDataFired(
         var status = ComposeTweet(youTubeSource);
 
         // Done
-        telemetryClient.TrackEvent(Metrics.FacebookProcessedNewYouTubeData, new Dictionary<string, string>
+        var properties = new Dictionary<string, string>
         {
             {"post", status},
             {"title", youTubeSource.Title},
             {"url", youTubeSource.Url},
             {"id", youTubeSource.Id.ToString()}
-        });
+        };
+        logger.LogCustomEvent(Metrics.TwitterProcessedNewYouTubeData, properties);
         logger.LogDebug("Done composing Facebook status for '{Id}' with title of '{Title}'", youTubeSource.Id, youTubeSource.Title);
         return status;
     }

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessScheduledItemFired.cs
@@ -5,7 +5,6 @@ using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +15,6 @@ public class ProcessScheduledItemFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IYouTubeSourceManager youTubeSourceManager,
     IEngagementManager engagementManager,
-    TelemetryClient telemetryClient,
     ILogger<ProcessScheduledItemFired> logger)
 {
     const int MaxTweetLength = 240;
@@ -76,13 +74,13 @@ public class ProcessScheduledItemFired(
                     return null;
             }
 
-            telemetryClient.TrackEvent(Metrics.TwitterProcessScheduledItemFired,
-                new Dictionary<string, string>
-                {
-                    { "tableName", scheduledItem.ItemTableName },
-                    { "primaryKey", scheduledItem.ItemPrimaryKey.ToString() },
-                    { "text", tweetText }
-                });
+            var properties = new Dictionary<string, string>
+            {
+                { "tableName", scheduledItem.ItemTableName },
+                { "primaryKey", scheduledItem.ItemPrimaryKey.ToString() },
+                { "text", tweetText }
+            };
+            logger.LogCustomEvent(Metrics.TwitterProcessScheduledItemFired, properties);
             logger.LogDebug("Generated the tweet for {TableName}, {PrimaryKey}",
                 scheduledItem.ItemTableName, scheduledItem.ItemPrimaryKey);
             return tweetText;

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/SendTweet.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/SendTweet.cs
@@ -1,12 +1,12 @@
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using LinqToTwitter;
-using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Twitter;
 
-public class SendTweet(TwitterContext twitterContext, TelemetryClient telemetryClient, ILogger<SendTweet> logger)
+public class SendTweet(TwitterContext twitterContext, ILogger<SendTweet> logger)
 {
 
     [Function(ConfigurationFunctionNames.TwitterSendTweet)]
@@ -24,12 +24,14 @@ public class SendTweet(TwitterContext twitterContext, TelemetryClient telemetryC
             else
             {
                 // This is good, just log success
-                logger.LogDebug("Posting to Twitter: {tweetText}", tweetText);
-                telemetryClient.TrackEvent(Metrics.TwitterPostSent, new Dictionary<string, string>
+                logger.LogDebug("Posting to Twitter: {TweetText}", tweetText);
+
+                var properties = new Dictionary<string, string>
                 {
                     {"message", tweetText},
-                    {"id", tweet.ID}
-                });
+                    {"id", tweet.ID?? string.Empty}
+                };
+                logger.LogCustomEvent(Metrics.TwitterPostSent, properties);
             }
         }
         catch (Exception ex)

--- a/src/JosephGuadagno.Broadcasting.Functions/host.json
+++ b/src/JosephGuadagno.Broadcasting.Functions/host.json
@@ -1,5 +1,6 @@
 {
   "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
   "logging": {
     "applicationInsights": {
       "samplingSettings": {

--- a/src/JosephGuadagno.Broadcasting.Functions/local.settings.json
+++ b/src/JosephGuadagno.Broadcasting.Functions/local.settings.json
@@ -16,6 +16,8 @@
     "publishers_scheduled_items_cron_settings": "0 */2 * * * *",
     "AzureWebJobs.CollectorsFeedLoadNewPosts.Disabled": true,
     "AzureWebJobs.CollectorsFeedLoadAllPosts.Disabled": true,
+    "AzureWebJobs.CollectorsSpeakingEngagementsLoadNew.Disabled": true,
+    "AzureWebJobs.CollectorsSpeakingEngagementsLoadAll.Disabled": true,
     "AzureWebJobs.CollectorsYouTubeLoadNewVideos.Disabled": true,
     "AzureWebJobs.CollectorsYouTubeLoadAllVideos.Disabled": true,
     "AzureWebJobs.PublishersRandomPosts.Disabled": true,
@@ -127,6 +129,9 @@
       "archive"
     ],
     "CutoffDate": "2019-01-01"
+  },
+  "SpeakingEngagementsReader": {
+    "SpeakingEngagementsFile": "http://localhost:4000/_data/engagements.json"
   },
   "SyndicationFeedReader": {
     "FeedUrl": "http://localhost:4000/feed.xml"

--- a/src/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests.csproj
@@ -36,10 +36,13 @@
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
+        <PackageReference Include="coverlet.collector" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
@@ -47,7 +50,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
 </Project>

--- a/src/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests.csproj
@@ -35,7 +35,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="linqtotwitter" Version="6.15.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
@@ -51,7 +50,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.1.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
@@ -1,4 +1,6 @@
 using AutoMapper;
+
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Web.Models;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -12,19 +14,16 @@ public class EngagementsController : Controller
 {
     private readonly IEngagementService _engagementService;
     private readonly IMapper _mapper;
-    private readonly ILogger<EngagementsController> _logger;
 
     /// <summary>
     /// The constructor for the EngagementsController.
     /// </summary>
     /// <param name="engagementService">The engagement service</param>
     /// <param name="mapper">The mapper service</param>
-    /// <param name="logger">The logger to use</param>
-    public EngagementsController(IEngagementService engagementService, IMapper mapper, ILogger<EngagementsController> logger)
+    public EngagementsController(IEngagementService engagementService, IMapper mapper)
     {
         _engagementService = engagementService;
         _mapper = mapper;
-        _logger = logger;
     }
 
     /// <summary>

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/HomeController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
 ﻿using System.Diagnostics;
+
+using JosephGuadagno.Broadcasting.Domain;
+
 using Microsoft.AspNetCore.Mvc;
 using JosephGuadagno.Broadcasting.Web.Models;
 
@@ -7,18 +10,8 @@ namespace JosephGuadagno.Broadcasting.Web.Controllers;
 /// <summary>
 /// The controller for the home page.
 /// </summary>
-public class HomeController : Controller
+public class HomeController(ILogger<HomeController> logger) : Controller
 {
-    private readonly ILogger<HomeController> _logger;
-
-    /// <summary>
-    /// The constructor for the home controller.
-    /// </summary>
-    /// <param name="logger">The logger to use.</param>
-    public HomeController(ILogger<HomeController> logger)
-    {
-        _logger = logger;
-    }
 
     /// <summary>
     /// Returns the home page

--- a/src/JosephGuadagno.Broadcasting.Web/JosephGuadagno.Broadcasting.Web.csproj
+++ b/src/JosephGuadagno.Broadcasting.Web/JosephGuadagno.Broadcasting.Web.csproj
@@ -1,139 +1,138 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>default</LangVersion>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId>872f5a5c-60ae-4319-9b7b-683cbd94220b</UserSecretsId>
-    <Company>JosephGuadagno.NET, LLC</Company>
-    <Authors>Joseph Guadagno</Authors>
-    <Product>JosephGuadagno.NET Broadcasting - Web</Product>
-    <Description>The website for the JosephGuadagno.NET Broadcasting application</Description>
-    <Copyright>Copyright ©2014-2026, Joseph Guadagno, JosephGuadagno.Net, LLC; josephguadagno.net</Copyright>
-    <Title>JosephGuadagno.NET Broadcasting - Web</Title>
-  </PropertyGroup>
-  <PropertyGroup>
-    <VersionMajor>2</VersionMajor>
-    <VersionMinor>0</VersionMinor>
-    <VersionBuild>0</VersionBuild>
-  </PropertyGroup>
-  <PropertyGroup>
-    <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionBuild)</VersionPrefix>
-  </PropertyGroup>
-  <PropertyGroup>
-    <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' == '' ">local</VersionSuffix>
-    <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' != '' And '$(Configuration)' == 'Debug'">$(GITHUB_RUN_ID)-preview</VersionSuffix>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</AssemblyVersion>
-    <AssemblyVersion Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</AssemblyVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
-    <FileVersion>$(VersionPrefix)</FileVersion>
-    <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DocumentationFile>bin\Debug\JosephGuadagno.Broadcasting.Web.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DocumentationFile>bin\Release\JosephGuadagno.Broadcasting.Web.xml</DocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.1.1" />
-    <PackageReference Include="AutoMapper" Version="16.0.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.3.0" />
-    <PackageReference Include="NodaTime" Version="3.3.0" />
-    <PackageReference Include="Rocket.Surgery.Extensions.AutoMapper.NodaTime" Version="9.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Data.KeyVault\JosephGuadagno.Broadcasting.Data.KeyVault.csproj" />
-    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Data\JosephGuadagno.Broadcasting.Data.csproj" />
-    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Domain\JosephGuadagno.Broadcasting.Domain.csproj" />
-    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Serilog\JosephGuadagno.Broadcasting.Serilog.csproj" />
-    <ProjectReference Include="..\JosephGuadagno.Broadcasting.ServiceDefaults\JosephGuadagno.Broadcasting.ServiceDefaults.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove=".gitignore" />
-  </ItemGroup>
-  <ItemGroup>
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.min.css" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.min.css.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.js.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.min.js.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.js.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.min.js.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.js.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.min.js.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\LICENSE" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation-unobtrusive\jquery.validate.unobtrusive.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation-unobtrusive\jquery.validate.unobtrusive.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation-unobtrusive\LICENSE.txt" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\additional-methods.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\additional-methods.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\jquery.validate.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\jquery.validate.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\LICENSE.md" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\dist\jquery.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\dist\jquery.min.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\dist\jquery.min.map" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\LICENSE.txt" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\foolproof-validation\mvcfoolproof.core.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\foolproof-validation\mvcfoolproof.jquery.validation.js" />
-    <_ContentIncludedByDefault Remove="wwwroot\lib\foolproof-validation\mvcfoolproof.unobtrusive.js" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>default</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>872f5a5c-60ae-4319-9b7b-683cbd94220b</UserSecretsId>
+        <Company>JosephGuadagno.NET, LLC</Company>
+        <Authors>Joseph Guadagno</Authors>
+        <Product>JosephGuadagno.NET Broadcasting - Web</Product>
+        <Description>The website for the JosephGuadagno.NET Broadcasting application</Description>
+        <Copyright>Copyright ©2014-2026, Joseph Guadagno, JosephGuadagno.Net, LLC; josephguadagno.net</Copyright>
+        <Title>JosephGuadagno.NET Broadcasting - Web</Title>
+    </PropertyGroup>
+    <PropertyGroup>
+        <VersionMajor>2</VersionMajor>
+        <VersionMinor>0</VersionMinor>
+        <VersionBuild>0</VersionBuild>
+    </PropertyGroup>
+    <PropertyGroup>
+        <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionBuild)</VersionPrefix>
+    </PropertyGroup>
+    <PropertyGroup>
+        <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' == '' ">local</VersionSuffix>
+        <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' != '' And '$(Configuration)' == 'Debug'">$(GITHUB_RUN_ID)-preview</VersionSuffix>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</AssemblyVersion>
+        <AssemblyVersion Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</AssemblyVersion>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+        <FileVersion>$(VersionPrefix)</FileVersion>
+        <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <DocumentationFile>bin\Debug\JosephGuadagno.Broadcasting.Web.xml</DocumentationFile>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DocumentationFile>bin\Release\JosephGuadagno.Broadcasting.Web.xml</DocumentationFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.1.1"/>
+        <PackageReference Include="AutoMapper" Version="16.0.0"/>
+        <PackageReference Include="Azure.Identity" Version="1.17.1"/>
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0"/>
+        <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0"/>
+        <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0"/>
+        <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0"/>
+        <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.3.0"/>
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0"/>
+        <PackageReference Include="NodaTime" Version="3.3.0"/>
+        <PackageReference Include="Rocket.Surgery.Extensions.AutoMapper.NodaTime" Version="9.0.1"/>
+        <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>
+        <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0"/>
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1"/>
+        <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
+        <PackageReference Include="Serilog.Exceptions" Version="8.4.0"/>
+        <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\JosephGuadagno.Broadcasting.Data.KeyVault\JosephGuadagno.Broadcasting.Data.KeyVault.csproj"/>
+        <ProjectReference Include="..\JosephGuadagno.Broadcasting.Data\JosephGuadagno.Broadcasting.Data.csproj"/>
+        <ProjectReference Include="..\JosephGuadagno.Broadcasting.Domain\JosephGuadagno.Broadcasting.Domain.csproj"/>
+        <ProjectReference Include="..\JosephGuadagno.Broadcasting.Serilog\JosephGuadagno.Broadcasting.Serilog.csproj"/>
+        <ProjectReference Include="..\JosephGuadagno.Broadcasting.ServiceDefaults\JosephGuadagno.Broadcasting.ServiceDefaults.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Remove=".gitignore"/>
+    </ItemGroup>
+    <ItemGroup>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.rtl.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-reboot.rtl.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-utilities.rtl.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.min.css"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap.rtl.min.css.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.js.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.bundle.min.js.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.js.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.esm.min.js.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.js.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\js\bootstrap.min.js.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\LICENSE"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation-unobtrusive\jquery.validate.unobtrusive.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation-unobtrusive\jquery.validate.unobtrusive.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation-unobtrusive\LICENSE.txt"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\additional-methods.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\additional-methods.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\jquery.validate.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\dist\jquery.validate.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery-validation\LICENSE.md"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\dist\jquery.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\dist\jquery.min.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\dist\jquery.min.map"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\jquery\LICENSE.txt"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\foolproof-validation\mvcfoolproof.core.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\foolproof-validation\mvcfoolproof.jquery.validation.js"/>
+        <_ContentIncludedByDefault Remove="wwwroot\lib\foolproof-validation\mvcfoolproof.unobtrusive.js"/>
+    </ItemGroup>
 </Project>

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -1,3 +1,5 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using JosephGuadagno.Broadcasting.Data.KeyVault;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -8,8 +10,6 @@ using JosephGuadagno.Broadcasting.Web.Interfaces;
 using JosephGuadagno.Broadcasting.Web.MappingProfiles;
 using JosephGuadagno.Broadcasting.Web.Models;
 using JosephGuadagno.Broadcasting.Web.Services;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
@@ -18,6 +18,9 @@ using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
+
+using OpenTelemetry.Logs;
+
 using Serilog;
 using Serilog.Exceptions;
 using Rocket.Surgery.Extensions.AutoMapper.NodaTime;
@@ -45,12 +48,10 @@ builder.Configuration.Bind("AutoMapper", autoMapperSettings);
 builder.Services.AddSingleton<IAutoMapperSettings>(autoMapperSettings);
 
 builder.Services.AddSession();
-builder.Services.AddSingleton<ITelemetryInitializer, AzureWebAppRoleEnvironmentTelemetryInitializer>();
-builder.Services.AddApplicationInsightsTelemetry();
 
 // Configure the logger
 var fullyQualifiedLogFile = Path.Combine(builder.Environment.ContentRootPath, "logs\\logs.txt");
-ConfigureLogging(builder.Configuration, builder.Services, settings, fullyQualifiedLogFile, "Web");
+ConfigureTelemetryAndLogging(builder.Services, settings.LoggingStorageAccount, fullyQualifiedLogFile, "Web");
 
 // Register DI services
 ConfigureApplication(builder.Services);
@@ -116,8 +117,9 @@ app.MapControllerRoute(
 
 app.Run();
 
-void ConfigureLogging(IConfigurationRoot configurationRoot, IServiceCollection services, ISettings configSettings, string logPath, string applicationName)
+void ConfigureTelemetryAndLogging(IServiceCollection services, string logStorageAccount, string logPath, string applicationName)
 {
+    services.AddOpenTelemetry().UseAzureMonitor();
     var logger = new LoggerConfiguration()
         .Enrich.FromLogContext()
         .Enrich.WithMachineName()
@@ -132,14 +134,15 @@ void ConfigureLogging(IConfigurationRoot configurationRoot, IServiceCollection s
         .Destructure.ToMaximumCollectionCount(10)
         .WriteTo.Console()
         .WriteTo.File(logPath, rollingInterval: RollingInterval.Day)
-        .WriteTo.AzureTableStorage(configSettings.LoggingStorageAccount, storageTableName:"Logging", keyGenerator: new SerilogKeyGenerator())
+        .WriteTo.AzureTableStorage(logStorageAccount, storageTableName:"Logging", keyGenerator: new SerilogKeyGenerator())
+        //.WriteTo.OpenTelemetry()
         .CreateLogger();
     services.AddLogging(loggingBuilder =>
     {
-        loggingBuilder.AddApplicationInsights(configureTelemetryConfiguration: (config) =>
-                config.ConnectionString =
-                    configurationRoot["APPLICATIONINSIGHTS_CONNECTION_STRING"],
-            configureApplicationInsightsLoggerOptions: (_) => { });loggingBuilder.AddApplicationInsights();
+        loggingBuilder.AddOpenTelemetry(options =>
+        {
+            options.AddConsoleExporter();
+        });
         loggingBuilder.AddSerilog(logger);
     });
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Services/EngagementService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/EngagementService.cs
@@ -3,7 +3,8 @@ using System.Text;
 using System.Text.Json;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
-using Microsoft.ApplicationInsights;
+using JosephGuadagno.Broadcasting.Web.Models;
+
 using Microsoft.Identity.Web;
 
 namespace JosephGuadagno.Broadcasting.Web.Services;
@@ -13,8 +14,6 @@ namespace JosephGuadagno.Broadcasting.Web.Services;
 /// </summary>
 public class EngagementService: ServiceBase, IEngagementService
 {
-    private readonly TelemetryClient _telemetryClient;
-    private readonly ILogger<EngagementService> _logger;
     private readonly string _engagementBaseUrl;
 
     /// <summary>
@@ -23,13 +22,9 @@ public class EngagementService: ServiceBase, IEngagementService
     /// <param name="httpClient">The HttpClient to use</param>
     /// <param name="tokenAcquisition">The token acquisition client</param>
     /// <param name="settings">Application <see cref="Settings"/> to use</param>
-    /// <param name="telemetryClient">The telemetry client</param>
-    /// <param name="logger">The logger</param>
-    public EngagementService(HttpClient httpClient, ITokenAcquisition tokenAcquisition, ISettings settings, TelemetryClient telemetryClient,
-        ILogger<EngagementService> logger): base(httpClient, tokenAcquisition, settings.ApiScopeUrl)
+    public EngagementService(HttpClient httpClient, ITokenAcquisition tokenAcquisition, ISettings settings
+        ): base(httpClient, tokenAcquisition, settings.ApiScopeUrl)
     {
-        _telemetryClient = telemetryClient;
-        _logger = logger;
         _engagementBaseUrl = settings.ApiRootUrl + "/engagements";
     }
     

--- a/src/JosephGuadagno.Broadcasting.Web/Services/ScheduledItemService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/ScheduledItemService.cs
@@ -3,7 +3,8 @@ using System.Text;
 using System.Text.Json;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
-using Microsoft.ApplicationInsights;
+using JosephGuadagno.Broadcasting.Web.Models;
+
 using Microsoft.Identity.Web;
 
 namespace JosephGuadagno.Broadcasting.Web.Services;
@@ -13,8 +14,6 @@ namespace JosephGuadagno.Broadcasting.Web.Services;
 /// </summary>
 public class ScheduledItemService: ServiceBase, IScheduledItemService
 {
-    private readonly TelemetryClient _telemetryClient;
-    private readonly ILogger<ScheduledItemService> _logger;
     private readonly string _scheduleBaseUrl;
 
     /// <summary>
@@ -23,13 +22,8 @@ public class ScheduledItemService: ServiceBase, IScheduledItemService
     /// <param name="httpClient">The HttpClient to use</param>
     /// <param name="tokenAcquisition">The token acquisition client</param>
     /// <param name="settings">Application <see cref="Settings"/> to use</param>
-    /// <param name="telemetryClient">The telemetry client</param>
-    /// <param name="logger">The logger</param>
-    public ScheduledItemService(HttpClient httpClient, ITokenAcquisition tokenAcquisition, ISettings settings, TelemetryClient telemetryClient,
-        ILogger<ScheduledItemService> logger): base(httpClient, tokenAcquisition, settings.ApiScopeUrl)
+    public ScheduledItemService(HttpClient httpClient, ITokenAcquisition tokenAcquisition, ISettings settings): base(httpClient, tokenAcquisition, settings.ApiScopeUrl)
     {
-        _telemetryClient = telemetryClient;
-        _logger = logger;
         _scheduleBaseUrl = settings.ApiRootUrl + "/schedules";
     }
     

--- a/src/JosephGuadagno.Broadcasting.YouTubeReader.Tests/JosephGuadagno.Broadcasting.YouTubeReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.YouTubeReader.Tests/JosephGuadagno.Broadcasting.YouTubeReader.Tests.csproj
@@ -36,10 +36,13 @@
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
+        <PackageReference Include="coverlet.collector" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
@@ -47,7 +50,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

This pull request removes the use of Application Insights in favor of Azure Monitor OpenTelemetry for logging and telemetry. 

Key changes include:
- Replacement of `TelemetryClient` with `ILogger` for custom logging.
- Integration of Azure Monitor OpenTelemetry for enhanced telemetry support.
- Updated Serilog configurations to work with Azure Monitor and OpenTelemetry exporters.
- Refactoring of logging-related dependency injection into a helper method `ConfigureTelemetryAndLogging`.
- Upgraded relevant package references and removed unused dependencies.

Implements #207.

### Checklist

- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] Changes adhere to project conventions