### PR TITLE
chore(security): add detect-secrets pre-commit hook (#283)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,283 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "scripts\\database\\database-create.sql": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts\\database\\database-create.sql",
+        "hashed_secret": "b79fe4495e8053aeb83b8ba16f21ee54a261f027",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.Data.KeyVault.Tests\\KeyVaultTests.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.Data.KeyVault.Tests\\KeyVaultTests.cs",
+        "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.Data.KeyVault.Tests\\KeyVaultTests.cs",
+        "hashed_secret": "6b1bcba9c8c2b71972374330fd2a437f0f48325a",
+        "is_verified": false,
+        "line_number": 69
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.Functions.IntegrationTests\\AzureKeyVaultTests.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.Functions.IntegrationTests\\AzureKeyVaultTests.cs",
+        "hashed_secret": "8e302a038bc3c767999d699c43d549c1d2606e75",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.Functions\\Facebook\\RefreshTokens.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.Functions\\Facebook\\RefreshTokens.cs",
+        "hashed_secret": "58da5746da827e900b7aa93bdacfccf5ba07cb2f",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.Managers.Facebook.Tests\\ModelsTests.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.Managers.Facebook.Tests\\ModelsTests.cs",
+        "hashed_secret": "f3bba5d9c0ce665f2efa6030c2fae011942c7409",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.Web\\Controllers\\LinkedInController.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Controllers\\LinkedInController.cs",
+        "hashed_secret": "6ec188295329efa23801a4e86883258788401d1c",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "2164c2d4df490e61fc8746e576b53b457f967243",
+        "is_verified": false,
+        "line_number": 9
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "aa5e09727f33373f88f4fe1c8dc28b073cac5729",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "60fc6c56e98ba973cfbe8608d98e684d8cbff542",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "bda4195ff28a812d14a7e4dd172299f68962d55a",
+        "is_verified": false,
+        "line_number": 129
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "f95d4d8d2b6823ad87d5ae3e58363a3fa4254ac1",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "655d66867fcd31519cca728cc1ebca40a687b87d",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "42ced608924563d6e9d777bae64fa5c9317dbf98",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src\\JosephGuadagno.Broadcasting.Web\\Views\\Shared\\_Layout.cshtml",
+        "hashed_secret": "0788986b1aa7b78d8c7bf886f05d6c81f92eff68",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests\\YouTubeReaderTests.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests\\YouTubeReaderTests.cs",
+        "hashed_secret": "f2ac855385c8bd428d3736989351631259a8236f",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.YouTubeReader.Tests\\YouTubeReaderFetchTests.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.YouTubeReader.Tests\\YouTubeReaderFetchTests.cs",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "src\\JosephGuadagno.Broadcasting.YouTubeReader.Tests\\YouTubeReaderTests.cs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\JosephGuadagno.Broadcasting.YouTubeReader.Tests\\YouTubeReaderTests.cs",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 152
+      }
+    ],
+    "src\\http-client.env.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\http-client.env.json",
+        "hashed_secret": "ae135808a5439f46237cc67318093949a458e754",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ]
+  },
+  "generated_at": "2026-03-16T21:03:24Z"
+}


### PR DESCRIPTION
## Summary

Closes #283

### Git History Check
\http-client.private.env.json\ was **NOT found** in git history — no history scrub was required. The file is already covered by the \.gitignore\ pattern \*.private.env.json\.

### Changes
- Added \.pre-commit-config.yaml\ with the [detect-secrets](https://github.com/Yelp/detect-secrets) v1.4.0 pre-commit hook to prevent future credential commits.
- Added \.secrets.baseline\ (generated by \detect-secrets scan\ v1.5.0) to track known secrets/false-positives.

### Using the hook
\\\ash
pip install pre-commit
pre-commit install
\\\

---

## ⚠️ ACTION REQUIRED — Rotate Credentials Manually

Even though the file was not in git history, any credentials stored in \http-client.private.env.json\ may have been exposed through other channels. **Please rotate the following:**

| Credential | Where to Rotate |
|---|---|
| Facebook App Secret | https://developers.facebook.com/ → Your App → Settings → Basic |
| Facebook Access Tokens | https://developers.facebook.com/ → Tools → Access Token Debugger / regenerate |
| Azure Functions Key | Azure Portal → Function App → App keys → Renew |

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>