### PR TITLE
fix(logging): address logging costs, retry policies, and production config

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/appsettings.Production.json
+++ b/src/JosephGuadagno.Broadcasting.Api/appsettings.Production.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "JosephGuadagno": "Information"
+    }
+  }
+}

--- a/src/JosephGuadagno.Broadcasting.Domain/ILoggerExtension.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/ILoggerExtension.cs
@@ -9,6 +9,11 @@ public static class ILoggerExtension
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(eventName);
 
+        if (!logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
         string message = "{microsoft.custom_event.name} ";
         object[] values;
         if (properties is not null && properties.Count > 0)

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
@@ -63,7 +63,7 @@ public class LoadAllPosts(
                 var existingItem = await syndicationFeedSourceManager.GetByFeedIdentifierAsync(item.FeedIdentifier);
                 if (existingItem != null)
                 {
-                    logger.LogWarning("Skipping duplicate syndication feed item with FeedIdentifier: '{FeedIdentifier}'", item.FeedIdentifier);
+                    logger.LogDebug("Skipping duplicate syndication feed item with FeedIdentifier: '{FeedIdentifier}'", item.FeedIdentifier);
                     continue;
                 }
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
@@ -69,7 +69,7 @@ public class LoadNewPosts(
                 var existingItem = await syndicationFeedSourceManager.GetByFeedIdentifierAsync(item.FeedIdentifier);
                 if (existingItem != null)
                 {
-                    logger.LogWarning("Skipping duplicate syndication feed item with FeedIdentifier: '{FeedIdentifier}'", item.FeedIdentifier);
+                    logger.LogDebug("Skipping duplicate syndication feed item with FeedIdentifier: '{FeedIdentifier}'", item.FeedIdentifier);
                     continue;
                 }
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
@@ -63,7 +63,7 @@ public class LoadAllVideos(
                 var existingItem = await youTubeSourceManager.GetByVideoIdAsync(item.VideoId);
                 if (existingItem != null)
                 {
-                    logger.LogWarning("Skipping duplicate YouTube video with VideoId: '{VideoId}'", item.VideoId);
+                    logger.LogDebug("Skipping duplicate YouTube video with VideoId: '{VideoId}'", item.VideoId);
                     continue;
                 }
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
@@ -70,7 +70,7 @@ public class LoadNewVideos(
                 var existingItem = await youTubeSourceManager.GetByVideoIdAsync(item.VideoId);
                 if (existingItem != null)
                 {
-                    logger.LogWarning("Skipping duplicate YouTube video with VideoId: '{VideoId}'", item.VideoId);
+                    logger.LogDebug("Skipping duplicate YouTube video with VideoId: '{VideoId}'", item.VideoId);
                     continue;
                 }
 

--- a/src/JosephGuadagno.Broadcasting.Functions/host.json
+++ b/src/JosephGuadagno.Broadcasting.Functions/host.json
@@ -5,8 +5,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "maxTelemetryItemsPerSecond" : 10,
-        "excludedTypes": "Request;Exception"
+        "maxTelemetryItemsPerSecond" : 10
       }
     },
     "logLevel": {

--- a/src/JosephGuadagno.Broadcasting.SyndicationFeedReader/SyndicationFeedReader.cs
+++ b/src/JosephGuadagno.Broadcasting.SyndicationFeedReader/SyndicationFeedReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ServiceModel.Syndication;
@@ -81,7 +81,7 @@ public class SyndicationFeedReader: ISyndicationFeedReader
     public List<SyndicationFeedSource> GetSyndicationItems(DateTimeOffset sinceWhen, List<string> excludeCategories = null)
     {
         _logger.LogDebug("Checking syndication feed '{FeedUrl}' for posts since '{SinceWhen:u}'",
-            _syndicationFeedReaderSettings, sinceWhen);
+            _syndicationFeedReaderSettings.FeedUrl, sinceWhen);
 
         DateTimeOffset currentTime = DateTimeOffset.UtcNow;
         List<SyndicationItem> syndicationItems = [];
@@ -106,7 +106,7 @@ public class SyndicationFeedReader: ISyndicationFeedReader
         catch (Exception e)
         {
             _logger.LogError(e, "Error parsing the syndication feed for: {FeedUrl}",
-                _syndicationFeedReaderSettings);
+                _syndicationFeedReaderSettings.FeedUrl);
             throw;
         }
             

--- a/src/JosephGuadagno.Broadcasting.Web/appsettings.Production.json
+++ b/src/JosephGuadagno.Broadcasting.Web/appsettings.Production.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "JosephGuadagno": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes six logging/config issues to reduce Application Insights costs and improve production observability.

### Changes

- **#625** - Remove excludedTypes from host.json sampling settings. Was bypassing adaptive sampling for all requests/exceptions.
- **#626** - Downgrade per-item LogWarning to LogDebug in collector foreach loops (SyndicationFeed and YouTube). Summary stats remain at LogInformation.
- **#627** - Add IsEnabled(LogLevel.Information) guard to LogCustomEvent extension method to skip unnecessary telemetry overhead.
- **#628** - Fix SyndicationFeedReader logging the settings object instead of .FeedUrl in two call sites (LogDebug + LogError).
- **#624** - Retry policy already present in host.json (exponentialBackoff, 3 retries). No change needed.
- **#630** - Add appsettings.Production.json to Api and Web projects with quiet log levels.

### Verification

Build passes with 0 errors.

Closes #625
Closes #626
Closes #627
Closes #628
Closes #624
Closes #630
