### PR TITLE
feat(functions): add retry policies and dead-letter queue handling to host.json

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Functions/host.json
+++ b/src/JosephGuadagno.Broadcasting.Functions/host.json
@@ -16,5 +16,20 @@
       "JosephGuadagno": "Warning",
       "Azure.Core": "Error"
     }
+  },
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 3,
+    "minimumInterval": "00:00:05",
+    "maximumInterval": "00:00:30"
+  },
+  "extensions": {
+    "queues": {
+      "maxPollingInterval": "00:00:02",
+      "visibilityTimeout": "00:00:30",
+      "batchSize": 16,
+      "maxDequeueCount": 3,
+      "newBatchThreshold": 8
+    }
   }
 }


### PR DESCRIPTION
## Summary
Adds exponential backoff retry policies and dead-letter queue (poison queue) handling to the Azure Functions host configuration.

## Changes
- **Retry strategy**: Exponential backoff with max 3 retries, 5s → 30s delay escalation
- **Dead-letter queue**: Messages exceeding maxDequeueCount (3) are automatically routed to {queue-name}-poison queues by Azure Storage Queue runtime
- **Queue configuration**: Set maxPollingInterval (2s), isibilityTimeout (30s), and batch processing parameters

## Affected Queues
Retry and DLQ policies apply to all queue-triggered functions:
- 	witter-tweets-to-send (→ 	witter-tweets-to-send-poison)
- acebook-post-status-to-page (→ acebook-post-status-to-page-poison)
- linkedin-post-text (→ linkedin-post-text-poison)
- linkedin-post-link (→ linkedin-post-link-poison)
- linkedin-post-image (→ linkedin-post-image-poison)
- luesky-post-to-send (→ luesky-post-to-send-poison)

Poison queues are auto-created by the Azure Storage SDK when messages exceed the dequeue count.

Closes #319