### PR TITLE
fix: add BlueSkyHandle to EngagementViewModel and TalkViewModel

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Models/EngagementViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/EngagementViewModel.cs
@@ -52,6 +52,11 @@ public class EngagementViewModel
     /// <remarks>Could be a discount code for the engagement</remarks>
     public string? Comments { get; set; }
 
+    /// <summary>
+    /// The BlueSky handle for the engagement
+    /// </summary>
+    public string? BlueSkyHandle { get; set; }
+
     public DateTimeOffset CreatedOn { get; set; }
     public DateTimeOffset LastUpdatedOn { get; set; }
 

--- a/src/JosephGuadagno.Broadcasting.Web/Models/TalkViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/TalkViewModel.cs
@@ -54,7 +54,12 @@ public class TalkViewModel
     /// Comments for the talk
     /// </summary>
     public string? Comments { get; set; }
-    
+
+    /// <summary>
+    /// The BlueSky handle for the talk
+    /// </summary>
+    public string? BlueSkyHandle { get; set; }
+
     /// <summary>
     /// The identifier for the <see cref="EngagementViewModel"/> that the talk is for.
     /// </summary>


### PR DESCRIPTION
## Problem
PR #523 added \BlueSkyHandle\ to the \Engagement\ and \Talk\ domain models but did not update the Web layer ViewModels. This causes \MappingProfile_IsValid()\ in \Web.Tests\ to fail with:

\\\
Unmapped properties: BlueSkyHandle
\\\

This is the root cause of CI failures on PRs #521 and #522.

## Fix
Added \public string? BlueSkyHandle { get; set; }\ to:
- \EngagementViewModel.cs\
- \TalkViewModel.cs\

AutoMapper's convention-based mapping picks this up automatically — no profile changes needed.

## Note
Form fields (UI) for BlueSkyHandle are tracked as follow-on work for Sparks.