### PR TITLE
feat(#287): add global exception handling middleware with ProblemDetails

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/Infrastructure/GlobalExceptionHandler.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Infrastructure/GlobalExceptionHandler.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Api.Infrastructure;
+
+/// <summary>
+/// Global exception handler that maps exceptions to RFC 9457 ProblemDetails responses.
+/// </summary>
+public class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+
+    public GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogError(exception, "Unhandled exception of type {ExceptionType}: {Message}",
+            exception.GetType().Name, exception.Message);
+
+        var problemDetails = new ProblemDetails
+        {
+            Instance = httpContext.Request.Path
+        };
+
+        if (exception is ApplicationException)
+        {
+            problemDetails.Status = StatusCodes.Status400BadRequest;
+            problemDetails.Title = "Bad Request";
+            problemDetails.Detail = exception.Message;
+        }
+        else
+        {
+            problemDetails.Status = StatusCodes.Status500InternalServerError;
+            problemDetails.Title = "Internal Server Error";
+            problemDetails.Detail = "An unexpected error occurred. Please try again later.";
+        }
+
+        httpContext.Response.StatusCode = problemDetails.Status.Value;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #287

## Changes
- Add \GlobalExceptionHandler\ implementing \IExceptionHandler\ (RFC 9457)
- \ApplicationException\ → 400 Bad Request with ProblemDetails
- All other exceptions → 500 Internal Server Error with ProblemDetails
- Register \AddProblemDetails()\, \AddExceptionHandler<GlobalExceptionHandler>()\
- Add \pp.UseExceptionHandler()\ to middleware pipeline

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>