### PR TITLE
fix(linkedin): populate ApiErrorCode/ApiErrorMessage on PostShareText failure (#320)

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Managers.LinkedIn.Tests/LinkedInManagerUnitTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.LinkedIn.Tests/LinkedInManagerUnitTests.cs
@@ -203,6 +203,23 @@ public class LinkedInManagerUnitTests
     }
 
     [Fact]
+    public async Task PostShareText_OnApiFailure_PopulatesApiErrorCodeAndMessage()
+    {
+        // Arrange — LinkedIn returns a failure response (no "id" field, so IsSuccess == false)
+        var errorJson = "{\"message\": \"Unauthorized\", \"serviceErrorCode\": 401, \"status\": 401}";
+        SetupHttpMessageHandler(HttpStatusCode.OK, errorJson);
+        var sut = new LinkedInManager(_httpClient, _mockLogger.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<LinkedInPostException>(
+            () => sut.PostShareText("validToken", "authorId123", "Hello LinkedIn!"));
+
+        // Assert — structured fields must be populated so PostText's catch handler can log them
+        Assert.Equal(401, exception.ApiErrorCode);
+        Assert.Equal("Unauthorized", exception.ApiErrorMessage);
+    }
+
+    [Fact]
     public async Task PostShareTextAndLink_OnApiFailure_ThrowsLinkedInPostException()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Managers.LinkedIn/LinkedInManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.LinkedIn/LinkedInManager.cs
@@ -99,7 +99,8 @@ public class LinkedInManager : ILinkedInManager
         {
             return linkedInResponse.Id;
         }
-        throw new LinkedInPostException($"Failed to post status update to LinkedIn: LinkedIn Status Code: '{linkedInResponse.ServiceErrorCode}', LinkedIn Message: '{linkedInResponse.Message}'");
+        throw new LinkedInPostException("Failed to post status update to LinkedIn",
+            linkedInResponse.ServiceErrorCode, linkedInResponse.Message);
     }
     
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #320

### Problem
\LinkedInManager.PostShareText\ threw \LinkedInPostException\ using the single-string constructor, so \ApiErrorCode\ and \ApiErrorMessage\ were always \
ull\. The \PostText\ Azure Function's catch handler logs those properties, making error logs useless on LinkedIn API failures.

### Fix
Switch to the structured 3-parameter constructor \LinkedInPostException(message, apiErrorCode, apiErrorMessage)\ so the \serviceErrorCode\ and \message\ from the LinkedIn API response are preserved and surfaced in logs.

### Tests
Added \PostShareText_OnApiFailure_PopulatesApiErrorCodeAndMessage\ to \LinkedInManagerUnitTests\ — verifies \ApiErrorCode\ and \ApiErrorMessage\ are correctly populated when the LinkedIn API returns a failure response.