### PR TITLE
fix(api): split POST/PUT into distinct REST endpoints (#317)

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
@@ -145,19 +145,19 @@ public class EngagementsControllerTests
     }
 
     // -------------------------------------------------------------------------
-    // SaveEngagementAsync
+    // CreateEngagementAsync
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SaveEngagementAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
+    public async Task CreateEngagementAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
     {
         // Arrange
-        var engagement = new Engagement { Id = 1 };
+        var engagement = new Engagement { Id = 0, Name = "New Conference", Url = "https://new-conf.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(2), TimeZoneId = "UTC" };
         var sut = CreateSut(Domain.Scopes.Engagements.All);
         sut.ModelState.AddModelError("Name", "Name is required");
 
         // Act
-        var result = await sut.SaveEngagementAsync(engagement);
+        var result = await sut.CreateEngagementAsync(engagement);
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();
@@ -165,7 +165,7 @@ public class EngagementsControllerTests
     }
 
     [Fact]
-    public async Task SaveEngagementAsync_WhenSaveSucceeds_ReturnsCreatedAtActionWithEngagement()
+    public async Task CreateEngagementAsync_WhenSaveSucceeds_ReturnsCreatedAtActionWithEngagement()
     {
         // Arrange
         var engagement = new Engagement
@@ -191,7 +191,7 @@ public class EngagementsControllerTests
         var sut = CreateSut(Domain.Scopes.Engagements.All);
 
         // Act
-        var result = await sut.SaveEngagementAsync(engagement);
+        var result = await sut.CreateEngagementAsync(engagement);
 
         // Assert
         var createdResult = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
@@ -203,7 +203,103 @@ public class EngagementsControllerTests
     }
 
     [Fact]
-    public async Task SaveEngagementAsync_WhenSaveFails_ReturnsInternalServerError()
+    public async Task CreateEngagementAsync_WhenSaveFails_ReturnsInternalServerError()
+    {
+        // Arrange
+        var engagement = new Engagement
+        {
+            Id = 0,
+            Name = "Test",
+            Url = "https://test.example.com",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            TimeZoneId = "UTC"
+        };
+        _engagementManagerMock.Setup(m => m.SaveAsync(engagement)).Returns(Task.FromResult<Engagement?>(null));
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All);
+
+        // Act
+        var result = await sut.CreateEngagementAsync(engagement);
+
+        // Assert
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(500);
+        _engagementManagerMock.Verify(m => m.SaveAsync(engagement), Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // UpdateEngagementAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateEngagementAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
+    {
+        // Arrange
+        var engagement = new Engagement { Id = 1, Name = "Conference A", Url = "https://conf-a.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(2), TimeZoneId = "UTC" };
+        var sut = CreateSut(Domain.Scopes.Engagements.All);
+        sut.ModelState.AddModelError("Name", "Name is required");
+
+        // Act
+        var result = await sut.UpdateEngagementAsync(1, engagement);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _engagementManagerMock.Verify(m => m.SaveAsync(It.IsAny<Engagement>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateEngagementAsync_WhenIdMismatch_ReturnsBadRequest()
+    {
+        // Arrange
+        var engagement = new Engagement { Id = 5, Name = "Conference A", Url = "https://conf-a.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(2), TimeZoneId = "UTC" };
+        var sut = CreateSut(Domain.Scopes.Engagements.All);
+
+        // Act
+        var result = await sut.UpdateEngagementAsync(99, engagement);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _engagementManagerMock.Verify(m => m.SaveAsync(It.IsAny<Engagement>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateEngagementAsync_WhenUpdateSucceeds_ReturnsOkWithEngagement()
+    {
+        // Arrange
+        var engagement = new Engagement
+        {
+            Id = 1,
+            Name = "Updated Conference",
+            Url = "https://updated-conf.example.com",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddDays(2),
+            TimeZoneId = "UTC"
+        };
+        var savedEngagement = new Engagement
+        {
+            Id = 1,
+            Name = engagement.Name,
+            Url = engagement.Url,
+            StartDateTime = engagement.StartDateTime,
+            EndDateTime = engagement.EndDateTime,
+            TimeZoneId = engagement.TimeZoneId
+        };
+        _engagementManagerMock.Setup(m => m.SaveAsync(engagement)).ReturnsAsync(savedEngagement);
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All);
+
+        // Act
+        var result = await sut.UpdateEngagementAsync(1, engagement);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+        okResult.Value.Should().Be(savedEngagement);
+        _engagementManagerMock.Verify(m => m.SaveAsync(engagement), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateEngagementAsync_WhenUpdateFails_ReturnsInternalServerError()
     {
         // Arrange
         var engagement = new Engagement
@@ -220,7 +316,7 @@ public class EngagementsControllerTests
         var sut = CreateSut(Domain.Scopes.Engagements.All);
 
         // Act
-        var result = await sut.SaveEngagementAsync(engagement);
+        var result = await sut.UpdateEngagementAsync(1, engagement);
 
         // Assert
         result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(500);
@@ -308,19 +404,19 @@ public class EngagementsControllerTests
     }
 
     // -------------------------------------------------------------------------
-    // SaveTalkAsync
+    // CreateTalkAsync
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SaveTalkAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
+    public async Task CreateTalkAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
     {
         // Arrange
-        var talk = new Talk { Id = 1, EngagementId = 10 };
+        var talk = new Talk { Id = 0, EngagementId = 10 };
         var sut = CreateSut(Domain.Scopes.Talks.All);
         sut.ModelState.AddModelError("Name", "Name is required");
 
         // Act
-        var result = await sut.SaveTalkAsync(talk);
+        var result = await sut.CreateTalkAsync(10, talk);
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();
@@ -328,7 +424,7 @@ public class EngagementsControllerTests
     }
 
     [Fact]
-    public async Task SaveTalkAsync_WhenSaveSucceeds_ReturnsCreatedAtActionWithTalk()
+    public async Task CreateTalkAsync_WhenSaveSucceeds_ReturnsCreatedAtActionWithTalk()
     {
         // Arrange
         var talk = new Talk
@@ -356,24 +452,24 @@ public class EngagementsControllerTests
         var sut = CreateSut(Domain.Scopes.Talks.All);
 
         // Act
-        var result = await sut.SaveTalkAsync(talk);
+        var result = await sut.CreateTalkAsync(10, talk);
 
         // Assert
         var createdResult = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
         createdResult.StatusCode.Should().Be(201);
         createdResult.ActionName.Should().Be(nameof(EngagementsController.GetTalkAsync));
-        createdResult.RouteValues.Should().ContainKey("talkId").WhoseValue.Should().Be(talk.Id);
+        createdResult.RouteValues.Should().ContainKey("talkId").WhoseValue.Should().Be(savedTalk.Id);
         createdResult.Value.Should().Be(savedTalk);
         _engagementManagerMock.Verify(m => m.SaveTalkAsync(talk), Times.Once);
     }
 
     [Fact]
-    public async Task SaveTalkAsync_WhenSaveFails_ReturnsInternalServerError()
+    public async Task CreateTalkAsync_WhenSaveFails_ReturnsInternalServerError()
     {
         // Arrange
         var talk = new Talk
         {
-            Id = 1,
+            Id = 0,
             EngagementId = 10,
             Name = "Failing Talk",
             UrlForConferenceTalk = "https://conf.example.com/talk",
@@ -386,7 +482,106 @@ public class EngagementsControllerTests
         var sut = CreateSut(Domain.Scopes.Talks.All);
 
         // Act
-        var result = await sut.SaveTalkAsync(talk);
+        var result = await sut.CreateTalkAsync(10, talk);
+
+        // Assert
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(500);
+        _engagementManagerMock.Verify(m => m.SaveTalkAsync(talk), Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // UpdateTalkAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateTalkAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
+    {
+        // Arrange
+        var talk = new Talk { Id = 5, EngagementId = 10 };
+        var sut = CreateSut(Domain.Scopes.Talks.All);
+        sut.ModelState.AddModelError("Name", "Name is required");
+
+        // Act
+        var result = await sut.UpdateTalkAsync(10, 5, talk);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _engagementManagerMock.Verify(m => m.SaveTalkAsync(It.IsAny<Talk>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTalkAsync_WhenIdMismatch_ReturnsBadRequest()
+    {
+        // Arrange
+        var talk = new Talk { Id = 5, EngagementId = 10, Name = "Talk A", UrlForConferenceTalk = "https://conf.example.com/talk", UrlForTalk = "https://example.com/talk", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddHours(1) };
+        var sut = CreateSut(Domain.Scopes.Talks.All);
+
+        // Act
+        var result = await sut.UpdateTalkAsync(10, 99, talk);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _engagementManagerMock.Verify(m => m.SaveTalkAsync(It.IsAny<Talk>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTalkAsync_WhenUpdateSucceeds_ReturnsOkWithTalk()
+    {
+        // Arrange
+        var talk = new Talk
+        {
+            Id = 5,
+            EngagementId = 10,
+            Name = "Updated Talk",
+            UrlForConferenceTalk = "https://conf.example.com/talk",
+            UrlForTalk = "https://example.com/talk",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        var savedTalk = new Talk
+        {
+            Id = 5,
+            EngagementId = talk.EngagementId,
+            Name = talk.Name,
+            UrlForConferenceTalk = talk.UrlForConferenceTalk,
+            UrlForTalk = talk.UrlForTalk,
+            StartDateTime = talk.StartDateTime,
+            EndDateTime = talk.EndDateTime
+        };
+        _engagementManagerMock.Setup(m => m.SaveTalkAsync(talk)).ReturnsAsync(savedTalk);
+
+        var sut = CreateSut(Domain.Scopes.Talks.All);
+
+        // Act
+        var result = await sut.UpdateTalkAsync(10, 5, talk);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+        okResult.Value.Should().Be(savedTalk);
+        _engagementManagerMock.Verify(m => m.SaveTalkAsync(talk), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTalkAsync_WhenUpdateFails_ReturnsInternalServerError()
+    {
+        // Arrange
+        var talk = new Talk
+        {
+            Id = 5,
+            EngagementId = 10,
+            Name = "Failing Talk",
+            UrlForConferenceTalk = "https://conf.example.com/talk",
+            UrlForTalk = "https://example.com/talk",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        _engagementManagerMock.Setup(m => m.SaveTalkAsync(talk)).Returns(Task.FromResult<Talk?>(null));
+
+        var sut = CreateSut(Domain.Scopes.Talks.All);
+
+        // Act
+        var result = await sut.UpdateTalkAsync(10, 5, talk);
 
         // Assert
         result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(500);

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -147,19 +147,19 @@ public class SchedulesControllerTests
     }
 
     // -------------------------------------------------------------------------
-    // SaveScheduledItemAsync
+    // CreateScheduledItemAsync
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SaveScheduledItemAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
+    public async Task CreateScheduledItemAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
     {
         // Arrange
-        var item = new ScheduledItem { Id = 1 };
+        var item = new ScheduledItem { Id = 0 };
         var sut = CreateSut(Domain.Scopes.Schedules.All);
         sut.ModelState.AddModelError("Message", "Message is required");
 
         // Act
-        var result = await sut.SaveScheduledItemAsync(item);
+        var result = await sut.CreateScheduledItemAsync(item);
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();
@@ -167,7 +167,7 @@ public class SchedulesControllerTests
     }
 
     [Fact]
-    public async Task SaveScheduledItemAsync_WhenSaveSucceeds_ReturnsCreatedAtActionWithItem()
+    public async Task CreateScheduledItemAsync_WhenSaveSucceeds_ReturnsCreatedAtActionWithItem()
     {
         // Arrange
         var item = new ScheduledItem
@@ -185,7 +185,7 @@ public class SchedulesControllerTests
         var sut = CreateSut(Domain.Scopes.Schedules.All);
 
         // Act
-        var result = await sut.SaveScheduledItemAsync(item);
+        var result = await sut.CreateScheduledItemAsync(item);
 
         // Assert
         var createdResult = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
@@ -197,7 +197,88 @@ public class SchedulesControllerTests
     }
 
     [Fact]
-    public async Task SaveScheduledItemAsync_WhenSaveFails_ReturnsInternalServerError()
+    public async Task CreateScheduledItemAsync_WhenSaveFails_ReturnsInternalServerError()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 0,
+            ItemType = Domain.Enums.ScheduledItemType.SyndicationFeedSources,
+            ItemPrimaryKey = 10,
+            Message = "Check out item!",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            MessageSent = false
+        };
+        _scheduledItemManagerMock.Setup(m => m.SaveAsync(item)).Returns(Task.FromResult<ScheduledItem?>(null));
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All);
+
+        // Act
+        var result = await sut.CreateScheduledItemAsync(item);
+
+        // Assert
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(500);
+        _scheduledItemManagerMock.Verify(m => m.SaveAsync(item), Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // UpdateScheduledItemAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateScheduledItemAsync_WhenModelStateIsInvalid_ReturnsBadRequest()
+    {
+        // Arrange
+        var item = BuildScheduledItem(5);
+        var sut = CreateSut(Domain.Scopes.Schedules.All);
+        sut.ModelState.AddModelError("Message", "Message is required");
+
+        // Act
+        var result = await sut.UpdateScheduledItemAsync(5, item);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _scheduledItemManagerMock.Verify(m => m.SaveAsync(It.IsAny<ScheduledItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateScheduledItemAsync_WhenIdMismatch_ReturnsBadRequest()
+    {
+        // Arrange
+        var item = BuildScheduledItem(5);
+        var sut = CreateSut(Domain.Scopes.Schedules.All);
+
+        // Act
+        var result = await sut.UpdateScheduledItemAsync(99, item);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _scheduledItemManagerMock.Verify(m => m.SaveAsync(It.IsAny<ScheduledItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateScheduledItemAsync_WhenUpdateSucceeds_ReturnsOkWithItem()
+    {
+        // Arrange
+        var item = BuildScheduledItem(5);
+        var savedItem = BuildScheduledItem(5);
+        savedItem.Message = "Updated message";
+        _scheduledItemManagerMock.Setup(m => m.SaveAsync(item)).ReturnsAsync(savedItem);
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All);
+
+        // Act
+        var result = await sut.UpdateScheduledItemAsync(5, item);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+        okResult.Value.Should().Be(savedItem);
+        _scheduledItemManagerMock.Verify(m => m.SaveAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateScheduledItemAsync_WhenUpdateFails_ReturnsInternalServerError()
     {
         // Arrange
         var item = BuildScheduledItem(5);
@@ -206,7 +287,7 @@ public class SchedulesControllerTests
         var sut = CreateSut(Domain.Scopes.Schedules.All);
 
         // Act
-        var result = await sut.SaveScheduledItemAsync(item);
+        var result = await sut.UpdateScheduledItemAsync(5, item);
 
         // Assert
         result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(500);

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
@@ -72,39 +72,76 @@ public class EngagementsController: ControllerBase
     }
 
     /// <summary>
-    /// Saves an engagement
+    /// Creates an engagement
     /// </summary>
-    /// <param name="engagement">The engagement to save</param>
-    /// <returns>The engagement with the Url to view its details</returns>
-    /// <response code="200">Returns if the engagement was updated</response>
+    /// <param name="engagement">The engagement to create</param>
+    /// <returns>The newly created engagement with the Url to view its details</returns>
     /// <response code="201">Returns the newly created engagement</response>
-    /// <response code="400">If the talk is null or there are data violations</response>     
+    /// <response code="400">If the engagement is null or there are data violations</response>     
     /// <response code="401">If the current user was unauthorized to access this endpoint</response>       
-    [HttpPost, HttpPut]
-    [ProducesResponseType(StatusCodes.Status200OK, Type=typeof(Engagement))]
+    [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created, Type=typeof(Engagement))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<ActionResult<Engagement>> SaveEngagementAsync(Engagement engagement)
+    public async Task<ActionResult<Engagement>> CreateEngagementAsync(Engagement engagement)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.All);
         //HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.Modify);
 
         if (!ModelState.IsValid)
         {
-            _logger.LogWarning("SaveEngagementAsync called with invalid model state");
+            _logger.LogWarning("CreateEngagementAsync called with invalid model state");
             return BadRequest(ModelState);    
         }
         
         var savedEngagement = await _engagementManager.SaveAsync(engagement);
         if (savedEngagement != null)
         {
-            _logger.LogInformation("Engagement saved with Id {EngagementId}", savedEngagement.Id);
+            _logger.LogInformation("Engagement created with Id {EngagementId}", savedEngagement.Id);
             return CreatedAtAction(nameof(GetEngagementAsync), new { engagementId = savedEngagement.Id },
                 savedEngagement);
         }
 
-        return Problem("Failed to save the engagement");
+        return Problem("Failed to create the engagement");
+    }
+
+    /// <summary>
+    /// Updates an existing engagement
+    /// </summary>
+    /// <param name="engagementId">The identifier of the engagement to update</param>
+    /// <param name="engagement">The updated engagement data</param>
+    /// <returns>The updated engagement</returns>
+    /// <response code="200">Returns the updated engagement</response>
+    /// <response code="400">If the engagement is null, the id does not match, or there are data violations</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPut("{engagementId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type=typeof(Engagement))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<Engagement>> UpdateEngagementAsync(int engagementId, Engagement engagement)
+    {
+        HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.All);
+        //HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.Modify);
+
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("UpdateEngagementAsync called with invalid model state");
+            return BadRequest(ModelState);    
+        }
+
+        if (engagementId != engagement.Id)
+        {
+            return BadRequest("Route id must match the engagement Id.");
+        }
+        
+        var savedEngagement = await _engagementManager.SaveAsync(engagement);
+        if (savedEngagement != null)
+        {
+            _logger.LogInformation("Engagement updated with Id {EngagementId}", savedEngagement.Id);
+            return Ok(savedEngagement);
+        }
+
+        return Problem("Failed to update the engagement");
     }
     
     /// <summary>
@@ -155,40 +192,78 @@ public class EngagementsController: ControllerBase
     }
     
     /// <summary>
-    /// Saves a talk
+    /// Creates a talk for an engagement
     /// </summary>
-    /// <param name="talk">The talk to save</param>
-    /// <returns>The talk with the Url to view its details</returns>
-    /// <response code="200">Returns if the talk was successfully updated</response>
+    /// <param name="engagementId">The identifier of the engagement</param>
+    /// <param name="talk">The talk to create</param>
+    /// <returns>The newly created talk with the Url to view its details</returns>
     /// <response code="201">Returns the newly created talk</response>
     /// <response code="400">If the data provided is null or there are data violations</response>
     /// <response code="401">If the current user was unauthorized to access this endpoint</response>      
-    [HttpPost("{engagementId:int}/talks/")]
-    [HttpPut("{engagementId:int}/talks/")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type=typeof(Talk))]
+    [HttpPost("{engagementId:int}/talks")]
     [ProducesResponseType(StatusCodes.Status201Created, Type=typeof(Talk))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<ActionResult<Talk>> SaveTalkAsync(Talk talk)
+    public async Task<ActionResult<Talk>> CreateTalkAsync(int engagementId, Talk talk)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.All);
         //HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.Modify);
 
         if (!ModelState.IsValid)
         {
-            _logger.LogWarning("SaveTalkAsync called with invalid model state");
+            _logger.LogWarning("CreateTalkAsync called with invalid model state");
             return BadRequest(ModelState);
         }
         
         var savedTalk = await _engagementManager.SaveTalkAsync(talk);
         if (savedTalk != null)
         {
-            _logger.LogInformation("Talk saved with Id {TalkId} for Engagement {EngagementId}", savedTalk.Id, talk.EngagementId);
-            return CreatedAtAction(nameof(GetTalkAsync), new { engagementId = talk.EngagementId, talkId = talk.Id },
+            _logger.LogInformation("Talk created with Id {TalkId} for Engagement {EngagementId}", savedTalk.Id, engagementId);
+            return CreatedAtAction(nameof(GetTalkAsync), new { engagementId = engagementId, talkId = savedTalk.Id },
                 savedTalk);
         }
 
-        return Problem("Failed to save the talk");
+        return Problem("Failed to create the talk");
+    }
+
+    /// <summary>
+    /// Updates an existing talk for an engagement
+    /// </summary>
+    /// <param name="engagementId">The identifier of the engagement</param>
+    /// <param name="talkId">The identifier of the talk to update</param>
+    /// <param name="talk">The updated talk data</param>
+    /// <returns>The updated talk</returns>
+    /// <response code="200">Returns the updated talk</response>
+    /// <response code="400">If the data provided is null, the id does not match, or there are data violations</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPut("{engagementId:int}/talks/{talkId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type=typeof(Talk))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<Talk>> UpdateTalkAsync(int engagementId, int talkId, Talk talk)
+    {
+        HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.All);
+        //HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.Modify);
+
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("UpdateTalkAsync called with invalid model state");
+            return BadRequest(ModelState);
+        }
+
+        if (talkId != talk.Id)
+        {
+            return BadRequest("Route id must match the talk Id.");
+        }
+        
+        var savedTalk = await _engagementManager.SaveTalkAsync(talk);
+        if (savedTalk != null)
+        {
+            _logger.LogInformation("Talk updated with Id {TalkId} for Engagement {EngagementId}", savedTalk.Id, engagementId);
+            return Ok(savedTalk);
+        }
+
+        return Problem("Failed to update the talk");
     }
     
     /// <summary>

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
@@ -70,40 +70,76 @@ public class SchedulesController: ControllerBase
     }
 
     /// <summary>
-    /// Saves a scheduled item
+    /// Creates a scheduled item
     /// </summary>
-    /// <param name="scheduledItem">The scheduled item</param>
-    /// <returns></returns>
-    /// <remarks>If the <see cref="ScheduledItem.Id"/> is 0, the scheduled item will be updated.</remarks>
-    /// <response code="200">If the scheduled item was updated</response>
+    /// <param name="scheduledItem">The scheduled item to create</param>
+    /// <returns>The newly created scheduled item</returns>
     /// <response code="201">If the scheduled item was created</response>
     /// <response code="400">If the data provided failed validation</response>
     /// <response code="401">If the current user was unauthorized to access this endpoint</response>
-    [HttpPost, HttpPut]
-    [ProducesResponseType(StatusCodes.Status200OK, Type=typeof(ScheduledItem))]
+    [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created, Type=typeof(ScheduledItem))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<ActionResult<ScheduledItem>> SaveScheduledItemAsync(ScheduledItem scheduledItem)
+    public async Task<ActionResult<ScheduledItem>> CreateScheduledItemAsync(ScheduledItem scheduledItem)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Schedules.All);
         //HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Schedules.Modify);
 
         if (!ModelState.IsValid)
         {
-            _logger.LogWarning("SaveScheduledItemAsync called with invalid model state");
+            _logger.LogWarning("CreateScheduledItemAsync called with invalid model state");
             return BadRequest(ModelState);
         }
         
         var savedScheduledItem = await _scheduledItemManager.SaveAsync(scheduledItem);
         if (savedScheduledItem != null)
         {
-            _logger.LogInformation("ScheduledItem saved with Id {ScheduledItemId}", savedScheduledItem.Id);
+            _logger.LogInformation("ScheduledItem created with Id {ScheduledItemId}", savedScheduledItem.Id);
             return CreatedAtAction(nameof(GetScheduledItemAsync), new { scheduledItemId = savedScheduledItem.Id },
                 savedScheduledItem);
         }
 
-        return Problem("Failed to save the scheduled item");
+        return Problem("Failed to create the scheduled item");
+    }
+
+    /// <summary>
+    /// Updates an existing scheduled item
+    /// </summary>
+    /// <param name="scheduledItemId">The identifier of the scheduled item to update</param>
+    /// <param name="scheduledItem">The updated scheduled item data</param>
+    /// <returns>The updated scheduled item</returns>
+    /// <response code="200">If the scheduled item was updated</response>
+    /// <response code="400">If the data provided failed validation or the id does not match</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPut("{scheduledItemId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type=typeof(ScheduledItem))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<ScheduledItem>> UpdateScheduledItemAsync(int scheduledItemId, ScheduledItem scheduledItem)
+    {
+        HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Schedules.All);
+        //HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Schedules.Modify);
+
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("UpdateScheduledItemAsync called with invalid model state");
+            return BadRequest(ModelState);
+        }
+
+        if (scheduledItemId != scheduledItem.Id)
+        {
+            return BadRequest("Route id must match the scheduled item Id.");
+        }
+        
+        var savedScheduledItem = await _scheduledItemManager.SaveAsync(scheduledItem);
+        if (savedScheduledItem != null)
+        {
+            _logger.LogInformation("ScheduledItem updated with Id {ScheduledItemId}", savedScheduledItem.Id);
+            return Ok(savedScheduledItem);
+        }
+
+        return Problem("Failed to update the scheduled item");
     }
     
     /// <summary>


### PR DESCRIPTION
## Summary
Splits combined [HttpPost, HttpPut] actions into distinct POST (create, 201 Created) and PUT /{id} (update, 200 OK) endpoints across all API controllers.

### Changes
- **EngagementsController**: SaveEngagementAsync split into CreateEngagementAsync (POST) + UpdateEngagementAsync (PUT /{engagementId})
- **EngagementsController**: SaveTalkAsync split into CreateTalkAsync (POST) + UpdateTalkAsync (PUT /{engagementId}/talks/{talkId})
- **SchedulesController**: SaveScheduledItemAsync split into CreateScheduledItemAsync (POST) + UpdateScheduledItemAsync (PUT /{scheduledItemId})
- All test cases updated to new method signatures
- New tests added for all Update endpoints including id-mismatch validation

Closes #317