### PR TITLE
Revert "fix(data): replace OrderBy(Guid.NewGuid()) with EF.Functions.Random()"

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
@@ -74,7 +74,7 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
             query = query.Where(s => s.Tags == null || !s.Tags.Contains(excludedCategory));
         }
 
-        var dbSyndicationFeedSource = await query.OrderBy(x => EF.Functions.Random())
+        var dbSyndicationFeedSource = await query.OrderBy(u => Guid.NewGuid())
             .FirstOrDefaultAsync();
 
         return dbSyndicationFeedSource is null ? null : mapper.Map<Domain.Models.SyndicationFeedSource>(dbSyndicationFeedSource);


### PR DESCRIPTION
Reverts jguadagno/jjgnet-broadcast#495

The EF.Functions.Random() does not work with SQL Server order by