### PR TITLE
feat(web): Add dedicated AuthError page and view model (#545)

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/HomeController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 
 using JosephGuadagno.Broadcasting.Domain;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using JosephGuadagno.Broadcasting.Web.Models;
 
@@ -29,6 +30,22 @@ public class HomeController(ILogger<HomeController> logger) : Controller
     public IActionResult Privacy()
     {
         return View();
+    }
+
+    /// <summary>
+    /// Returns the authentication error page
+    /// </summary>
+    /// <param name="message">Optional sanitized error message from the OIDC event handler.</param>
+    /// <returns>The authentication error view</returns>
+    [AllowAnonymous]
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public IActionResult AuthError(string? message)
+    {
+        return View(new AuthErrorViewModel
+        {
+            Message = message ?? "An error occurred during authentication.",
+            RetryUrl = "/Account/SignIn"
+        });
     }
 
     /// <summary>

--- a/src/JosephGuadagno.Broadcasting.Web/Models/AuthErrorViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/AuthErrorViewModel.cs
@@ -1,0 +1,8 @@
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+public class AuthErrorViewModel
+{
+    public string Message { get; set; } = "An error occurred during authentication.";
+    public string RetryUrl { get; set; } = "/Account/SignIn";
+    public string? SupportEmail { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Home/AuthError.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Home/AuthError.cshtml
@@ -1,0 +1,23 @@
+@model JosephGuadagno.Broadcasting.Web.Models.AuthErrorViewModel
+@{
+    ViewData["Title"] = "Authentication Error";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="alert alert-warning" role="alert">
+    <h4 class="alert-heading">Sign-in Problem</h4>
+    <p>@Model.Message</p>
+    @if (Model.SupportEmail != null)
+    {
+        <hr />
+        <p class="mb-0">
+            Need help? Contact support at <a href="mailto:@Model.SupportEmail">@Model.SupportEmail</a>.
+        </p>
+    }
+</div>
+
+<div class="d-flex gap-2">
+    <a href="@Model.RetryUrl" class="btn btn-primary">Try Again</a>
+    <a href="/" class="btn btn-secondary">Return to Home</a>
+</div>


### PR DESCRIPTION
## Summary

Adds a dedicated authentication error page for handling OIDC/OAuth2 failures gracefully, as part of #85 — Handle Exceptions with Microsoft Entra login.

## Changes

- **Models/AuthErrorViewModel.cs** — New view model with \Message\, \RetryUrl\, and \SupportEmail\ properties
- **\Controllers/HomeController.cs\** — New \AuthError\ action with \[AllowAnonymous]\ (required since auth errors occur before authentication completes)
- **\Views/Home/AuthError.cshtml\** — Bootstrap \lert-warning\ view with message, retry button, home button, and optional support email

## Acceptance Criteria

- [x] AuthErrorViewModel created with Message, RetryUrl, SupportEmail properties
- [x] HomeController.AuthError action added with [AllowAnonymous]
- [x] AuthError.cshtml uses Bootstrap alert-warning styling
- [x] View shows message, retry button, home button, optional support email
- [x] Build passes

Closes #545
Part of #85