### PR TITLE
feat: add duplicate detection to LoadNewSpeakingEngagements collector

### DIFF
--- a/.squad/decisions/inbox/trinity-engagement-dupe-detection.md
+++ b/.squad/decisions/inbox/trinity-engagement-dupe-detection.md
@@ -1,0 +1,60 @@
+# Decision: Engagement Duplicate Detection (feature/engagement-dupe-detection)
+
+**Date:** 2026-07-11
+**Author:** Trinity (Backend Dev)
+**Branch:** `feature/engagement-dupe-detection`
+
+## Context
+
+`LoadNewSpeakingEngagements` is a timer-triggered Azure Function that pulls engagements from an
+external reader and saves them to the database. Running it repeatedly (e.g. on redeploy or manual
+trigger) would re-insert the same engagements, causing duplicate rows.
+
+## Natural Key Chosen
+
+| Field | Rationale |
+|-------|-----------|
+| `Name` | Title of the speaking engagement |
+| `Url` | Canonical event URL — unique per event |
+| `StartDateTime.Year` | Scopes collisions to the same calendar year |
+
+Combined: **Name + Url + Year** — this mirrors the existing `GetByNameAndUrlAndYearAsync` already
+present on `IEngagementDataStore` and `EngagementManager` from a previous sprint. No new query
+method was needed.
+
+## Detection Approach
+
+"Check then skip" in the Function, before the save pipeline:
+
+```csharp
+var existingEngagement = await engagementManager.GetByNameAndUrlAndYearAsync(
+    item.Name, item.Url, item.StartDateTime.Year);
+if (existingEngagement != null)
+{
+    logger.LogDebug("Skipping duplicate speaking engagement '{Name}' ({Url}, {Year})", ...);
+    continue;
+}
+```
+
+- Duplicates are **skipped** (not upserted) — re-running the collector is now idempotent.
+- Logged at **Debug** level (low-noise, appropriate for an expected skip path).
+- Pattern matches `LoadNewPosts` (SyndicationFeed) and `LoadNewVideos` (YouTube) collectors.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `Domain/Interfaces/IEngagementManager.cs` | Added `GetByNameAndUrlAndYearAsync` to interface (was implemented but not exposed) |
+| `Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs` | Added duplicate check + skip before `SavePipeline.ExecuteAsync`; removed TODO comment |
+| `Functions.Tests/Collectors/LoadNewSpeakingEngagementsTests.cs` | New — 3 tests covering duplicate-skip, new-save, and no-items paths |
+
+## Why Not Upsert?
+
+`EngagementManager.SaveAsync` already does an implicit "find by natural key and update" when
+`entity.Id == 0`. The collector does not need to update existing engagements — if the reader
+returns a known engagement, the correct behavior is to skip it so that any manual edits made via
+the Web UI are preserved.
+
+## Test Count
+
+3 new unit tests in `JosephGuadagno.Broadcasting.Functions.Tests.Collectors.LoadNewSpeakingEngagementsTests`.

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IEngagementManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IEngagementManager.cs
@@ -9,4 +9,5 @@ public interface IEngagementManager: IManager<Engagement>
     public Task<bool> RemoveTalkFromEngagementAsync(int talkId);
     public Task<bool> RemoveTalkFromEngagementAsync(Talk talk);
     public Task<Talk> GetTalkAsync(int talkId);
