### PR TITLE
fix(sql): bounded NVARCHAR columns for indexing (#322)

### DIFF
--- a/scripts/database/migrations/2026-04-07-nvarchar-bounded-columns.sql
+++ b/scripts/database/migrations/2026-04-07-nvarchar-bounded-columns.sql
@@ -1,0 +1,97 @@
+-- Migration: Bound previously-unbounded NVARCHAR columns for indexing
+-- Issue: #322
+-- Date: 2026-04-07
+-- 
+-- Convert NVARCHAR(MAX) to bounded lengths on filterable columns to enable
+-- non-clustered index creation. SQL Server requires bounded column lengths
+-- for index keys.
+
+USE JJGNet;
+GO
+
+-- Engagements table
+-- Name: NVARCHAR(MAX) → NVARCHAR(500)
+-- Url: NVARCHAR(MAX) → NVARCHAR(2048)
+
+IF EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.types t ON c.user_type_id = t.user_type_id
+    WHERE c.object_id = OBJECT_ID('dbo.Engagements')
+    AND c.name = 'Name'
+    AND t.name = 'nvarchar'
+    AND c.max_length = -1  -- -1 indicates MAX
+)
+BEGIN
+    PRINT 'Altering Engagements.Name to NVARCHAR(500)';
+    ALTER TABLE dbo.Engagements
+        ALTER COLUMN [Name] NVARCHAR(500) NOT NULL;
+END
+ELSE
+BEGIN
+    PRINT 'Engagements.Name already bounded or does not exist';
+END
+GO
+
+IF EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.types t ON c.user_type_id = t.user_type_id
+    WHERE c.object_id = OBJECT_ID('dbo.Engagements')
+    AND c.name = 'Url'
+    AND t.name = 'nvarchar'
+    AND c.max_length = -1  -- -1 indicates MAX
+)
+BEGIN
+    PRINT 'Altering Engagements.Url to NVARCHAR(2048)';
+    ALTER TABLE dbo.Engagements
+        ALTER COLUMN [Url] NVARCHAR(2048) NULL;
+END
+ELSE
+BEGIN
+    PRINT 'Engagements.Url already bounded or does not exist';
+END
+GO
+
+-- Talks table
+-- Name: NVARCHAR(MAX) → NVARCHAR(500)
+-- TalkLocation: NVARCHAR(MAX) → NVARCHAR(500)
+
+IF EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.types t ON c.user_type_id = t.user_type_id
+    WHERE c.object_id = OBJECT_ID('dbo.Talks')
+    AND c.name = 'Name'
+    AND t.name = 'nvarchar'
+    AND c.max_length = -1  -- -1 indicates MAX
+)
+BEGIN
+    PRINT 'Altering Talks.Name to NVARCHAR(500)';
+    ALTER TABLE dbo.Talks
+        ALTER COLUMN [Name] NVARCHAR(500) NOT NULL;
+END
+ELSE
+BEGIN
+    PRINT 'Talks.Name already bounded or does not exist';
+END
+GO
+
+IF EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.types t ON c.user_type_id = t.user_type_id
+    WHERE c.object_id = OBJECT_ID('dbo.Talks')
+    AND c.name = 'TalkLocation'
+    AND t.name = 'nvarchar'
+    AND c.max_length = -1  -- -1 indicates MAX
+)
+BEGIN
+    PRINT 'Altering Talks.TalkLocation to NVARCHAR(500)';
+    ALTER TABLE dbo.Talks
+        ALTER COLUMN [TalkLocation] NVARCHAR(500) NULL;
+END
+ELSE
+BEGIN
+    PRINT 'Talks.TalkLocation already bounded or does not exist';
+END
+GO
+
+PRINT 'Migration completed: NVARCHAR bounded columns (#322)';
+GO

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/Engagement.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/Engagement.cs
@@ -19,6 +19,7 @@ public class Engagement
     /// The name of the engagement
     /// </summary>
     [Required]
+    [MaxLength(500)]
     public string Name { get; set; }
         
     /// <summary>
@@ -26,6 +27,7 @@ public class Engagement
     /// </summary>
     [Required]
     [Url]
+    [MaxLength(2048)]
     public string Url { get; set; }
         
     /// <summary>

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/Talk.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/Talk.cs
@@ -17,6 +17,7 @@ public class Talk
     /// The name of the talk
     /// </summary>
     [Required]
+    [MaxLength(500)]
     public string Name { get; set; }
         
     /// <summary>
@@ -48,6 +49,7 @@ public class Talk
     /// <summary>
     /// The room/channel/url for the talk
     /// </summary>
+    [MaxLength(500)]
     public string TalkLocation { get; set; }
         
     /// <summary>


### PR DESCRIPTION
## Summary
Fixes #322 by replacing NVARCHAR(MAX) with bounded lengths on filterable columns in Engagements and Talks tables.

## Changes
- **Engagements.Name**: NVARCHAR(MAX) → NVARCHAR(500)
- **Engagements.Url**: NVARCHAR(MAX) → NVARCHAR(2048)
- **Talks.Name**: NVARCHAR(MAX) → NVARCHAR(500)
- **Talks.TalkLocation**: NVARCHAR(MAX) → NVARCHAR(500)

## Implementation
1. Created migration script 2026-04-07-nvarchar-bounded-columns.sql with ALTER TABLE statements
2. Updated 	able-create.sql for fresh database installs
3. Updated EF Core BroadcastingContext.cs with .HasMaxLength() configurations
4. Added [MaxLength] data annotations to Domain models

## Testing
- ✅ Build succeeds with 0 errors
- ✅ All layers (Domain, Data.Sql, schema) synchronized

## Impact
Enables creation of non-clustered indexes on these columns for improved query performance.

## Note on #323
Issue #323 (Tags junction table normalization) will be handled in a separate PR due to its complexity and data migration requirements.

Closes #322