### PR TITLE
fix: allow anonymous access to home page (#600)

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/HomeController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/HomeController.cs
@@ -18,6 +18,7 @@ public class HomeController(ILogger<HomeController> logger) : Controller
     /// Returns the home page
     /// </summary>
     /// <returns>Returns the home page</returns>
+    [AllowAnonymous]
     public IActionResult Index()
     {
         return View();
@@ -27,6 +28,7 @@ public class HomeController(ILogger<HomeController> logger) : Controller
     /// Returns the privacy page
     /// </summary>
     /// <returns></returns>
+    [AllowAnonymous]
     public IActionResult Privacy()
     {
         return View();

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
@@ -56,22 +56,25 @@
                     <li class="nav-item">
                         <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-controller="Engagements" asp-action="Index">Engagements</a>
-                    </li>
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="scheduleDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="False">Schedules</a>
-                        <ul class="dropdown-menu" aria-labelledby="scheduleDropdown">
-                            <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Index">All</a></li>    
-                            <li><hr class="dropdown-divider"></li>    
-                            <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Calendar">Calendar</a></li>    
-                            <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Upcoming">Upcoming</a></li>    
-                            <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Unsent">Unsent</a></li>    
-                        </ul>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-controller="MessageTemplates" asp-action="Index">Message Templates</a>
-                    </li>
+                    @if (User.Identity?.IsAuthenticated == true)
+                    {
+                        <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-controller="Engagements" asp-action="Index">Engagements</a>
+                        </li>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" id="scheduleDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="False">Schedules</a>
+                            <ul class="dropdown-menu" aria-labelledby="scheduleDropdown">
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Index">All</a></li>    
+                                <li><hr class="dropdown-divider"></li>    
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Calendar">Calendar</a></li>    
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Upcoming">Upcoming</a></li>    
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedules" asp-action="Unsent">Unsent</a></li>    
+                            </ul>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-controller="MessageTemplates" asp-action="Index">Message Templates</a>
+                        </li>
+                    }
                     <li class="nav-item">
                         <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                     </li>


### PR DESCRIPTION
## Summary

Closes #600

Allows unauthenticated users to access the Home and Privacy pages without being redirected to login.

## Changes

### 1. HomeController.cs — Added [AllowAnonymous]
The Web project has a global RequireAuthenticatedUser policy in Program.cs. Added [AllowAnonymous] to both Index() and Privacy() actions so these pages are publicly accessible.

### 2. _Layout.cshtml — Conditional nav rendering
Wrapped the **Engagements**, **Schedules**, and **Message Templates** nav links inside an @if (User.Identity?.IsAuthenticated == true) block. **Home** and **Privacy** links remain always visible.

## Testing
- Build: 0 errors (25 pre-existing warnings)
- Unauthenticated users can now reach / and /Home/Privacy without a login redirect
- Auth-only nav links are hidden from unauthenticated visitors