### PR TITLE
**feat(workflows): remove staging slots and deploy directly to produc…

### DIFF
--- a/.github/workflows/main_api-jjgnet-broadcast.yml
+++ b/.github/workflows/main_api-jjgnet-broadcast.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
-          include-prerelease: true
 
       - name: Restore dependencies
         run: dotnet restore ./src/JosephGuadagno.Broadcasting.Api
@@ -59,11 +58,11 @@ jobs:
           name: .api-app
           path: ${{env.DOTNET_ROOT}}/api-jjgnet-broadcast
 
-  deploy-to-staging:
+  deploy-to-production:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'staging'
+      name: 'production'
 
     steps:
       - name: Download artifact from build job
@@ -78,49 +77,10 @@ jobs:
           tenant-id: ${{ secrets.API_TENANT_ID }}
           subscription-id: ${{ secrets.API_SUBSCRIPTION_ID }}
 
-      - name: Deploy to staging slot
-        id: deploy-to-staging
+      - name: Deploy to production
+        id: deploy-to-production
         uses: azure/webapps-deploy@v3
         with:
           app-name: 'api-jjgnet-broadcast'
-          slot-name: 'staging'
+          slot-name: 'production'
           package: .
-
-  swap-to-production:
-    runs-on: ubuntu-latest
-    needs: deploy-to-staging
-    environment:
-      name: 'production'
-      url: ${{ steps.get-url.outputs.webapp-url }}
-    permissions:
-      id-token: write #This is required for requesting the JWT
-      contents: read
-
-    steps:
-      - name: Login to Azure
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.API_CLIENT_ID }}
-          tenant-id: ${{ secrets.API_TENANT_ID }}
-          subscription-id: ${{ secrets.API_SUBSCRIPTION_ID }}
-
-      - name: Swap staging to production
-        run: |
-          az webapp deployment slot swap \
-            --name api-jjgnet-broadcast \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --slot staging \
-            --target-slot production
-
-      - name: Stop staging slot
-        run: |
-          az webapp stop \
-            --name api-jjgnet-broadcast \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --slot staging
-
-      - name: Get production URL
-        id: get-url
-        run: |
-          url=$(az webapp show --name api-jjgnet-broadcast --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --query defaultHostName -o tsv)
-          echo "webapp-url=https://$url" >> $GITHUB_OUTPUT

--- a/.github/workflows/main_jjgnet-broadcast.yml
+++ b/.github/workflows/main_jjgnet-broadcast.yml
@@ -75,11 +75,11 @@ jobs:
           path: ${{ env.WORKING_DIRECTORY }}/publish
           include-hidden-files: 'true'
 
-  deploy-to-staging:
+  deploy-to-production:
     runs-on: ubuntu-latest
     needs: build-and-test
     environment:
-      name: 'staging'
+      name: 'production'
 
     steps:
       # Download the build artifact from the previous job
@@ -96,38 +96,10 @@ jobs:
           tenant-id: ${{ secrets.FUNCTIONAPP_TENANT_ID }}
           subscription-id: ${{ secrets.FUNCTIONAPP_SUBSCRIPTION_ID }}
 
-      - name: Deploy to staging slot
+      - name: Deploy to production
         uses: Azure/functions-action@v1
-        id: fa-staging
+        id: fa-production
         with:
           app-name: 'jjgnet-broadcast'
-          slot-name: 'staging'
+          slot-name: 'production'
           package: ./publish
-
-  swap-to-production:
-    runs-on: ubuntu-latest
-    needs: deploy-to-staging
-    environment: production
-
-    steps:
-      - name: Login to Azure
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.FUNCTIONAPP_CLIENT_ID }}
-          tenant-id: ${{ secrets.FUNCTIONAPP_TENANT_ID }}
-          subscription-id: ${{ secrets.FUNCTIONAPP_SUBSCRIPTION_ID }}
-
-      - name: Swap staging to production
-        run: |
-          az functionapp deployment slot swap \
-            --name jjgnet-broadcast \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --slot staging \
-            --target-slot production
-
-      - name: Stop staging slot
-        run: |
-          az functionapp stop \
-            --name jjgnet-broadcast \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --slot staging

--- a/.github/workflows/main_web-jjgnet-broadcast.yml
+++ b/.github/workflows/main_web-jjgnet-broadcast.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
-          include-prerelease: true
 
       - name: Restore dependencies
         run: dotnet restore ./src/JosephGuadagno.Broadcasting.Web
@@ -59,11 +58,11 @@ jobs:
           name: .web-app
           path: ${{env.DOTNET_ROOT}}/web-jjgnet-broadcast
 
-  deploy-to-staging:
+  deploy-to-production:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'staging'
+      name: 'production'
 
     steps:
       - name: Download artifact from build job
@@ -78,46 +77,10 @@ jobs:
           tenant-id: ${{ secrets.WEBAPP_TENANT_ID }}
           subscription-id: ${{ secrets.WEBAPP_SUBSCRIPTION_ID }}
 
-      - name: Deploy to staging slot
-        id: deploy-to-staging
+      - name: Deploy to production
+        id: deploy-to-production
         uses: azure/webapps-deploy@v3
         with:
           app-name: 'web-jjgnet-broadcast'
-          slot-name: 'staging'
+          slot-name: 'production'
           package: .
-
-  swap-to-production:
-    runs-on: ubuntu-latest
-    needs: deploy-to-staging
-    environment:
-      name: 'production'
-      url: ${{ steps.get-url.outputs.webapp-url }}
-
-    steps:
-      - name: Login to Azure
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.WEBAPP_CLIENT_ID }}
-          tenant-id: ${{ secrets.WEBAPP_TENANT_ID }}
-          subscription-id: ${{ secrets.WEBAPP_SUBSCRIPTION_ID }}
-
-      - name: Swap staging to production
-        run: |
-          az webapp deployment slot swap \
-            --name web-jjgnet-broadcast \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --slot staging \
-            --target-slot production
-
-      - name: Stop staging slot
-        run: |
-          az webapp stop \
-            --name web-jjgnet-broadcast \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --slot staging
-
-      - name: Get production URL
-        id: get-url
-        run: |
-          url=$(az webapp show --name web-jjgnet-broadcast --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --query defaultHostName -o tsv)
-          echo "webapp-url=https://$url" >> $GITHUB_OUTPUT


### PR DESCRIPTION
…tion (#583)**

- Updated GitHub Actions workflows (`main_api-jjgnet-broadcast.yml`, `main_jjgnet-broadcast.yml`, `main_web-jjgnet-broadcast.yml`) to remove staging environment setup.
- Replaced staging deployment steps with direct production deployment for `api-jjgnet-broadcast`, `jjgnet-broadcast`, and `web-jjgnet-broadcast`.
- Removed `swap-to-production` jobs and related Azure CLI commands for slot swapping and stopping staging slots.
- Simplified workflow by eliminating unnecessary pre-release settings and environment configurations.

Resolves: #583