### PR TITLE
fix(data): replace OrderBy(Guid.NewGuid()) with EF.Functions.Random()

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
@@ -74,7 +74,7 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
             query = query.Where(s => s.Tags == null || !s.Tags.Contains(excludedCategory));
         }
 
-        var dbSyndicationFeedSource = await query.OrderBy(u => Guid.NewGuid())
+        var dbSyndicationFeedSource = await query.OrderBy(x => EF.Functions.Random())
             .FirstOrDefaultAsync();
 
         return dbSyndicationFeedSource is null ? null : mapper.Map<Domain.Models.SyndicationFeedSource>(dbSyndicationFeedSource);


### PR DESCRIPTION
## Summary

Fixes #297

### Problem
OrderBy(Guid.NewGuid()) in GetRandomSyndicationDataAsync causes EF Core to evaluate ordering client-side, pulling **all** matching rows into memory before shuffling and selecting the first one. This defeats the purpose of FirstOrDefaultAsync() — it becomes a full table scan.

### Fix
Replace with OrderBy(x => EF.Functions.Random()) which EF Core translates to a server-side RAND() expression, keeping ordering in the database.

### Files Changed
- src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs

### Test Results
All 133 tests in Data.Sql.Tests pass.