### PR TITLE
feat(infra): codify Functions storage RBAC role assignments in Bicep

### DIFF
--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -190,6 +190,20 @@ module functionApp 'modules/compute/function-app.bicep' = {
   ]
 }
 
+module storageRbac 'modules/security/storage-rbac.bicep' = {
+  name: 'deploy-storage-rbac'
+  params: {
+    location: locationPrimary
+    storageAccountName: functionsStorageAccountName
+    functionsPrincipalId: functionApp.outputs.functionAppPrincipalId
+    tags: tags
+  }
+  dependsOn: [
+    functionApp
+    storage
+  ]
+}
+
 module alertRules 'modules/monitoring/alert-rules.bicep' = {
   name: 'deploy-alert-rules'
   params: {

--- a/infrastructure/bicep/main.json
+++ b/infrastructure/bicep/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "13155034322814227020"
+      "templateHash": "4452323678386870845"
     }
   },
   "parameters": {
@@ -1600,6 +1600,127 @@
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', 'deploy-app-insights')]",
         "[resourceId('Microsoft.Resources/deployments', 'deploy-app-services')]",
+        "[resourceId('Microsoft.Resources/deployments', 'deploy-storage')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "deploy-storage-rbac",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('locationPrimary')]"
+          },
+          "storageAccountName": {
+            "value": "[parameters('functionsStorageAccountName')]"
+          },
+          "functionsPrincipalId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'deploy-function-app'), '2025-04-01').outputs.functionAppPrincipalId.value]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "3113802800569198082"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for reference (not actively used by role assignments)."
+              }
+            },
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Functions storage account (jjgnetbeb6)."
+              }
+            },
+            "functionsPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Principal ID of the Functions app system-assigned managed identity."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Resource tags."
+              }
+            }
+          },
+          "variables": {
+            "storageBlobDataContributorRoleId": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+            "storageQueueDataContributorRoleId": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
+            "storageTableDataContributorRoleId": "0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('functionsPrincipalId'), variables('storageBlobDataContributorRoleId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataContributorRoleId'))]",
+                "principalId": "[parameters('functionsPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('functionsPrincipalId'), variables('storageQueueDataContributorRoleId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageQueueDataContributorRoleId'))]",
+                "principalId": "[parameters('functionsPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('functionsPrincipalId'), variables('storageTableDataContributorRoleId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageTableDataContributorRoleId'))]",
+                "principalId": "[parameters('functionsPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ],
+          "outputs": {
+            "storageAccountId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+            },
+            "roleAssignmentsGranted": {
+              "type": "array",
+              "value": [
+                "Storage Blob Data Contributor",
+                "Storage Queue Data Contributor",
+                "Storage Table Data Contributor"
+              ]
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'deploy-function-app')]",
         "[resourceId('Microsoft.Resources/deployments', 'deploy-storage')]"
       ]
     },

--- a/infrastructure/bicep/modules/security/storage-rbac.bicep
+++ b/infrastructure/bicep/modules/security/storage-rbac.bicep
@@ -1,0 +1,61 @@
+@description('Azure region for reference (not actively used by role assignments).')
+param location string
+
+@description('Name of the Functions storage account (jjgnetbeb6).')
+param storageAccountName string
+
+@description('Principal ID of the Functions app system-assigned managed identity.')
+param functionsPrincipalId string
+
+@description('Resource tags.')
+param tags object = {}
+
+// Reference the existing Functions storage account (do not redeploy)
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-04-01' existing = {
+  name: storageAccountName
+}
+
+// Built-in Azure Storage role definition IDs
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var storageQueueDataContributorRoleId = '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
+
+// Grant Storage Blob Data Contributor role to Functions system-assigned identity
+resource blobContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, functionsPrincipalId, storageBlobDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Grant Storage Queue Data Contributor role to Functions system-assigned identity
+resource queueContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, functionsPrincipalId, storageQueueDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageQueueDataContributorRoleId)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Grant Storage Table Data Contributor role to Functions system-assigned identity
+resource tableContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, functionsPrincipalId, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRoleId)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output storageAccountId string = storageAccount.id
+output roleAssignmentsGranted array = [
+  'Storage Blob Data Contributor'
+  'Storage Queue Data Contributor'
+  'Storage Table Data Contributor'
+]


### PR DESCRIPTION
## Summary

Adds infrastructure/bicep/modules/security/storage-rbac.bicep to codify the three storage role assignments that were manually granted to the Functions app (jjgnet-broadcast) system-assigned identity in PR #657.

## Context

After PR #657 merged (consolidating to system-assigned identities only), Joseph manually granted these roles in the Azure Portal on storage account jjgnetbeb6:

- Storage Blob Data Contributor
- Storage Queue Data Contributor
- Storage Table Data Contributor

These role assignments were NOT codified in Bicep, meaning a fresh infrastructure deployment would lose storage access for the Functions app.

## Changes

**New module: modules/security/storage-rbac.bicep**
- References the existing Functions storage account (jjgnetbeb6) as an existing resource
- Creates 3 role assignments using deterministic naming: guid(storageAccount.id, functionsPrincipalId, roleDefId)
- Follows the same pattern as key-vault.bicep for RBAC role assignments

**Updated: main.bicep**
- Added storageRbac module block after unctionApp module
- Passes Functions system-assigned principal ID and storage account name

**Generated: main.json**
- Regenerated ARM template with z bicep build (exit code 0, only pre-existing warnings)

## Deployment Impact

⚠️ **IMPORTANT:** The role assignments already exist in production (granted manually). When this Bicep is deployed:
- Azure will **reconcile** the existing assignments (idempotent by name using guid())
- No duplicates will be created
- No errors expected — role assignments are idempotent

This closes the infrastructure gap identified in .squad/decisions/inbox/cypher-bicep-validation-gap.md

## Testing

- ✅ Bicep compiles cleanly: z bicep build --file main.bicep (exit code 0)
- ✅ Follows existing patterns from key-vault.bicep and storage-account.bicep
- ✅ Uses deterministic role assignment names (guid-based)
- ✅ Sets principalType: 'ServicePrincipal' as required