### PR TITLE
feat(#271): create TwitterManager abstraction and refactor SendTweet …

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ITwitterManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ITwitterManager.cs
@@ -1,0 +1,6 @@
+namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
+
+public interface ITwitterManager
+{
+    Task<string?> SendTweetAsync(string tweetText);
+}

--- a/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
@@ -100,6 +100,7 @@
     <ProjectReference Include="..\JosephGuadagno.Broadcasting.SpeakingEngagementsReader\JosephGuadagno.Broadcasting.SpeakingEngagementsReader.csproj" />
     <ProjectReference Include="..\JosephGuadagno.Broadcasting.SyndicationFeedReader\JosephGuadagno.Broadcasting.SyndicationFeedReader.csproj" />
     <ProjectReference Include="..\JosephGuadagno.Broadcasting.YouTubeReader\JosephGuadagno.Broadcasting.YouTubeReader.csproj" />
+    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Managers.Twitter\JosephGuadagno.Broadcasting.Managers.Twitter.csproj" />
   </ItemGroup>
     <!-- Exclude local.settings.json in release build -->
     <ItemGroup>

--- a/src/JosephGuadagno.Broadcasting.Functions/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Program.cs
@@ -14,6 +14,7 @@ using JosephGuadagno.Broadcasting.Managers;
 using JosephGuadagno.Broadcasting.Managers.Bluesky;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Interfaces;
 using JosephGuadagno.Broadcasting.Managers.Bluesky.Models;
+using JosephGuadagno.Broadcasting.Managers.Twitter;
 using JosephGuadagno.Broadcasting.Managers.Facebook;
 using JosephGuadagno.Broadcasting.Managers.Facebook.Interfaces;
 using JosephGuadagno.Broadcasting.Managers.Facebook.Models;
@@ -247,6 +248,7 @@ void ConfigureTwitter(IServiceCollection services, IConfiguration config)
         }
         return new TwitterContext(authorizer);
     });
+    services.TryAddSingleton<ITwitterManager, TwitterManager>();
 }
 
 void ConfigureSyndicationFeedReader(IServiceCollection services, IConfiguration config)

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/SendTweet.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/SendTweet.cs
@@ -1,12 +1,12 @@
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
-using LinqToTwitter;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Functions.Twitter;
 