+    public Task<Engagement?> GetByNameAndUrlAndYearAsync(string name, string url, int year);
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewSpeakingEngagementsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewSpeakingEngagementsTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Functions.Collectors.SpeakingEngagement;
+using JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
+
+public class LoadNewSpeakingEngagementsTests
+{
+    private readonly Mock<ISpeakingEngagementsReader> _engagementsReader;
+    private readonly Mock<IEngagementManager> _engagementManager;
+    private readonly Mock<IFeedCheckManager> _feedCheckManager;
+    private readonly LoadNewSpeakingEngagements _sut;
+
+    public LoadNewSpeakingEngagementsTests()
+    {
+        _engagementsReader = new Mock<ISpeakingEngagementsReader>();
+        _engagementManager = new Mock<IEngagementManager>();
+        _feedCheckManager = new Mock<IFeedCheckManager>();
+
+        _sut = new LoadNewSpeakingEngagements(
+            _engagementsReader.Object,
+            _engagementManager.Object,
+            _feedCheckManager.Object,
+            NullLogger<LoadNewSpeakingEngagements>.Instance);
+    }
+
+    private static Engagement CreateEngagement(string name = "Test Conf", string url = "https://example.com/conf", int year = 2025) =>
+        new Engagement
+        {
+            Id = 0,
+            Name = name,
+            Url = url,
+            StartDateTime = new DateTimeOffset(year, 6, 1, 9, 0, 0, TimeSpan.Zero),
+            EndDateTime = new DateTimeOffset(year, 6, 3, 17, 0, 0, TimeSpan.Zero),
+            TimeZoneId = "America/Phoenix",
+            CreatedOn = DateTimeOffset.UtcNow,
+            LastUpdatedOn = DateTimeOffset.UtcNow
+        };
+
+    private void SetupFeedCheck() =>
+        _feedCheckManager.Setup(f => f.GetByNameAsync(It.IsAny<string>()))
+            .ReturnsAsync(new FeedCheck
+            {
+                Id = 1,
+                Name = "LoadNewSpeakingEngagements",
+                LastCheckedFeed = DateTimeOffset.UtcNow,
+                LastItemAddedOrUpdated = DateTimeOffset.MinValue,
+                LastUpdatedOn = DateTimeOffset.UtcNow
+            });
+
+    [Fact]
+    public async Task RunAsync_SkipsDuplicate_WhenEngagementAlreadyExists()
+    {
+        // Arrange
+        var item = CreateEngagement();
+        var existing = CreateEngagement();
+        existing.Id = 7;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _engagementsReader.Setup(r => r.GetAll(It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<Engagement> { item });
+        _engagementManager
+            .Setup(m => m.GetByNameAndUrlAndYearAsync(item.Name, item.Url, item.StartDateTime.Year))
+            .ReturnsAsync(existing);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _engagementManager.Verify(m => m.SaveAsync(It.IsAny<Engagement>()), Times.Never);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("0", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_SavesEngagement_WhenEngagementIsNew()
+    {
+        // Arrange
+        var item = CreateEngagement();
+        var saved = CreateEngagement();
+        saved.Id = 42;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _engagementsReader.Setup(r => r.GetAll(It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<Engagement> { item });
+        _engagementManager
+            .Setup(m => m.GetByNameAndUrlAndYearAsync(item.Name, item.Url, item.StartDateTime.Year))
+            .ReturnsAsync((Engagement?)null);
+        _engagementManager.Setup(m => m.SaveAsync(It.IsAny<Engagement>())).ReturnsAsync(saved);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _engagementManager.Verify(m => m.SaveAsync(It.IsAny<Engagement>()), Times.Once);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsOk_WhenNoEngagementsFound()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>())).ReturnsAsync(new FeedCheck());
+        _engagementsReader.Setup(r => r.GetAll(It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<Engagement>());
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _engagementManager.Verify(m => m.SaveAsync(It.IsAny<Engagement>()), Times.Never);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("0", okResult.Value!.ToString());
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs
@@ -64,10 +64,20 @@ public class LoadNewSpeakingEngagements(
             var savedCount = 0;
             foreach (var item in newItems)
             {
+                // Skip if the engagement already exists (Name + Url + StartDateTime.Year is the natural key)
+                var existingEngagement = await engagementManager.GetByNameAndUrlAndYearAsync(
+                    item.Name, item.Url, item.StartDateTime.Year);
+                if (existingEngagement != null)
+                {
+                    logger.LogDebug(
+                        "Skipping duplicate speaking engagement '{Name}' ({Url}, {Year})",
+                        item.Name, item.Url, item.StartDateTime.Year);
+                    continue;
+                }
+
                 // attempt to save the item
                 try
                 {
-                    // TODO: Add a check to see if the item already exists, if so, update it.
                     var engagement = await SavePipeline.ExecuteAsync(
                         async ct => await engagementManager.SaveAsync(item));
                     var properties = new Dictionary<string, string>


### PR DESCRIPTION
## Summary

Prevents duplicate speaking engagements when \LoadNewSpeakingEngagements\ runs repeatedly.

## Natural Key

\Name + Url + StartDateTime.Year\ — mirrors the existing \GetByNameAndUrlAndYearAsync\ already present on the data store and manager.

## Changes

| File | Change |
|------|--------|
| \Domain/Interfaces/IEngagementManager.cs\ | Added \GetByNameAndUrlAndYearAsync\ to interface |
| \Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs\ | Duplicate check + skip before save; removed TODO |
| \Functions.Tests/Collectors/LoadNewSpeakingEngagementsTests.cs\ | New — 3 tests |

## Tests

3 new unit tests:
- \RunAsync_SkipsDuplicate_WhenEngagementAlreadyExists\
- \RunAsync_SavesEngagement_WhenEngagementIsNew\
- \RunAsync_ReturnsOk_WhenNoEngagementsFound\

All 43 Functions.Tests pass.