### PR TITLE
fix(#292): pin GitHub Actions to valid @v4 versions

### DIFF
--- a/.github/workflows/main_api-jjgnet-broadcast.yml
+++ b/.github/workflows/main_api-jjgnet-broadcast.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.x'
           include-prerelease: true
@@ -32,7 +32,7 @@ jobs:
         run: dotnet publish ./src/JosephGuadagno.Broadcasting.Api -c Release -o ${{env.DOTNET_ROOT}}/api-jjgnet-broadcast
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: .api-app
           path: ${{env.DOTNET_ROOT}}/api-jjgnet-broadcast
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: .api-app
       

--- a/.github/workflows/main_jjgnet-broadcast.yml
+++ b/.github/workflows/main_jjgnet-broadcast.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/main_web-jjgnet-broadcast.yml
+++ b/.github/workflows/main_web-jjgnet-broadcast.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.x'
           include-prerelease: true
@@ -32,7 +32,7 @@ jobs:
         run: dotnet publish ./src/JosephGuadagno.Broadcasting.Web -c Release -o ${{env.DOTNET_ROOT}}/web-jjgnet-broadcast
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: .web-app
           path: ${{env.DOTNET_ROOT}}/web-jjgnet-broadcast
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: .web-app
       


### PR DESCRIPTION
Closes #292

Replace non-existent action versions across all three CI workflow files with valid @v4 pins:

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | @v6 | @v4 |
| actions/setup-dotnet | @v5 | @v4 |
| actions/upload-artifact | @v7 | @v4 |
| actions/download-artifact | @v8 | @v4 |

The existing \zure/*\ action versions (\login@v2\, \webapps-deploy@v3\, \unctions-action@v1\) are already valid and left unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>