### PR TITLE
feat(#275): add retry policy and structured logging to EventPublisher

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Data.Tests/EventPublisherTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Tests/EventPublisherTests.cs
@@ -28,6 +28,7 @@ public class EventPublisherTests
         public TestableEventPublisher(IEventPublisherSettings settings, ILogger<EventPublisher> logger)
             : base(settings, logger)
         {
+            InitialRetryDelay = TimeSpan.Zero;
         }
 
         protected override EventGridPublisherClient GetEventGridPublisherClient(ITopicEndpointSettings topicSettings)
@@ -124,6 +125,44 @@ public class EventPublisherTests
 
         // Assert
         Assert.False(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task PublishSyndicationFeedEventsAsync_WhenFirstAttemptFails_RetriesAndSucceeds()
+    {
+        // Arrange
+        var topicSettings = CreateTopicSettings(Topics.NewSyndicationFeedItem);
+        _settingsMock.Setup(s => s.TopicEndpointSettings).Returns(new List<ITopicEndpointSettings> { topicSettings });
+        var items = new List<SyndicationFeedSource> { new SyndicationFeedSource { Id = 1, FeedIdentifier = "f1", Author = "a", Title = "t", Url = "https://example.com", PublicationDate = DateTimeOffset.UtcNow, AddedOn = DateTimeOffset.UtcNow, LastUpdatedOn = DateTimeOffset.UtcNow } };
+        _publisher.ClientMock.SetupSequence(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Transient failure"))
+            .ReturnsAsync(Mock.Of<Azure.Response>());
+
+        // Act
+        var result = await _publisher.PublishSyndicationFeedEventsAsync("subject", items);
+
+        // Assert
+        Assert.True(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task PublishSyndicationFeedEventsAsync_WhenAllAttemptsFailWithException_ReturnsFalse()
+    {
+        // Arrange
+        var topicSettings = CreateTopicSettings(Topics.NewSyndicationFeedItem);
+        _settingsMock.Setup(s => s.TopicEndpointSettings).Returns(new List<ITopicEndpointSettings> { topicSettings });
+        var items = new List<SyndicationFeedSource> { new SyndicationFeedSource { Id = 1, FeedIdentifier = "f1", Author = "a", Title = "t", Url = "https://example.com", PublicationDate = DateTimeOffset.UtcNow, AddedOn = DateTimeOffset.UtcNow, LastUpdatedOn = DateTimeOffset.UtcNow } };
+        _publisher.ClientMock.Setup(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Persistent failure"));
+
+        // Act
+        var result = await _publisher.PublishSyndicationFeedEventsAsync("subject", items);
+
+        // Assert
+        Assert.False(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
     }
 
     #endregion
@@ -210,6 +249,44 @@ public class EventPublisherTests
 
         // Assert
         Assert.False(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task PublishYouTubeEventsAsync_WhenFirstAttemptFails_RetriesAndSucceeds()
+    {
+        // Arrange
+        var topicSettings = CreateTopicSettings(Topics.NewYouTubeItem);
+        _settingsMock.Setup(s => s.TopicEndpointSettings).Returns(new List<ITopicEndpointSettings> { topicSettings });
+        var items = new List<YouTubeSource> { new YouTubeSource { Id = 1, VideoId = "v1", Author = "a", Title = "t", Url = "https://youtube.com/v1", PublicationDate = DateTimeOffset.UtcNow, AddedOn = DateTimeOffset.UtcNow, LastUpdatedOn = DateTimeOffset.UtcNow } };
+        _publisher.ClientMock.SetupSequence(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Transient failure"))
+            .ReturnsAsync(Mock.Of<Azure.Response>());
+
+        // Act
+        var result = await _publisher.PublishYouTubeEventsAsync("subject", items);
+
+        // Assert
+        Assert.True(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task PublishYouTubeEventsAsync_WhenAllAttemptsFailWithException_ReturnsFalse()
+    {
+        // Arrange
+        var topicSettings = CreateTopicSettings(Topics.NewYouTubeItem);
+        _settingsMock.Setup(s => s.TopicEndpointSettings).Returns(new List<ITopicEndpointSettings> { topicSettings });
+        var items = new List<YouTubeSource> { new YouTubeSource { Id = 1, VideoId = "v1", Author = "a", Title = "t", Url = "https://youtube.com/v1", PublicationDate = DateTimeOffset.UtcNow, AddedOn = DateTimeOffset.UtcNow, LastUpdatedOn = DateTimeOffset.UtcNow } };
+        _publisher.ClientMock.Setup(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Persistent failure"));
+
+        // Act
+        var result = await _publisher.PublishYouTubeEventsAsync("subject", items);
+
+        // Assert
+        Assert.False(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
     }
 
     #endregion
@@ -296,6 +373,7 @@ public class EventPublisherTests
 
         // Assert
         Assert.False(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
     }
 
     #endregion
@@ -380,6 +458,7 @@ public class EventPublisherTests
 
         // Assert
         Assert.False(result);
+        _publisher.ClientMock.Verify(c => c.SendEventsAsync(It.IsAny<IEnumerable<EventGridEvent>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
     }
 
     #endregion

--- a/src/JosephGuadagno.Broadcasting.Data/EventPublisher.cs
+++ b/src/JosephGuadagno.Broadcasting.Data/EventPublisher.cs
@@ -13,10 +13,16 @@ namespace JosephGuadagno.Broadcasting.Data;
 public class EventPublisher(IEventPublisherSettings eventPublisherSettings, ILogger<EventPublisher> logger)
     : IEventPublisher
 {
+    private const int MaxRetryAttempts = 3;
+
+    /// <summary>
+    /// Initial delay between retry attempts. Exposed as protected so tests can override via subclass.
+    /// </summary>
+    protected TimeSpan InitialRetryDelay { get; init; } = TimeSpan.FromSeconds(1);
+
     public async Task<bool> PublishSyndicationFeedEventsAsync(string subject,
         IReadOnlyCollection<SyndicationFeedSource> syndicationFeedSourceDataItems)
     {
-
         if (string.IsNullOrEmpty(subject))
         {
             throw new ArgumentNullException(nameof(subject), "The subject is required.");
@@ -46,21 +52,11 @@ public class EventPublisher(IEventPublisherSettings eventPublisherSettings, ILog
                 new EventGridEvent(subject, Topics.NewSyndicationFeedItem, "1.1", data));
         }
 
-        try
-        {
-            await client.SendEventsAsync(eventList);
-            return true;
-        }
-        catch (Exception e)
-        {
-            logger.LogError(e, "Failed to publish the event to TopicUrl: '{TopicUrl}'. Exception: '{Exception}'", topicSettings.Endpoint, e);
-            return false;
-        }
+        return await SendWithRetryAsync(client, eventList, topicSettings.Endpoint, Topics.NewSyndicationFeedItem);
     }
 
     public async Task<bool> PublishYouTubeEventsAsync(string subject, IReadOnlyCollection<YouTubeSource> youTubeSourceDataItems)
     {
-
         if (string.IsNullOrEmpty(subject))
         {
             throw new ArgumentNullException(nameof(subject), "The subject is required.");
@@ -90,16 +86,7 @@ public class EventPublisher(IEventPublisherSettings eventPublisherSettings, ILog
                 new EventGridEvent(subject, Topics.NewYouTubeItem, "1.1", data));
         }
 
-        try
-        {
-            await client.SendEventsAsync(eventList);
-            return true;
-        }
-        catch (Exception e)
-        {
-            logger.LogError(e, "Failed to publish the event to TopicUrl: '{TopicUrl}'. Exception: '{Exception}'", topicSettings.Endpoint, e);
-            return false;
-        }
+        return await SendWithRetryAsync(client, eventList, topicSettings.Endpoint, Topics.NewYouTubeItem);
     }
 
     public async Task<bool> PublishScheduledItemFiredEventsAsync(string subject,
@@ -133,17 +120,8 @@ public class EventPublisher(IEventPublisherSettings eventPublisherSettings, ILog
             eventList.Add(
                 new EventGridEvent(subject, Topics.ScheduledItemFired, "1.1", data));
         }
-        
-        try
-        {
-            await client.SendEventsAsync(eventList);
-            return true;
-        }
-        catch (Exception e)
-        {
-            logger.LogError(e, "Failed to publish the event to TopicUrl: '{TopicUrl}'. Exception: '{Exception}'", topicSettings.Endpoint, e);
-            return false;
-        }
+
+        return await SendWithRetryAsync(client, eventList, topicSettings.Endpoint, Topics.ScheduledItemFired);
     }
 
     public async Task<bool> PublishRandomPostsEventsAsync(string subject, int randomPostId)
@@ -167,20 +145,46 @@ public class EventPublisher(IEventPublisherSettings eventPublisherSettings, ILog
         var client = GetEventGridPublisherClient(topicSettings);
 
         var data = new RandomPostEvent{ Id = randomPostId};
-
         var eventList = new List<EventGridEvent>
             { new(subject, Topics.NewRandomPost, "1.0", data) };
 
-        try
+        return await SendWithRetryAsync(client, eventList, topicSettings.Endpoint, Topics.NewRandomPost);
+    }
+
+    private async Task<bool> SendWithRetryAsync(
+        EventGridPublisherClient client,
+        IEnumerable<EventGridEvent> events,
+        string topicUrl,
+        string eventType,
+        CancellationToken cancellationToken = default)
+    {
+        var delay = InitialRetryDelay;
+
+        for (var attempt = 1; attempt <= MaxRetryAttempts; attempt++)
         {
-            await client.SendEventsAsync(eventList);
-            return true;
+            try
+            {
+                await client.SendEventsAsync(events, cancellationToken);
+                return true;
+            }
+            catch (Exception ex) when (attempt < MaxRetryAttempts)
+            {
+                logger.LogWarning(ex,
+                    "Event Grid publish attempt {Attempt}/{MaxRetries} failed for event type '{EventType}' to '{TopicUrl}'. Retrying in {DelaySeconds}s.",
+                    attempt, MaxRetryAttempts, eventType, topicUrl, delay.TotalSeconds);
+                await Task.Delay(delay, cancellationToken);
+                delay *= 2;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Event Grid publish failed after {MaxRetries} attempts for event type '{EventType}' to '{TopicUrl}'.",
+                    MaxRetryAttempts, eventType, topicUrl);
+                return false;
+            }
         }
-        catch (Exception e)
-        {
-            logger.LogError(e, "Failed to publish the event to TopicUrl: '{TopicUrl}'. Exception: '{Exception}'", topicSettings.Endpoint, e);
-            return false;
-        }
+
+        return false;
     }
 
     private ITopicEndpointSettings? GetTopicEndpointSettings(string topicName)


### PR DESCRIPTION
- Add SendWithRetryAsync helper with 3-attempt exponential backoff
- Replace direct SendEventsAsync calls in all 4 publish methods
- Log warnings on each retry attempt with event type and topic URL
- Log error with structured context after all attempts exhausted
- Expose InitialRetryDelay as protected init property for fast tests
- Add retry unit tests: transient failure recovers, all-fail returns false
#275 