### PR TITLE
fix(#291): add dotnet test step to all CI pipelines

### DIFF
--- a/.github/workflows/main_api-jjgnet-broadcast.yml
+++ b/.github/workflows/main_api-jjgnet-broadcast.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build with dotnet
         run: dotnet build ./src/JosephGuadagno.Broadcasting.Api --configuration Release
 
+      - name: Test
+        run: dotnet test src/ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"
+
       - name: dotnet publish
         run: dotnet publish ./src/JosephGuadagno.Broadcasting.Api -c Release -o ${{env.DOTNET_ROOT}}/api-jjgnet-broadcast
 

--- a/.github/workflows/main_jjgnet-broadcast.yml
+++ b/.github/workflows/main_jjgnet-broadcast.yml
@@ -37,6 +37,10 @@ jobs:
           dotnet build ./src/JosephGuadagno.Broadcasting.Functions --configuration Release --output ./output
           popd
       
+      - name: Test
+        shell: bash
+        run: dotnet test src/ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"
+
       - name: Login to Azure
         uses: azure/login@v2
         with:

--- a/.github/workflows/main_web-jjgnet-broadcast.yml
+++ b/.github/workflows/main_web-jjgnet-broadcast.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build with dotnet
         run: dotnet build ./src/JosephGuadagno.Broadcasting.Web --configuration Release
 
+      - name: Test
+        run: dotnet test src/ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"
+
       - name: dotnet publish
         run: dotnet publish ./src/JosephGuadagno.Broadcasting.Web -c Release -o ${{env.DOTNET_ROOT}}/web-jjgnet-broadcast
 


### PR DESCRIPTION
Closes #291

Add a Test step after dotnet build in all three CI workflow files:
- main_api-jjgnet-broadcast.yml
- main_web-jjgnet-broadcast.yml
- main_jjgnet-broadcast.yml (Functions)

The test step uses --filter "FullyQualifiedName!~SyndicationFeedReader" to exclude network-dependent tests that hit josephguadagno.net and would fail in CI environments.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>