### PR TITLE
test(#272): add unit tests for duplicate-detection logic

### DIFF
--- a/scripts/database/2026-03-16-feedsource-unique-constraints.sql
+++ b/scripts/database/2026-03-16-feedsource-unique-constraints.sql
@@ -1,0 +1,44 @@
+USE JJGNet;
+GO
+
+-- Resize SyndicationFeedSources.FeedIdentifier from NVARCHAR(MAX) to NVARCHAR(450)
+-- SQL Server cannot index NVARCHAR(MAX); 450 chars = 900 bytes = max key size for a unique index.
+IF EXISTS (
+    SELECT 1
+    FROM sys.columns c
+    JOIN sys.tables t ON c.object_id = t.object_id
+    WHERE t.name = 'SyndicationFeedSources'
+      AND c.name = 'FeedIdentifier'
+      AND c.max_length = -1  -- -1 indicates MAX type
+)
+BEGIN
+    ALTER TABLE dbo.SyndicationFeedSources
+        ALTER COLUMN FeedIdentifier NVARCHAR(450) NOT NULL;
+END
+GO
+
+-- Add unique constraint on SyndicationFeedSources.FeedIdentifier
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.key_constraints
+    WHERE name = 'UQ_SyndicationFeedSources_FeedIdentifier'
+      AND parent_object_id = OBJECT_ID('dbo.SyndicationFeedSources')
+)
+BEGIN
+    ALTER TABLE dbo.SyndicationFeedSources
+        ADD CONSTRAINT UQ_SyndicationFeedSources_FeedIdentifier UNIQUE (FeedIdentifier);
+END
+GO
+
+-- Add unique constraint on YouTubeSources.VideoId (already NVARCHAR(20), no resize needed)
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.key_constraints
+    WHERE name = 'UQ_YouTubeSources_VideoId'
+      AND parent_object_id = OBJECT_ID('dbo.YouTubeSources')
+)
+BEGIN
+    ALTER TABLE dbo.YouTubeSources
+        ADD CONSTRAINT UQ_YouTubeSources_VideoId UNIQUE (VideoId);
+END
+GO

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/SyndicationFeedSourceDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/SyndicationFeedSourceDataStoreTests.cs
@@ -311,6 +311,24 @@ public class SyndicationFeedSourceDataStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetByFeedIdentifierAsync_ReturnsRecord_WhenFeedIdentifierExists()
+    {
+        SeedData();
+        var result = await _dataStore.GetByFeedIdentifierAsync("post2");
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Id);
+        Assert.Equal("post2", result.FeedIdentifier);
+    }
+
+    [Fact]
+    public async Task GetByFeedIdentifierAsync_ReturnsNull_WhenFeedIdentifierDoesNotExist()
+    {
+        SeedData();
+        var result = await _dataStore.GetByFeedIdentifierAsync("non-existent-feed-identifier");
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task SaveAsync_ThrowsApplicationException_WhenSaveReturnsZero()
     {
         var options = new DbContextOptionsBuilder<BroadcastingContext>()

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/YouTubeSourceDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/YouTubeSourceDataStoreTests.cs
@@ -213,4 +213,30 @@ public class YouTubeSourceDataStoreTests : IDisposable
         // Assert
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task GetByVideoIdAsync_ReturnsRecord_WhenVideoIdExists()
+    {
+        // Arrange
+        var source = CreateYouTubeSource("testvid42", "https://youtube.com/watch?v=testvid42");
+        _context.YouTubeSources.Add(source);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetByVideoIdAsync("testvid42");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("testvid42", result.VideoId);
+    }
+
+    [Fact]
+    public async Task GetByVideoIdAsync_ReturnsNull_WhenVideoIdDoesNotExist()
+    {
+        // Act
+        var result = await _dataStore.GetByVideoIdAsync("nonexistent-video-id");
+
+        // Assert
+        Assert.Null(result);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
@@ -113,6 +113,7 @@ public partial class BroadcastingContext : DbContext
                 .HasName("SyndicationFeedSource_pk_Id");
 
             entity.Property(e => e.FeedIdentifier)
+                .HasMaxLength(450)
                 .IsRequired();
 
             entity.Property(e => e.Author)

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
@@ -51,6 +51,13 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
         return await broadcastingContext.SaveChangesAsync() != 0;
     }
 
+    public async Task<Domain.Models.SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier)
+    {
+        var dbSyndicationFeedSource = await broadcastingContext.SyndicationFeedSources.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.FeedIdentifier == feedIdentifier);
+        return dbSyndicationFeedSource is null ? null : mapper.Map<Domain.Models.SyndicationFeedSource>(dbSyndicationFeedSource);
+    }
+
     public async Task<Domain.Models.SyndicationFeedSource?> GetByUrlAsync(string url)
     {
         var dbSyndicationFeedSource = await broadcastingContext.SyndicationFeedSources.AsNoTracking()

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
@@ -57,4 +57,11 @@ public class YouTubeSourceDataStore(BroadcastingContext broadcastingContext, IMa
             .FirstOrDefaultAsync(y => y.Url == url);
         return dbYouTubeSource is null ? null : mapper.Map<Domain.Models.YouTubeSource>(dbYouTubeSource);
     }
+
+    public async Task<Domain.Models.YouTubeSource?> GetByVideoIdAsync(string videoId)
+    {
+        var dbYouTubeSource = await broadcastingContext.YouTubeSources.AsNoTracking()
+            .FirstOrDefaultAsync(y => y.VideoId == videoId);
+        return dbYouTubeSource is null ? null : mapper.Map<Domain.Models.YouTubeSource>(dbYouTubeSource);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Tests/Repositories/SyndicationFeedSourceRepositoryTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Tests/Repositories/SyndicationFeedSourceRepositoryTests.cs
@@ -134,4 +134,33 @@ public class SyndicationFeedSourceRepositoryTests
         Assert.Equal(source, result);
         _dataStoreMock.Verify(d => d.GetRandomSyndicationDataAsync(cutoffDate, excludedCategories), Times.Once);
     }
+
+    [Fact]
+    public async Task GetByFeedIdentifierAsync_DelegatesToDataStore()
+    {
+        // Arrange
+        var source = CreateSource();
+        _dataStoreMock.Setup(d => d.GetByFeedIdentifierAsync("feed1")).ReturnsAsync(source);
+
+        // Act
+        var result = await _repository.GetByFeedIdentifierAsync("feed1");
+
+        // Assert
+        Assert.Equal(source, result);
+        _dataStoreMock.Verify(d => d.GetByFeedIdentifierAsync("feed1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByFeedIdentifierAsync_ReturnsNull_WhenNotFound()
+    {
+        // Arrange
+        _dataStoreMock.Setup(d => d.GetByFeedIdentifierAsync("missing")).ReturnsAsync((SyndicationFeedSource?)null);
+
+        // Act
+        var result = await _repository.GetByFeedIdentifierAsync("missing");
+
+        // Assert
+        Assert.Null(result);
+        _dataStoreMock.Verify(d => d.GetByFeedIdentifierAsync("missing"), Times.Once);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Tests/Repositories/YouTubeSourceRepositoryTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Tests/Repositories/YouTubeSourceRepositoryTests.cs
@@ -117,4 +117,33 @@ public class YouTubeSourceRepositoryTests
         Assert.Equal(source, result);
         _dataStoreMock.Verify(d => d.GetByUrlAsync("https://youtube.com/watch?v=vid0001"), Times.Once);
     }
+
+    [Fact]
+    public async Task GetByVideoIdAsync_DelegatesToDataStore()
+    {
+        // Arrange
+        var source = CreateSource();
+        _dataStoreMock.Setup(d => d.GetByVideoIdAsync("vid0001")).ReturnsAsync(source);
+
+        // Act
+        var result = await _repository.GetByVideoIdAsync("vid0001");
+
+        // Assert
+        Assert.Equal(source, result);
+        _dataStoreMock.Verify(d => d.GetByVideoIdAsync("vid0001"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByVideoIdAsync_ReturnsNull_WhenNotFound()
+    {
+        // Arrange
+        _dataStoreMock.Setup(d => d.GetByVideoIdAsync("missing")).ReturnsAsync((YouTubeSource?)null);
+
+        // Act
+        var result = await _repository.GetByVideoIdAsync("missing");
+
+        // Assert
+        Assert.Null(result);
+        _dataStoreMock.Verify(d => d.GetByVideoIdAsync("missing"), Times.Once);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Data/Repositories/SyndicationFeedSourceRepository.cs
+++ b/src/JosephGuadagno.Broadcasting.Data/Repositories/SyndicationFeedSourceRepository.cs
@@ -42,6 +42,11 @@ public class SyndicationFeedSourceRepository : ISyndicationFeedSourceRepository
         return await _syndicationFeedSourceDataStore.GetByUrlAsync(url);
     }
 
+    public async Task<SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier)
+    {
+        return await _syndicationFeedSourceDataStore.GetByFeedIdentifierAsync(feedIdentifier);
+    }
+
     public async Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(DateTimeOffset cutoffDate, List<string> excludedCategories)
     {
         return await _syndicationFeedSourceDataStore.GetRandomSyndicationDataAsync(cutoffDate, excludedCategories);

--- a/src/JosephGuadagno.Broadcasting.Data/Repositories/YouTubeSourceRepository.cs
+++ b/src/JosephGuadagno.Broadcasting.Data/Repositories/YouTubeSourceRepository.cs
@@ -41,4 +41,9 @@ public class YouTubeSourceRepository : IYouTubeSourceRepository
     {
         return await _youTubeSourceDataStore.GetByUrlAsync(url);
     }
+
+    public async Task<YouTubeSource?> GetByVideoIdAsync(string videoId)
+    {
+        return await _youTubeSourceDataStore.GetByVideoIdAsync(videoId);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceDataStore.cs
@@ -5,5 +5,6 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface ISyndicationFeedSourceDataStore : IDataStore<SyndicationFeedSource>
 {
     public Task<SyndicationFeedSource?> GetByUrlAsync(string url);
+    Task<SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier);
     Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(DateTimeOffset cutoffDate, List<string> excludedCategories);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceManager.cs
@@ -5,5 +5,6 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface ISyndicationFeedSourceManager : IManager<SyndicationFeedSource>
 {
     public Task<SyndicationFeedSource?> GetByUrlAsync(string url);
+    Task<SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier);
     Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(DateTimeOffset cutoffDate, List<string> excludedCategories);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceRepository.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceRepository.cs
@@ -5,5 +5,6 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface ISyndicationFeedSourceRepository : IDataRepository<SyndicationFeedSource>
 {
     public Task<SyndicationFeedSource?> GetByUrlAsync(string url);
+    Task<SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier);
     Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(DateTimeOffset cutoffDate, List<string> excludedCategories);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceDataStore.cs
@@ -5,4 +5,5 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface IYouTubeSourceDataStore : IDataStore<Domain.Models.YouTubeSource>
 {
     public Task<Domain.Models.YouTubeSource?> GetByUrlAsync(string url);
+    Task<Domain.Models.YouTubeSource?> GetByVideoIdAsync(string videoId);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceManager.cs
@@ -5,4 +5,5 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface IYouTubeSourceManager : IManager<YouTubeSource>
 {
     public Task<YouTubeSource?> GetByUrlAsync(string url);
+    Task<YouTubeSource?> GetByVideoIdAsync(string videoId);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceRepository.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceRepository.cs
@@ -5,4 +5,5 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface IYouTubeSourceRepository : IDataRepository<YouTubeSource>
 {
     public Task<YouTubeSource?> GetByUrlAsync(string url);
+    Task<YouTubeSource?> GetByVideoIdAsync(string videoId);
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Functions.Collectors.SyndicationFeed;
+using JosephGuadagno.Broadcasting.Functions.Interfaces;
+using JosephGuadagno.Broadcasting.SyndicationFeedReader.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
+
+public class LoadNewPostsTests
+{
+    private readonly Mock<ISyndicationFeedReader> _feedReader;
+    private readonly Mock<ISettings> _settings;
+    private readonly Mock<ISyndicationFeedSourceManager> _feedSourceManager;
+    private readonly Mock<IFeedCheckManager> _feedCheckManager;
+    private readonly Mock<IUrlShortener> _urlShortener;
+    private readonly Mock<IEventPublisher> _eventPublisher;
+    private readonly LoadNewPosts _sut;
+
+    public LoadNewPostsTests()
+    {
+        _feedReader = new Mock<ISyndicationFeedReader>();
+        _settings = new Mock<ISettings>();
+        _feedSourceManager = new Mock<ISyndicationFeedSourceManager>();
+        _feedCheckManager = new Mock<IFeedCheckManager>();
+        _urlShortener = new Mock<IUrlShortener>();
+        _eventPublisher = new Mock<IEventPublisher>();
+
+        _settings.Setup(s => s.ShortenedDomainToUse).Returns("short.example.com");
+        _eventPublisher.Setup(e => e.PublishSyndicationFeedEventsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<SyndicationFeedSource>>()))
+            .ReturnsAsync(true);
+
+        _sut = new LoadNewPosts(
+            _feedReader.Object,
+            _settings.Object,
+            _feedSourceManager.Object,
+            _feedCheckManager.Object,
+            _urlShortener.Object,
+            _eventPublisher.Object,
+            NullLogger<LoadNewPosts>.Instance);
+    }
+
+    private static SyndicationFeedSource CreateFeedSource(string feedIdentifier = "feed-abc") =>
+        new SyndicationFeedSource
+        {
+            Id = 0,
+            FeedIdentifier = feedIdentifier,
+            Title = "Test Post",
+            Author = "Test Author",
+            Url = "https://example.com/post",
+            PublicationDate = DateTimeOffset.UtcNow,
+            AddedOn = DateTimeOffset.UtcNow,
+            LastUpdatedOn = DateTimeOffset.UtcNow
+        };
+
+    private void SetupFeedCheck() =>
+        _feedCheckManager.Setup(f => f.GetByNameAsync(It.IsAny<string>()))
+            .ReturnsAsync(new FeedCheck
+            {
+                Id = 1,
+                Name = "LoadNewPosts",
+                LastCheckedFeed = DateTimeOffset.UtcNow,
+                LastItemAddedOrUpdated = DateTimeOffset.MinValue,
+                LastUpdatedOn = DateTimeOffset.UtcNow
+            });
+
+    [Fact]
+    public async Task RunAsync_SkipsDuplicate_WhenFeedIdentifierAlreadyExists()
+    {
+        // Arrange
+        var item = CreateFeedSource("duplicate-feed-id");
+        var existingItem = CreateFeedSource("duplicate-feed-id");
+        existingItem.Id = 99;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _feedReader.Setup(r => r.GetAsync(It.IsAny<DateTimeOffset>())).ReturnsAsync(new List<SyndicationFeedSource> { item });
+        _feedSourceManager.Setup(m => m.GetByFeedIdentifierAsync("duplicate-feed-id")).ReturnsAsync(existingItem);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _feedSourceManager.Verify(m => m.SaveAsync(It.IsAny<SyndicationFeedSource>()), Times.Never);
+        _eventPublisher.Verify(
+            e => e.PublishSyndicationFeedEventsAsync(It.IsAny<string>(), It.Is<IReadOnlyCollection<SyndicationFeedSource>>(l => l.Count == 0)),
+            Times.Once);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("0", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_SavesItem_WhenFeedIdentifierIsNew()
+    {
+        // Arrange
+        var item = CreateFeedSource("brand-new-feed-id");
+        var savedItem = CreateFeedSource("brand-new-feed-id");
+        savedItem.Id = 42;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _feedReader.Setup(r => r.GetAsync(It.IsAny<DateTimeOffset>())).ReturnsAsync(new List<SyndicationFeedSource> { item });
+        _feedSourceManager.Setup(m => m.GetByFeedIdentifierAsync("brand-new-feed-id")).ReturnsAsync((SyndicationFeedSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("https://short.example.com/abc");
+        _feedSourceManager.Setup(m => m.SaveAsync(It.IsAny<SyndicationFeedSource>())).ReturnsAsync(savedItem);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _feedSourceManager.Verify(m => m.SaveAsync(It.IsAny<SyndicationFeedSource>()), Times.Once);
+        _eventPublisher.Verify(
+            e => e.PublishSyndicationFeedEventsAsync(It.IsAny<string>(), It.Is<IReadOnlyCollection<SyndicationFeedSource>>(l => l.Count == 1)),
+            Times.Once);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsOk_WhenNoNewItemsFound()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _feedReader.Setup(r => r.GetAsync(It.IsAny<DateTimeOffset>())).ReturnsAsync(new List<SyndicationFeedSource>());
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _feedSourceManager.Verify(m => m.SaveAsync(It.IsAny<SyndicationFeedSource>()), Times.Never);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("0", okResult.Value!.ToString());
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewVideosTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewVideosTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Functions.Collectors.YouTube;
+using JosephGuadagno.Broadcasting.Functions.Interfaces;
+using JosephGuadagno.Broadcasting.YouTubeReader.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
+
+public class LoadNewVideosTests
+{
+    private readonly Mock<IYouTubeReader> _youTubeReader;
+    private readonly Mock<ISettings> _settings;
+    private readonly Mock<IFeedCheckManager> _feedCheckManager;
+    private readonly Mock<IYouTubeSourceManager> _youTubeSourceManager;
+    private readonly Mock<IUrlShortener> _urlShortener;
+    private readonly Mock<IEventPublisher> _eventPublisher;
+    private readonly LoadNewVideos _sut;
+
+    public LoadNewVideosTests()
+    {
+        _youTubeReader = new Mock<IYouTubeReader>();
+        _settings = new Mock<ISettings>();
+        _feedCheckManager = new Mock<IFeedCheckManager>();
+        _youTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        _urlShortener = new Mock<IUrlShortener>();
+        _eventPublisher = new Mock<IEventPublisher>();
+
+        _settings.Setup(s => s.ShortenedDomainToUse).Returns("short.example.com");
+        _eventPublisher.Setup(e => e.PublishYouTubeEventsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<YouTubeSource>>()))
+            .ReturnsAsync(true);
+
+        _sut = new LoadNewVideos(
+            _youTubeReader.Object,
+            _settings.Object,
+            _feedCheckManager.Object,
+            _youTubeSourceManager.Object,
+            _urlShortener.Object,
+            _eventPublisher.Object,
+            NullLogger<LoadNewVideos>.Instance);
+    }
+
+    private static YouTubeSource CreateVideoSource(string videoId = "abc123") =>
+        new YouTubeSource
+        {
+            Id = 0,
+            VideoId = videoId,
+            Title = "Test Video",
+            Author = "Test Channel",
+            Url = $"https://youtube.com/watch?v={videoId}",
+            PublicationDate = DateTimeOffset.UtcNow,
+            AddedOn = DateTimeOffset.UtcNow,
+            LastUpdatedOn = DateTimeOffset.UtcNow
+        };
+
+    private void SetupFeedCheck() =>
+        _feedCheckManager.Setup(f => f.GetByNameAsync(It.IsAny<string>()))
+            .ReturnsAsync(new FeedCheck
+            {
+                Id = 1,
+                Name = "LoadNewVideos",
+                LastCheckedFeed = DateTimeOffset.UtcNow,
+                LastItemAddedOrUpdated = DateTimeOffset.MinValue,
+                LastUpdatedOn = DateTimeOffset.UtcNow
+            });
+
+    [Fact]
+    public async Task RunAsync_SkipsDuplicate_WhenVideoIdAlreadyExists()
+    {
+        // Arrange
+        var item = CreateVideoSource("duplicate-video-id");
+        var existingItem = CreateVideoSource("duplicate-video-id");
+        existingItem.Id = 77;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _youTubeReader.Setup(r => r.GetAsync(It.IsAny<DateTimeOffset>())).ReturnsAsync(new List<YouTubeSource> { item });
+        _youTubeSourceManager.Setup(m => m.GetByVideoIdAsync("duplicate-video-id")).ReturnsAsync(existingItem);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.SaveAsync(It.IsAny<YouTubeSource>()), Times.Never);
+        _eventPublisher.Verify(
+            e => e.PublishYouTubeEventsAsync(It.IsAny<string>(), It.Is<IReadOnlyCollection<YouTubeSource>>(l => l.Count == 0)),
+            Times.Once);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("0", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_SavesVideo_WhenVideoIdIsNew()
+    {
+        // Arrange
+        var item = CreateVideoSource("brand-new-video-id");
+        var savedItem = CreateVideoSource("brand-new-video-id");
+        savedItem.Id = 55;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _youTubeReader.Setup(r => r.GetAsync(It.IsAny<DateTimeOffset>())).ReturnsAsync(new List<YouTubeSource> { item });
+        _youTubeSourceManager.Setup(m => m.GetByVideoIdAsync("brand-new-video-id")).ReturnsAsync((YouTubeSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("https://short.example.com/xyz");
+        _youTubeSourceManager.Setup(m => m.SaveAsync(It.IsAny<YouTubeSource>())).ReturnsAsync(savedItem);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.SaveAsync(It.IsAny<YouTubeSource>()), Times.Once);
+        _eventPublisher.Verify(
+            e => e.PublishYouTubeEventsAsync(It.IsAny<string>(), It.Is<IReadOnlyCollection<YouTubeSource>>(l => l.Count == 1)),
+            Times.Once);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsOk_WhenNoNewVideosFound()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _youTubeReader.Setup(r => r.GetAsync(It.IsAny<DateTimeOffset>())).ReturnsAsync(new List<YouTubeSource>());
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.SaveAsync(It.IsAny<YouTubeSource>()), Times.Never);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("0", okResult.Value!.ToString());
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
@@ -68,6 +68,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0"/>
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>
         <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0"/>
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1"/>

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
@@ -59,6 +59,14 @@ public class LoadAllPosts(
             var savedCount = 0;
             foreach (var item in newItems)
             {
+                // Skip if item already exists
+                var existingItem = await syndicationFeedSourceManager.GetByFeedIdentifierAsync(item.FeedIdentifier);
+                if (existingItem != null)
+                {
+                    logger.LogWarning("Skipping duplicate syndication feed item with FeedIdentifier: '{FeedIdentifier}'", item.FeedIdentifier);
+                    continue;
+                }
+
                 // shorten the url
                 item.ShortenedUrl = await urlShortener.GetShortenedUrlAsync(item.Url, settings.ShortenedDomainToUse);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
@@ -54,6 +54,14 @@ public class LoadNewPosts(
             var eventsToPublish = new List<SyndicationFeedSource>();
             foreach (var item in newItems)
             {
+                // Skip if item already exists
+                var existingItem = await syndicationFeedSourceManager.GetByFeedIdentifierAsync(item.FeedIdentifier);
+                if (existingItem != null)
+                {
+                    logger.LogWarning("Skipping duplicate syndication feed item with FeedIdentifier: '{FeedIdentifier}'", item.FeedIdentifier);
+                    continue;
+                }
+
                 // shorten the url
                 item.ShortenedUrl = await urlShortener.GetShortenedUrlAsync(item.Url, settings.ShortenedDomainToUse);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
@@ -59,6 +59,14 @@ public class LoadAllVideos(
             var savedCount = 0;
             foreach (var item in newItems)
             {
+                // Skip if item already exists
+                var existingItem = await youTubeSourceManager.GetByVideoIdAsync(item.VideoId);
+                if (existingItem != null)
+                {
+                    logger.LogWarning("Skipping duplicate YouTube video with VideoId: '{VideoId}'", item.VideoId);
+                    continue;
+                }
+
                 // shorten the url
                 item.ShortenedUrl = await urlShortener.GetShortenedUrlAsync(item.Url, settings.ShortenedDomainToUse);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
@@ -54,6 +54,14 @@ public class LoadNewVideos(
             var eventsToPublish = new List<YouTubeSource>();
             foreach (var item in newItems)
             {
+                // Skip if item already exists
+                var existingItem = await youTubeSourceManager.GetByVideoIdAsync(item.VideoId);
+                if (existingItem != null)
+                {
+                    logger.LogWarning("Skipping duplicate YouTube video with VideoId: '{VideoId}'", item.VideoId);
+                    continue;
+                }
+
                 // shorten the url
                 item.ShortenedUrl = await urlShortener.GetShortenedUrlAsync(item.Url, settings.ShortenedDomainToUse);
 

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
@@ -120,4 +120,33 @@ public class SyndicationFeedSourceManagerTests
         Assert.Equal(source, result);
         _repository.Verify(r => r.GetRandomSyndicationDataAsync(cutoffDate, excludedCategories), Times.Once);
     }
+
+    [Fact]
+    public async Task GetByFeedIdentifierAsync_ShouldCallRepository()
+    {
+        // Arrange
+        var source = new SyndicationFeedSource { Id = 1, FeedIdentifier = "test-feed-id" };
+        _repository.Setup(r => r.GetByFeedIdentifierAsync("test-feed-id")).ReturnsAsync(source);
+
+        // Act
+        var result = await _syndicationFeedSourceManager.GetByFeedIdentifierAsync("test-feed-id");
+
+        // Assert
+        Assert.Equal(source, result);
+        _repository.Verify(r => r.GetByFeedIdentifierAsync("test-feed-id"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByFeedIdentifierAsync_ReturnsNull_WhenNotFound()
+    {
+        // Arrange
+        _repository.Setup(r => r.GetByFeedIdentifierAsync("missing")).ReturnsAsync((SyndicationFeedSource?)null);
+
+        // Act
+        var result = await _syndicationFeedSourceManager.GetByFeedIdentifierAsync("missing");
+
+        // Assert
+        Assert.Null(result);
+        _repository.Verify(r => r.GetByFeedIdentifierAsync("missing"), Times.Once);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
@@ -103,4 +103,33 @@ public class YouTubeSourceManagerTests
         Assert.Equal(source, result);
         _repository.Verify(r => r.GetByUrlAsync("http://test.com"), Times.Once);
     }
+
+    [Fact]
+    public async Task GetByVideoIdAsync_ShouldCallRepository()
+    {
+        // Arrange
+        var source = new YouTubeSource { Id = 1, VideoId = "testvideoid" };
+        _repository.Setup(r => r.GetByVideoIdAsync("testvideoid")).ReturnsAsync(source);
+
+        // Act
+        var result = await _youTubeSourceManager.GetByVideoIdAsync("testvideoid");
+
+        // Assert
+        Assert.Equal(source, result);
+        _repository.Verify(r => r.GetByVideoIdAsync("testvideoid"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByVideoIdAsync_ReturnsNull_WhenNotFound()
+    {
+        // Arrange
+        _repository.Setup(r => r.GetByVideoIdAsync("missing")).ReturnsAsync((YouTubeSource?)null);
+
+        // Act
+        var result = await _youTubeSourceManager.GetByVideoIdAsync("missing");
+
+        // Assert
+        Assert.Null(result);
+        _repository.Verify(r => r.GetByVideoIdAsync("missing"), Times.Once);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/SyndicationFeedSourceManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/SyndicationFeedSourceManager.cs
@@ -46,6 +46,11 @@ public class SyndicationFeedSourceManager : ISyndicationFeedSourceManager
         return await _syndicationFeedSourceRepository.GetByUrlAsync(url);
     }
 
+    public async Task<SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier)
+    {
+        return await _syndicationFeedSourceRepository.GetByFeedIdentifierAsync(feedIdentifier);
+    }
+
     public async Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(DateTimeOffset cutoffDate, List<string> excludedCategories)
     {
         return await _syndicationFeedSourceRepository.GetRandomSyndicationDataAsync(cutoffDate, excludedCategories);

--- a/src/JosephGuadagno.Broadcasting.Managers/YouTubeSourceManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/YouTubeSourceManager.cs
@@ -44,4 +44,9 @@ public class YouTubeSourceManager : IYouTubeSourceManager
     {
         return await _youTubeSourceRepository.GetByUrlAsync(url);
     }
+
+    public async Task<YouTubeSource?> GetByVideoIdAsync(string videoId)
+    {
+        return await _youTubeSourceRepository.GetByVideoIdAsync(videoId);
+    }
 }


### PR DESCRIPTION
Closes #272

Adds unit tests for duplicate-detection logic:
- Data store: GetByFeedIdentifierAsync (found/not-found) for SyndicationFeedSourceDataStore
- Data store: GetByVideoIdAsync (found/not-found) for YouTubeSourceDataStore
- Repository: GetByFeedIdentifierAsync delegates to data store
- Repository: GetByVideoIdAsync delegates to data store
- Manager: GetByFeedIdentifierAsync delegates to repository
- Manager: GetByVideoIdAsync delegates to repository
- Collector: LoadNewPosts skips duplicate FeedIdentifier / saves new item
- Collector: LoadNewVideos skips duplicate VideoId / saves new video
- Add Moq and Microsoft.NET.Test.Sdk to Functions.Tests project