-public class SendTweet(TwitterContext twitterContext, ILogger<SendTweet> logger)
+public class SendTweet(ITwitterManager twitterManager, ILogger<SendTweet> logger)
 {
 
     [Function(ConfigurationFunctionNames.TwitterSendTweet)]
@@ -15,8 +15,8 @@ public class SendTweet(TwitterContext twitterContext, ILogger<SendTweet> logger)
     {
         try
         {
-            var tweet = await twitterContext.TweetAsync(tweetText);
-            if (tweet is null)
+            var tweetId = await twitterManager.SendTweetAsync(tweetText);
+            if (tweetId is null)
             {
                 // Log the error
                 logger.LogError("Failed to send the tweet: '{TweetText}'. ", tweetText);
@@ -29,7 +29,7 @@ public class SendTweet(TwitterContext twitterContext, ILogger<SendTweet> logger)
                 var properties = new Dictionary<string, string>
                 {
                     {"message", tweetText},
-                    {"id", tweet.ID?? string.Empty}
+                    {"id", tweetId}
                 };
                 logger.LogCustomEvent(Metrics.TwitterPostSent, properties);
             }

--- a/src/JosephGuadagno.Broadcasting.Managers.Twitter.Tests/JosephGuadagno.Broadcasting.Managers.Twitter.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Twitter.Tests/JosephGuadagno.Broadcasting.Managers.Twitter.Tests.csproj
@@ -1,0 +1,62 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <Company>JosephGuadagno.NET, LLC</Company>
+    <Authors>Joseph Guadagno</Authors>
+    <Product>JosephGuadagno.NET Broadcasting - Twitter Manager Test Library</Product>
+    <Description>This library contains the unit tests for the Twitter Manager for the JosephGuadagno.NET Broadcasting application</Description>
+    <Copyright>Copyright ©2014-2026, Joseph Guadagno, JosephGuadagno.Net, LLC; josephguadagno.net</Copyright>
+    <Title>JosephGuadagno.NET Broadcasting - Twitter Manager Tests</Title>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionMajor>1</VersionMajor>
+    <VersionMinor>0</VersionMinor>
+    <VersionBuild>0</VersionBuild>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionBuild)</VersionPrefix>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' == '' ">local</VersionSuffix>
+    <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' != '' And '$(Configuration)' == 'Debug'">$(GITHUB_RUN_ID)-preview</VersionSuffix>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</AssemblyVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+    <FileVersion>$(VersionPrefix)</FileVersion>
+    <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Managers.Twitter\JosephGuadagno.Broadcasting.Managers.Twitter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/JosephGuadagno.Broadcasting.Managers.Twitter.Tests/TwitterManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Twitter.Tests/TwitterManagerTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using LinqToTwitter;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace JosephGuadagno.Broadcasting.Managers.Twitter.Tests;
+
+public class TwitterManagerTests
+{
+    private readonly Mock<ILogger<TwitterManager>> _mockLogger;
+
+    public TwitterManagerTests()
+    {
+        _mockLogger = new Mock<ILogger<TwitterManager>>();
+    }
+
+    private static TestableTwitterManager CreateSut(ILogger<TwitterManager> logger, Tweet? tweetResult, Exception? exception = null)
+        => new(logger, tweetResult, exception);
+
+    [Fact]
+    public async Task SendTweetAsync_WhenTweetSucceeds_ReturnsTweetId()
+    {
+        // Arrange
+        var expectedId = "123456789";
+        var tweet = new Tweet { ID = expectedId };
+        var sut = CreateSut(_mockLogger.Object, tweet);
+
+        // Act
+        var result = await sut.SendTweetAsync("Hello world!");
+
+        // Assert
+        result.Should().Be(expectedId);
+    }
+
+    [Fact]
+    public async Task SendTweetAsync_WhenTweetReturnsNull_ReturnsNull()
+    {
+        // Arrange
+        var sut = CreateSut(_mockLogger.Object, tweetResult: null);
+
+        // Act
+        var result = await sut.SendTweetAsync("Hello world!");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendTweetAsync_WhenExceptionThrown_ReturnsNull()
+    {
+        // Arrange
+        var sut = CreateSut(_mockLogger.Object, tweetResult: null, exception: new InvalidOperationException("Twitter API error"));
+
+        // Act
+        var result = await sut.SendTweetAsync("Hello world!");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private sealed class TestableTwitterManager(ILogger<TwitterManager> logger, Tweet? tweetResult, Exception? exception = null)
+        : TwitterManager(null!, logger)
+    {
+        protected override Task<Tweet?> TweetAsync(string tweetText)
+        {
+            if (exception is not null)
+                throw exception;
+            return Task.FromResult(tweetResult);
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Managers.Twitter/JosephGuadagno.Broadcasting.Managers.Twitter.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Twitter/JosephGuadagno.Broadcasting.Managers.Twitter.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Company>JosephGuadagno.NET, LLC</Company>
+    <Authors>Joseph Guadagno</Authors>
+    <Product>JosephGuadagno.NET Broadcasting - Twitter Manager</Product>
+    <Description>The Twitter Manager for the JosephGuadagno.NET Broadcasting application</Description>
+    <Copyright>Copyright ©2014-2026, Joseph Guadagno, JosephGuadagno.Net, LLC; josephguadagno.net</Copyright>
+    <Title>JosephGuadagno.NET Broadcasting - Twitter</Title>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionMajor>1</VersionMajor>
+    <VersionMinor>0</VersionMinor>
+    <VersionBuild>0</VersionBuild>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionBuild)</VersionPrefix>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' == '' ">local</VersionSuffix>
+    <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' != '' And '$(Configuration)' == 'Debug'">$(GITHUB_RUN_ID)-preview</VersionSuffix>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</AssemblyVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+    <FileVersion>$(VersionPrefix)</FileVersion>
+    <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="linqtotwitter" Version="6.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JosephGuadagno.Broadcasting.Domain\JosephGuadagno.Broadcasting.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/JosephGuadagno.Broadcasting.Managers.Twitter/TwitterManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Twitter/TwitterManager.cs
@@ -1,0 +1,35 @@
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using LinqToTwitter;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Managers.Twitter;
+
+public class TwitterManager(TwitterContext twitterContext, ILogger<TwitterManager> logger)
+    : ITwitterManager
+{
+    public async Task<string?> SendTweetAsync(string tweetText)
+    {
+        try
+        {
+            var tweet = await TweetAsync(tweetText);
+            if (tweet is null)
+            {
+                logger.LogError("Failed to send the tweet: '{TweetText}'.", tweetText);
+                return null;
+            }
+
+            logger.LogDebug("Tweet sent successfully. Id: '{TweetId}'", tweet.ID);
+            return tweet.ID;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send the tweet: '{TweetText}'. Exception: '{ExceptionMessage}'", tweetText, ex.Message);
+            return null;
+        }
+    }
+
+    protected virtual async Task<Tweet?> TweetAsync(string tweetText)
+    {
+        return await twitterContext.TweetAsync(tweetText);
+    }
+}

--- a/src/JosephGuadagnoNet.Broadcasting.sln
+++ b/src/JosephGuadagnoNet.Broadcasting.sln
@@ -162,6 +162,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JosephGuadagno.Broadcasting
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JosephGuadagno.Broadcasting.Functions.IntegrationTests", "JosephGuadagno.Broadcasting.Functions.IntegrationTests\JosephGuadagno.Broadcasting.Functions.IntegrationTests.csproj", "{CFC93EFC-BAD1-4AAC-94F9-6B69224919E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JosephGuadagno.Broadcasting.Managers.Twitter", "JosephGuadagno.Broadcasting.Managers.Twitter\JosephGuadagno.Broadcasting.Managers.Twitter.csproj", "{42DEF471-4FC8-4815-8CBB-3211989A0050}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JosephGuadagno.Broadcasting.Managers.Twitter.Tests", "JosephGuadagno.Broadcasting.Managers.Twitter.Tests\JosephGuadagno.Broadcasting.Managers.Twitter.Tests.csproj", "{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -608,6 +612,30 @@ Global
 		{CFC93EFC-BAD1-4AAC-94F9-6B69224919E4}.Release|x64.Build.0 = Release|Any CPU
 		{CFC93EFC-BAD1-4AAC-94F9-6B69224919E4}.Release|x86.ActiveCfg = Release|Any CPU
 		{CFC93EFC-BAD1-4AAC-94F9-6B69224919E4}.Release|x86.Build.0 = Release|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Debug|x64.Build.0 = Debug|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Debug|x86.Build.0 = Debug|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Release|x64.ActiveCfg = Release|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Release|x64.Build.0 = Release|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Release|x86.ActiveCfg = Release|Any CPU
+		{42DEF471-4FC8-4815-8CBB-3211989A0050}.Release|x86.Build.0 = Release|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Release|x64.Build.0 = Release|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC961A52-5EB9-4F8B-A1F4-583C8B0D28D4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
…function

- Add ITwitterManager interface to Domain/Interfaces
- Create Managers.Twitter project with TwitterManager implementation
- TwitterManager uses protected virtual TweetAsync for testability
- Refactor SendTweet Azure Function to consume ITwitterManager
- Register ITwitterManager in Functions Program.cs DI
- Add Managers.Twitter.Tests project with 3 unit tests

#271