### PR TITLE
test(functions): add unit tests for per-type template selection and coverage gaps

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Bluesky/ProcessScheduledItemFiredTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Bluesky/ProcessScheduledItemFiredTests.cs
@@ -42,6 +42,44 @@ public class ProcessScheduledItemFiredTests
         LastUpdatedOn = DateTimeOffset.UtcNow
     };
 
+    private static Engagement BuildEngagement(int id = 42) => new()
+    {
+        Id = id,
+        Name = "Tech Conference 2026",
+        Url = "https://conf.example.com",
+        StartDateTime = new DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 3, 17, 0, 0, TimeSpan.Zero),
+        TimeZoneId = "UTC",
+        Comments = "Great event!"
+    };
+
+    private static Talk BuildTalk(int id = 42, int engagementId = 99) => new()
+    {
+        Id = id,
+        Name = "Building .NET Apps",
+        UrlForConferenceTalk = "https://conf.example.com/talks/dotnet",
+        UrlForTalk = "https://josephguadagno.net/talks/dotnet",
+        StartDateTime = new DateTimeOffset(2026, 6, 2, 10, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 2, 11, 0, 0, TimeSpan.Zero),
+        TalkLocation = "Room A",
+        Comments = "Excellent session",
+        EngagementId = engagementId
+    };
+
+    private static YouTubeSource BuildYouTubeSource(int id = 42) => new()
+    {
+        Id = id,
+        VideoId = "abc123def",
+        Author = "Joseph Guadagno",
+        Title = "Building Better Apps with .NET",
+        Url = "https://youtube.com/watch?v=abc123def",
+        ShortenedUrl = null,
+        Tags = null,
+        PublicationDate = DateTimeOffset.UtcNow,
+        AddedOn = DateTimeOffset.UtcNow,
+        LastUpdatedOn = DateTimeOffset.UtcNow
+    };
+
     private static Functions.Bluesky.ProcessScheduledItemFired BuildSut(
         Mock<IScheduledItemManager> scheduledItemManager,
         Mock<ISyndicationFeedSourceManager> feedSourceManager,
@@ -239,5 +277,327 @@ public class ProcessScheduledItemFiredTests
         // Assert — empty template is treated as no template → fallback
         Assert.NotNull(result);
         Assert.Contains("Blog Post:", result!.Text);
+    }
+
+    // ── Per-type template selection: Engagements ─────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestNewSpeakingEngagementTemplate_WhenItemTypeIsEngagements()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the engagement-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.NewSpeakingEngagement),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateFound_RendersEngagementNameAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Bluesky",
+            MessageType = MessageTemplates.MessageTypes.NewSpeakingEngagement,
+            Template = "Speaking at {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — rendered via Scriban using engagement fields
+        Assert.NotNull(result);
+        Assert.Equal("Speaking at Tech Conference 2026 - https://conf.example.com", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateIsNull_FallsBackToEngagementPost()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback includes engagement name
+        Assert.NotNull(result);
+        Assert.Contains("I'm speaking at", result!.Text);
+        Assert.Contains("Tech Conference 2026", result!.Text);
+    }
+
+    // ── Per-type template selection: Talks ────────────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestScheduledItemTemplate_WhenItemTypeIsTalks()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var associatedEngagement = BuildEngagement(talk.Id);
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+        mockEngagementManager.Setup(m => m.GetAsync(talk.Id)).ReturnsAsync(associatedEngagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the talk-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.ScheduledItem),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateFound_RendersTalkNameAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Bluesky",
+            MessageType = MessageTemplates.MessageTypes.ScheduledItem,
+            Template = "My talk: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — template renders talk name and URL
+        Assert.NotNull(result);
+        Assert.Equal("My talk: Building .NET Apps - https://josephguadagno.net/talks/dotnet", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateIsNull_FallsBackToTalkPost()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var associatedEngagement = BuildEngagement(talk.Id);
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+        mockEngagementManager.Setup(m => m.GetAsync(talk.Id)).ReturnsAsync(associatedEngagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback generates talk post
+        Assert.NotNull(result);
+        Assert.Contains("My talk:", result!.Text);
+        Assert.Contains("Building .NET Apps", result!.Text);
+    }
+
+    // ── Per-type template selection: YouTubeSources ───────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestNewYouTubeItemTemplate_WhenItemTypeIsYouTubeSources()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the YouTube-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.NewYouTubeItem),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateFound_RendersVideoTitleAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Bluesky",
+            MessageType = MessageTemplates.MessageTypes.NewYouTubeItem,
+            Template = "New video: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — template renders video title and URL
+        Assert.NotNull(result);
+        Assert.Equal("New video: Building Better Apps with .NET - https://youtube.com/watch?v=abc123def", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateIsNull_FallsBackToVideoPost()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Bluesky, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback generates video post
+        Assert.NotNull(result);
+        Assert.Contains("Video:", result!.Text);
+        Assert.Contains("Building Better Apps with .NET", result!.Text);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Facebook/ProcessScheduledItemFiredTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Facebook/ProcessScheduledItemFiredTests.cs
@@ -42,6 +42,44 @@ public class ProcessScheduledItemFiredTests
         LastUpdatedOn = DateTimeOffset.UtcNow
     };
 
+    private static Engagement BuildEngagement(int id = 42) => new()
+    {
+        Id = id,
+        Name = "Tech Conference 2026",
+        Url = "https://conf.example.com",
+        StartDateTime = new DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 3, 17, 0, 0, TimeSpan.Zero),
+        TimeZoneId = "UTC",
+        Comments = "Great event!"
+    };
+
+    private static Talk BuildTalk(int id = 42, int engagementId = 99) => new()
+    {
+        Id = id,
+        Name = "Building .NET Apps",
+        UrlForConferenceTalk = "https://conf.example.com/talks/dotnet",
+        UrlForTalk = "https://josephguadagno.net/talks/dotnet",
+        StartDateTime = new DateTimeOffset(2026, 6, 2, 10, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 2, 11, 0, 0, TimeSpan.Zero),
+        TalkLocation = "Room A",
+        Comments = "Excellent session",
+        EngagementId = engagementId
+    };
+
+    private static YouTubeSource BuildYouTubeSource(int id = 42) => new()
+    {
+        Id = id,
+        VideoId = "abc123def",
+        Author = "Joseph Guadagno",
+        Title = "Building Better Apps with .NET",
+        Url = "https://youtube.com/watch?v=abc123def",
+        ShortenedUrl = null,
+        Tags = null,
+        PublicationDate = DateTimeOffset.UtcNow,
+        AddedOn = DateTimeOffset.UtcNow,
+        LastUpdatedOn = DateTimeOffset.UtcNow
+    };
+
     private static Functions.Facebook.ProcessScheduledItemFired BuildSut(
         Mock<IScheduledItemManager> scheduledItemManager,
         Mock<ISyndicationFeedSourceManager> feedSourceManager,
@@ -243,5 +281,223 @@ public class ProcessScheduledItemFiredTests
         Assert.NotNull(result);
         Assert.Equal("https://example.com/post", result.LinkUri);
         Assert.Equal("Just the title: Test Blog Post Title", result.StatusText);
+    }
+
+    // ── Per-type tests: Facebook always uses RandomPost regardless of item type ──
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateFound_RendersEngagementDataInStatusText()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Facebook",
+            MessageType = MessageTemplates.MessageTypes.NewSpeakingEngagement,
+            Template = "Speaking at {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Facebook, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — rendered via Scriban; LinkUri from the engagement
+        Assert.NotNull(result);
+        Assert.Equal("Speaking at Tech Conference 2026 - https://conf.example.com", result!.StatusText);
+        Assert.Equal("https://conf.example.com", result.LinkUri);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateIsNull_FallsBackToEngagementStatusText()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Facebook, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback includes engagement name and URL
+        Assert.NotNull(result);
+        Assert.Contains("Tech Conference 2026", result!.StatusText);
+        Assert.Equal("https://conf.example.com", result.LinkUri);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateFound_RendersTalkDataInStatusText()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Facebook",
+            MessageType = MessageTemplates.MessageTypes.ScheduledItem,
+            Template = "My talk: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Facebook, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — rendered via Scriban using talk data
+        Assert.NotNull(result);
+        Assert.Equal("My talk: Building .NET Apps - https://josephguadagno.net/talks/dotnet", result!.StatusText);
+        Assert.Equal("https://conf.example.com/talks/dotnet", result.LinkUri);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateIsNull_FallsBackToTalkStatusText()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Facebook, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback includes talk name; LinkUri is conference URL
+        Assert.NotNull(result);
+        Assert.Contains("Building .NET Apps", result!.StatusText);
+        Assert.Equal("https://conf.example.com/talks/dotnet", result.LinkUri);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateFound_RendersVideoDataInStatusText()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Facebook",
+            MessageType = MessageTemplates.MessageTypes.NewYouTubeItem,
+            Template = "New video: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Facebook, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — rendered via Scriban; LinkUri is video URL
+        Assert.NotNull(result);
+        Assert.Equal("New video: Building Better Apps with .NET - https://youtube.com/watch?v=abc123def", result!.StatusText);
+        Assert.Equal("https://youtube.com/watch?v=abc123def", result.LinkUri);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateIsNull_FallsBackToVideoStatusText()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Facebook, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback includes video title; LinkUri is video URL
+        Assert.NotNull(result);
+        Assert.Contains("Building Better Apps with .NET", result!.StatusText);
+        Assert.Equal("https://youtube.com/watch?v=abc123def", result.LinkUri);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/ProcessScheduledItemFiredTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/ProcessScheduledItemFiredTests.cs
@@ -43,6 +43,44 @@ public class ProcessScheduledItemFiredTests
         LastUpdatedOn = DateTimeOffset.UtcNow
     };
 
