### PR TITLE
fix(#294): expose health check endpoints in all environments

### DIFF
--- a/src/JosephGuadagno.Broadcasting.ServiceDefaults/Extensions.cs
+++ b/src/JosephGuadagno.Broadcasting.ServiceDefaults/Extensions.cs
@@ -107,19 +107,14 @@ public static class Extensions
 
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks(HealthEndpointPath);
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks(HealthEndpointPath);
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live")
+        });
 
         return app;
     }


### PR DESCRIPTION
Closes #294

Remove the \IsDevelopment()\ guard from \MapDefaultEndpoints\ in \ServiceDefaults/Extensions.cs\.

**Problem**: \/health\ and \/alive\ returned 404 in production because \MapHealthChecks\ was wrapped in \if (app.Environment.IsDevelopment())\. This prevented Azure App Service health probes and load balancers from getting valid health status.

**Fix**: Unconditionally map both health endpoints. The endpoints only expose liveness/readiness booleans — no sensitive application data is revealed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>