### PR TITLE
fix: remove redundant HasDefaultValueSql on MessageSent bool property

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
@@ -112,8 +112,7 @@ public partial class BroadcastingContext : DbContext
 
             entity.Property(e => e.Message);
 
-            entity.Property(e => e.MessageSent)
-                .HasDefaultValueSql("0");
+            entity.Property(e => e.MessageSent);
 
             entity.Property(e => e.ImageUrl)
                 .HasMaxLength(2048);


### PR DESCRIPTION
## Summary
Removes \.HasDefaultValueSql(\"0\")\ from the \ScheduledItem.MessageSent\ bool property configuration in \BroadcastingContext\.

## Root Cause
EF Core 8+ cannot distinguish an explicit \alse\ from the CLR default for non-nullable \ool\ properties with a database-generated default. This causes a warning in Application Insights logs on every startup.

## Fix
The \.HasDefaultValueSql(\"0\")\ call is entirely redundant — EF Core inserts the C# value directly for value types. Removing it eliminates the warning with no behavioral change.

## Testing
- Build passes
- No behavior change (EF Core was already inserting the C# value, not the DB default)

Fixes #639