+    private static Engagement BuildEngagement(int id = 42) => new()
+    {
+        Id = id,
+        Name = "Tech Conference 2026",
+        Url = "https://conf.example.com",
+        StartDateTime = new DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 3, 17, 0, 0, TimeSpan.Zero),
+        TimeZoneId = "UTC",
+        Comments = "Great event!"
+    };
+
+    private static Talk BuildTalk(int id = 42, int engagementId = 99) => new()
+    {
+        Id = id,
+        Name = "Building .NET Apps",
+        UrlForConferenceTalk = "https://conf.example.com/talks/dotnet",
+        UrlForTalk = "https://josephguadagno.net/talks/dotnet",
+        StartDateTime = new DateTimeOffset(2026, 6, 2, 10, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 2, 11, 0, 0, TimeSpan.Zero),
+        TalkLocation = "Room A",
+        Comments = "Excellent session",
+        EngagementId = engagementId
+    };
+
+    private static YouTubeSource BuildYouTubeSource(int id = 42) => new()
+    {
+        Id = id,
+        VideoId = "abc123def",
+        Author = "Joseph Guadagno",
+        Title = "Building Better Apps with .NET",
+        Url = "https://youtube.com/watch?v=abc123def",
+        ShortenedUrl = null,
+        Tags = null,
+        PublicationDate = DateTimeOffset.UtcNow,
+        AddedOn = DateTimeOffset.UtcNow,
+        LastUpdatedOn = DateTimeOffset.UtcNow
+    };
+
     private static Mock<ILinkedInApplicationSettings> BuildLinkedInSettings()
     {
         var mock = new Mock<ILinkedInApplicationSettings>();
@@ -252,5 +290,321 @@ public class ProcessScheduledItemFiredTests
         Assert.NotNull(result);
         Assert.Equal("urn:li:person:test123", result.AuthorId);
         Assert.Equal("test-access-token", result.AccessToken);
+    }
+
+    // ── Per-type template selection: Engagements ─────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestNewSpeakingEngagementTemplate_WhenItemTypeIsEngagements()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the engagement-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.NewSpeakingEngagement),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateFound_RendersEngagementNameAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "LinkedIn",
+            MessageType = MessageTemplates.MessageTypes.NewSpeakingEngagement,
+            Template = "Speaking at {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — rendered via Scriban using engagement fields
+        Assert.NotNull(result);
+        Assert.Equal("Speaking at Tech Conference 2026 - https://conf.example.com", result!.Text);
+        Assert.Equal("urn:li:person:test123", result.AuthorId);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateIsNull_FallsBackToScheduledItemMessage()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement fallback message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — LinkedIn fallback is scheduledItem.Message (not auto-generated)
+        Assert.NotNull(result);
+        Assert.Equal("engagement fallback message", result!.Text);
+    }
+
+    // ── Per-type template selection: Talks ────────────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestScheduledItemTemplate_WhenItemTypeIsTalks()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the talk-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.ScheduledItem),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateFound_RendersTalkNameAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "LinkedIn",
+            MessageType = MessageTemplates.MessageTypes.ScheduledItem,
+            Template = "My talk: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — template renders talk name and URL
+        Assert.NotNull(result);
+        Assert.Equal("My talk: Building .NET Apps - https://josephguadagno.net/talks/dotnet", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateIsNull_FallsBackToScheduledItemMessage()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk fallback message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — LinkedIn fallback is scheduledItem.Message
+        Assert.NotNull(result);
+        Assert.Equal("talk fallback message", result!.Text);
+    }
+
+    // ── Per-type template selection: YouTubeSources ───────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestNewYouTubeItemTemplate_WhenItemTypeIsYouTubeSources()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the YouTube-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.NewYouTubeItem),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateFound_RendersVideoTitleAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "LinkedIn",
+            MessageType = MessageTemplates.MessageTypes.NewYouTubeItem,
+            Template = "New video: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — template renders video title and URL
+        Assert.NotNull(result);
+        Assert.Equal("New video: Building Better Apps with .NET - https://youtube.com/watch?v=abc123def", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateIsNull_FallsBackToScheduledItemMessage()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube fallback message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.LinkedIn, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildLinkedInSettings(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — LinkedIn fallback is scheduledItem.Message
+        Assert.NotNull(result);
+        Assert.Equal("youtube fallback message", result!.Text);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/RefreshTokensTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/RefreshTokensTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Security.KeyVault.Secrets;
+using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace JosephGuadagno.Broadcasting.Functions.Tests.LinkedIn;
+
+public class RefreshTokensTests
+{
+    private readonly Mock<ILinkedInManager> _linkedInManager = new();
+    private readonly Mock<ILinkedInApplicationSettings> _linkedInSettings = new();
+    private readonly Mock<ITokenRefreshManager> _tokenRefreshManager = new();
+    private readonly Mock<IKeyVault> _keyVault = new();
+
+    private Functions.LinkedIn.RefreshTokens BuildSut() => new(
+        _linkedInManager.Object,
+        _linkedInSettings.Object,
+        _tokenRefreshManager.Object,
+        _keyVault.Object,
+        NullLogger<Functions.LinkedIn.RefreshTokens>.Instance);
+
+    private static KeyVaultSecret BuildRefreshTokenSecret(string value = "valid-refresh-token") =>
+        new("jjg-net-linkedin-refresh-token", value);
+
+    private static TokenRefresh BuildTokenInfo(DateTime expires) => new()
+    {
+        Id = 1,
+        Name = "LinkedIn",
+        Expires = expires,
+        LastChecked = DateTime.UtcNow,
+        LastRefreshed = DateTime.UtcNow,
+        LastUpdatedOn = DateTimeOffset.UtcNow
+    };
+
+    private static LinkedInTokenInfo BuildNewTokenInfo() => new()
+    {
+        AccessToken = "new-access-token-xyz",
+        ExpiresOn = DateTime.UtcNow.AddDays(60)
+    };
+
+    // ── Token still valid (5+ days remaining) ────────────────────────────────
+
+    [Fact]
+    public async Task Run_WhenTokenExpiresInMoreThan5Days_DoesNotRefresh()
+    {
+        // Arrange — token expires in 6 days; above the 5-day threshold
+        var tokenInfo = BuildTokenInfo(DateTime.UtcNow.AddDays(6));
+
+        _keyVault.Setup(m => m.GetSecretAsync("jjg-net-linkedin-refresh-token"))
+            .ReturnsAsync(BuildRefreshTokenSecret());
+        _tokenRefreshManager.Setup(m => m.GetByNameAsync("LinkedIn")).ReturnsAsync(tokenInfo);
+        _linkedInSettings.Setup(m => m.ClientId).Returns("client-id");
+        _linkedInSettings.Setup(m => m.ClientSecret).Returns("client-secret");
+        _linkedInSettings.Setup(m => m.AccessTokenUrl).Returns("https://www.linkedin.com/oauth/v2/accessToken");
+
+        var sut = BuildSut();
+
+        // Act
+        await sut.Run(null!);
+
+        // Assert — no refresh should be triggered
+        _linkedInManager.Verify(
+            m => m.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+        _keyVault.Verify(
+            m => m.UpdateSecretValueAndPropertiesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()),
+            Times.Never);
+    }
+
+    // ── Token expiring within 5 days ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Run_WhenTokenExpiresInLessThan5Days_TriggersRefresh()
+    {
+        // Arrange — token expires in 4 days; within the 5-day threshold
+        var tokenInfo = BuildTokenInfo(DateTime.UtcNow.AddDays(4));
+        var newTokenInfo = BuildNewTokenInfo();
+
+        _keyVault.Setup(m => m.GetSecretAsync("jjg-net-linkedin-refresh-token"))
+            .ReturnsAsync(BuildRefreshTokenSecret("my-refresh-token"));
+        _tokenRefreshManager.Setup(m => m.GetByNameAsync("LinkedIn")).ReturnsAsync(tokenInfo);
+        _tokenRefreshManager.Setup(m => m.SaveAsync(It.IsAny<TokenRefresh>())).ReturnsAsync(tokenInfo);
+        _linkedInSettings.Setup(m => m.ClientId).Returns("client-id");
+        _linkedInSettings.Setup(m => m.ClientSecret).Returns("client-secret");
+        _linkedInSettings.Setup(m => m.AccessTokenUrl).Returns("https://www.linkedin.com/oauth/v2/accessToken");
+        _linkedInManager
+            .Setup(m => m.RefreshTokenAsync("client-id", "client-secret", "my-refresh-token", "https://www.linkedin.com/oauth/v2/accessToken"))
+            .ReturnsAsync(newTokenInfo);
+        _keyVault
+            .Setup(m => m.UpdateSecretValueAndPropertiesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = BuildSut();
+
+        // Act
+        await sut.Run(null!);
+
+        // Assert — refresh was triggered and new access token saved
+        _linkedInManager.Verify(
+            m => m.RefreshTokenAsync("client-id", "client-secret", "my-refresh-token", "https://www.linkedin.com/oauth/v2/accessToken"),
+            Times.Once);
+        _keyVault.Verify(
+            m => m.UpdateSecretValueAndPropertiesAsync("jjg-net-linkedin-access-token", "new-access-token-xyz", It.IsAny<DateTime>()),
+            Times.Once);
+        _tokenRefreshManager.Verify(m => m.SaveAsync(It.IsAny<TokenRefresh>()), Times.Once);
+    }
+
+    // ── Token already expired ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Run_WhenTokenAlreadyExpired_TriggersRefresh()
+    {
+        // Arrange — token expired yesterday
+        var tokenInfo = BuildTokenInfo(DateTime.UtcNow.AddDays(-1));
+        var newTokenInfo = BuildNewTokenInfo();
+
+        _keyVault.Setup(m => m.GetSecretAsync("jjg-net-linkedin-refresh-token"))
+            .ReturnsAsync(BuildRefreshTokenSecret());
+        _tokenRefreshManager.Setup(m => m.GetByNameAsync("LinkedIn")).ReturnsAsync(tokenInfo);
+        _tokenRefreshManager.Setup(m => m.SaveAsync(It.IsAny<TokenRefresh>())).ReturnsAsync(tokenInfo);
+        _linkedInSettings.Setup(m => m.ClientId).Returns("client-id");
+        _linkedInSettings.Setup(m => m.ClientSecret).Returns("client-secret");
+        _linkedInSettings.Setup(m => m.AccessTokenUrl).Returns("https://www.linkedin.com/oauth/v2/accessToken");
+        _linkedInManager
+            .Setup(m => m.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(newTokenInfo);
+        _keyVault
+            .Setup(m => m.UpdateSecretValueAndPropertiesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = BuildSut();
+
+        // Act
+        await sut.Run(null!);
+
+        // Assert — refresh was triggered
+        _linkedInManager.Verify(
+            m => m.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    // ── Refresh API throws ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Run_WhenRefreshApiThrows_DoesNotThrow()
+    {
+        // Arrange — token expired so refresh will be attempted, but API throws
+        var tokenInfo = BuildTokenInfo(DateTime.MinValue);
+
+        _keyVault.Setup(m => m.GetSecretAsync("jjg-net-linkedin-refresh-token"))
+            .ReturnsAsync(BuildRefreshTokenSecret());
+        _tokenRefreshManager.Setup(m => m.GetByNameAsync("LinkedIn")).ReturnsAsync(tokenInfo);
+        _linkedInSettings.Setup(m => m.ClientId).Returns("client-id");
+        _linkedInSettings.Setup(m => m.ClientSecret).Returns("client-secret");
+        _linkedInSettings.Setup(m => m.AccessTokenUrl).Returns("https://www.linkedin.com/oauth/v2/accessToken");
+        _linkedInManager
+            .Setup(m => m.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("LinkedIn API unavailable"));
+
+        var sut = BuildSut();
+
+        // Act & Assert — should NOT throw; error is caught and logged
+        var exception = await Record.ExceptionAsync(() => sut.Run(null!));
+        Assert.Null(exception);
+    }
+
+    // ── Key Vault failure ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Run_WhenKeyVaultGetSecretThrows_DoesNotThrow()
+    {
+        // Arrange — Key Vault is unavailable
+        _keyVault.Setup(m => m.GetSecretAsync("jjg-net-linkedin-refresh-token"))
+            .ThrowsAsync(new Exception("Key Vault unreachable"));
+
+        var sut = BuildSut();
+
+        // Act & Assert — should NOT throw; error is caught and logged
+        var exception = await Record.ExceptionAsync(() => sut.Run(null!));
+        Assert.Null(exception);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Twitter/ProcessScheduledItemFiredTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Twitter/ProcessScheduledItemFiredTests.cs
@@ -42,6 +42,44 @@ public class ProcessScheduledItemFiredTests
         LastUpdatedOn = DateTimeOffset.UtcNow
     };
 
+    private static Engagement BuildEngagement(int id = 42) => new()
+    {
+        Id = id,
+        Name = "Tech Conference 2026",
+        Url = "https://conf.example.com",
+        StartDateTime = new DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 3, 17, 0, 0, TimeSpan.Zero),
+        TimeZoneId = "UTC",
+        Comments = "Great event!"
+    };
+
+    private static Talk BuildTalk(int id = 42, int engagementId = 99) => new()
+    {
+        Id = id,
+        Name = "Building .NET Apps",
+        UrlForConferenceTalk = "https://conf.example.com/talks/dotnet",
+        UrlForTalk = "https://josephguadagno.net/talks/dotnet",
+        StartDateTime = new DateTimeOffset(2026, 6, 2, 10, 0, 0, TimeSpan.Zero),
+        EndDateTime = new DateTimeOffset(2026, 6, 2, 11, 0, 0, TimeSpan.Zero),
+        TalkLocation = "Room A",
+        Comments = "Excellent session",
+        EngagementId = engagementId
+    };
+
+    private static YouTubeSource BuildYouTubeSource(int id = 42) => new()
+    {
+        Id = id,
+        VideoId = "abc123def",
+        Author = "Joseph Guadagno",
+        Title = "Building Better Apps with .NET",
+        Url = "https://youtube.com/watch?v=abc123def",
+        ShortenedUrl = null,
+        Tags = null,
+        PublicationDate = DateTimeOffset.UtcNow,
+        AddedOn = DateTimeOffset.UtcNow,
+        LastUpdatedOn = DateTimeOffset.UtcNow
+    };
+
     private static Functions.Twitter.ProcessScheduledItemFired BuildSut(
         Mock<IScheduledItemManager> scheduledItemManager,
         Mock<ISyndicationFeedSourceManager> feedSourceManager,
@@ -239,5 +277,327 @@ public class ProcessScheduledItemFiredTests
         // Assert — empty template is treated as no template → fallback
         Assert.NotNull(result);
         Assert.Contains("Blog Post:", result!.Text);
+    }
+
+    // ── Per-type template selection: Engagements ─────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestNewSpeakingEngagementTemplate_WhenItemTypeIsEngagements()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the engagement-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.NewSpeakingEngagement),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateFound_RendersEngagementNameAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Twitter",
+            MessageType = MessageTemplates.MessageTypes.NewSpeakingEngagement,
+            Template = "Speaking at {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — rendered via Scriban using engagement fields
+        Assert.NotNull(result);
+        Assert.Equal("Speaking at Tech Conference 2026 - https://conf.example.com", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEngagementTemplateIsNull_FallsBackToEngagementPost()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var engagement = BuildEngagement();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetAsync(42)).ReturnsAsync(engagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.NewSpeakingEngagement))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback includes the engagement name
+        Assert.NotNull(result);
+        Assert.Contains("I'm speaking at", result!.Text);
+        Assert.Contains("Tech Conference 2026", result!.Text);
+    }
+
+    // ── Per-type template selection: Talks ────────────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestScheduledItemTemplate_WhenItemTypeIsTalks()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var associatedEngagement = BuildEngagement(talk.Id);
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+        mockEngagementManager.Setup(m => m.GetAsync(talk.Id)).ReturnsAsync(associatedEngagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the talk-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.ScheduledItem),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateFound_RendersTalkNameAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Twitter",
+            MessageType = MessageTemplates.MessageTypes.ScheduledItem,
+            Template = "My talk: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — template renders talk name (title) and URL
+        Assert.NotNull(result);
+        Assert.Equal("My talk: Building .NET Apps - https://josephguadagno.net/talks/dotnet", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTalkTemplateIsNull_FallsBackToTalkPost()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var talk = BuildTalk();
+        var associatedEngagement = BuildEngagement(talk.Id);
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockEngagementManager = new Mock<IEngagementManager>();
+        mockEngagementManager.Setup(m => m.GetTalkAsync(42)).ReturnsAsync(talk);
+        mockEngagementManager.Setup(m => m.GetAsync(talk.Id)).ReturnsAsync(associatedEngagement);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.ScheduledItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback generates talk post
+        Assert.NotNull(result);
+        Assert.Contains("My talk:", result!.Text);
+        Assert.Contains("Building .NET Apps", result!.Text);
+    }
+
+    // ── Per-type template selection: YouTubeSources ───────────────────────────
+
+    [Fact]
+    public async Task RunAsync_ShouldRequestNewYouTubeItemTemplate_WhenItemTypeIsYouTubeSources()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — must request the YouTube-specific template
+        mockMessageTemplateDataStore.Verify(
+            m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.NewYouTubeItem),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateFound_RendersVideoTitleAndUrl()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+        var messageTemplate = new MessageTemplate
+        {
+            Platform = "Twitter",
+            MessageType = MessageTemplates.MessageTypes.NewYouTubeItem,
+            Template = "New video: {{ title }} - {{ url }}"
+        };
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync(messageTemplate);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — template renders video title and URL
+        Assert.NotNull(result);
+        Assert.Equal("New video: Building Better Apps with .NET - https://youtube.com/watch?v=abc123def", result!.Text);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenYouTubeTemplateIsNull_FallsBackToVideoPost()
+    {
+        // Arrange
+        var scheduledItem = new Domain.Models.ScheduledItem
+        {
+            Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+        };
+        var youTubeSource = BuildYouTubeSource();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockYouTubeSourceManager = new Mock<IYouTubeSourceManager>();
+        mockYouTubeSourceManager.Setup(m => m.GetAsync(42)).ReturnsAsync(youTubeSource);
+
+        var mockMessageTemplateDataStore = new Mock<IMessageTemplateDataStore>();
+        mockMessageTemplateDataStore.Setup(m => m.GetAsync(MessageTemplates.Platforms.Twitter, MessageTemplates.MessageTypes.NewYouTubeItem))
+            .ReturnsAsync((MessageTemplate?)null);
+
+        var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), mockMessageTemplateDataStore);
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — fallback generates video post
+        Assert.NotNull(result);
+        Assert.Contains("Video:", result!.Text);
+        Assert.Contains("Building Better Apps with .NET", result!.Text);
     }
 }


### PR DESCRIPTION
## Summary
Adds 38 new unit tests on top of the existing 43, covering S5-1 changes and S4 gaps.

### New tests
- **Per-type template selection** (Twitter, Facebook, Bluesky, LinkedIn): verifies \GetAsync\ is called with the correct \MessageType\ constant for each \ScheduledItemType\ value — Engagements, Talks, YouTubeSources
- **Scriban fallback**: when template is null, hardcoded fallback still returns a valid result
- **LinkedIn token refresh edge cases**: 6+ days remaining (no refresh), 4 days remaining (refresh triggered), expired (refresh triggered), errors don't propagate

**Total: 81 tests passing**

Part of Sprint 5.