### PR TITLE
fix(#488): patch CVE-2026-26127 DoS vulnerability in idunno.Bluesky packages

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities privately via [GitHub's security advisory feature](https://github.com/jguadagno/jjgnet-broadcast/security/advisories/new)
+or by emailing the maintainer directly.
+
+You can expect an acknowledgment within 48 hours and a resolution timeline communicated within 5 business days.
+
+---
+
+## Known Addressed Vulnerabilities
+
+### CVE-2026-26127 / GHSA-8fh9-c4jq-94h4 — Denial of Service via `Microsoft.Bcl.Memory`
+
+| Field        | Detail |
+|--------------|--------|
+| **Severity** | High |
+| **Advisory** | https://github.com/advisories/GHSA-8fh9-c4jq-94h4 |
+| **Affected**  | `Microsoft.Bcl.Memory` (transitive via `idunno.AtProto` / `idunno.Bluesky` < 1.7.0) |
+| **Fix**       | Upgrade `idunno.Bluesky` to **1.7.0** (removes the vulnerable transitive dependency) |
+| **Status**    | ✅ Patched — `idunno.Bluesky` pinned to `1.7.0` in `JosephGuadagno.Broadcasting.Managers.Bluesky` |
+| **PR**        | [#488](https://github.com/jguadagno/jjgnet-broadcast/pull/488) |
+
+#### Background
+
+`idunno.Bluesky` versions prior to 1.7.0 pulled in a vulnerable version of `Microsoft.Bcl.Memory`
+as a transitive dependency through `idunno.AtProto`. The vulnerability allows a remote attacker
+to trigger a Denial of Service condition. Upgrading `idunno.Bluesky` to 1.7.0 removes the
+dependency on the affected `Microsoft.Bcl.Memory` version entirely.


### PR DESCRIPTION
## Summary

Patches **CVE-2026-26127 / GHSA-8fh9-c4jq-94h4** — Denial of Service vulnerability via \Microsoft.Bcl.Memory\, a transitive dependency of \idunno.AtProto\ and related packages.

## Advisory

https://github.com/advisories/GHSA-8fh9-c4jq-94h4

## What Changed

- **Confirms** \idunno.Bluesky\ is pinned to **v1.7.0** in \JosephGuadagno.Broadcasting.Managers.Bluesky\ (upgraded from v1.6.0 by dependabot in e36ba32)
- **Adds \SECURITY.md\** to formally document the CVE, the affected versions, and the fix, providing a permanent audit trail for this security issue

## Root Cause

\idunno.Bluesky\ < 1.7.0 transitively pulled in a vulnerable version of \Microsoft.Bcl.Memory\ via \idunno.AtProto\. Upgrading to 1.7.0 removes \Microsoft.Bcl.Memory\ from the transitive dependency tree entirely.

## Verification

\\\
dotnet list JosephGuadagno.Broadcasting.Managers.Bluesky package --include-transitive
\\\

Confirms \Microsoft.Bcl.Memory\ is **not present** in the resolved dependency graph for \idunno.Bluesky\ 1.7.0.

Build: ✅ 0 errors  
Tests: ✅ No regressions introduced

Closes #488