### PR TITLE
fix(auth): break infinite re-authentication loop introduced by PR #648

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/RejectSessionCookieWhenAccountNotInCacheEvents.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/RejectSessionCookieWhenAccountNotInCacheEvents.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
@@ -10,7 +9,15 @@ internal class RejectSessionCookieWhenAccountNotInCacheEvents : CookieAuthentica
 {
     public override async Task ValidatePrincipal(CookieValidatePrincipalContext context)
     {
-        // Fix 1: Extract logger once at method start to avoid multiple service resolutions per request (performance)
+        // Guard: If the principal is null or unauthenticated (e.g. after SignOut clears the session cookie),
+        // skip all token cache operations. Without this guard, calling GetAccessTokenForUserAsync(user: null)
+        // throws MsalUiRequiredException with ErrorCode "user_null", which matches AccountDoesNotExitInTokenCache,
+        // which calls SignOutAsync again — creating an infinite redirect loop.
+        if (context.Principal?.Identity?.IsAuthenticated != true)
+        {
+            return;
+        }
+
         var logger = context.HttpContext.RequestServices.GetService<ILogger<RejectSessionCookieWhenAccountNotInCacheEvents>>();
         
         try
@@ -22,26 +29,19 @@ internal class RejectSessionCookieWhenAccountNotInCacheEvents : CookieAuthentica
         }
         catch (MicrosoftIdentityWebChallengeUserException ex) when (AccountDoesNotExitInTokenCache(ex))
         {
-            // Fix 2: SignOutAsync added to clear stale session cookies before forcing re-authentication.
-            // When token cache is empty but cookie still exists (common after app recycle), the stale cookie
-            // would cause repeated validation failures. SignOutAsync ensures clean state for re-login flow.
-            // This extends the original fix from PR #555 (reverted in #572) to handle issue #81's cache collision scenario.
             logger?.LogWarning("Token cache issue detected during cookie validation: {ErrorCode}. Rejecting principal to force re-authentication.", 
                 ex.InnerException is MsalUiRequiredException msalEx ? msalEx.ErrorCode : "unknown");
             context.RejectPrincipal();
-            await context.HttpContext.SignOutAsync();
         }
         catch (MsalServiceException ex) when (IsTokenCacheCollision(ex))
         {
             logger?.LogWarning("Multiple tokens detected in cache after app recycle: {ErrorCode}. Rejecting principal to force re-authentication.", ex.ErrorCode);
             context.RejectPrincipal();
-            await context.HttpContext.SignOutAsync();
         }
         catch (MsalClientException ex) when (IsTokenCacheCollision(ex))
         {
             logger?.LogWarning("Token cache collision detected: {ErrorCode}. Rejecting principal to force re-authentication.", ex.ErrorCode);
             context.RejectPrincipal();
-            await context.HttpContext.SignOutAsync();
         }
     }
     
@@ -55,15 +55,8 @@ internal class RejectSessionCookieWhenAccountNotInCacheEvents : CookieAuthentica
         return ex.InnerException is MsalUiRequiredException { ErrorCode: "user_null" };
     }
     
-    /// <summary>
-    /// Detects token cache collision errors (multiple matching tokens in cache)
-    /// </summary>
-    /// <param name="ex">MSAL exception</param>
-    /// <returns>True if this is a cache collision error</returns>
     private static bool IsTokenCacheCollision(MsalException ex)
     {
-        // Fix 3: Use ErrorCode constants instead of fragile Message string matching
-        // MSAL error codes are stable across versions; error messages can change
         return ex.ErrorCode == MsalError.MultipleTokensMatchedError ||
                ex.ErrorCode == MsalError.NoTokensFoundError;
     }


### PR DESCRIPTION
## Root Cause

PR #648 added `SignOutAsync()` inside `ValidatePrincipal` alongside `context.RejectPrincipal()`. This creates an infinite authentication loop:

1. `ValidatePrincipal` fires for an authenticated user
2. `GetAccessTokenForUserAsync` fails (account not in token cache)
3. `RejectPrincipal()` + `SignOutAsync()` → triggers OIDC end-session redirect to Azure AD
4. Azure AD redirects back → new OIDC callback → new session cookie
5. But the token cache entry is still missing for this user
6. Next request → `ValidatePrincipal` fires again → step 2 repeats → infinite loop

The `user_null` log entry repeating in the logs confirms the loop.

## The Fix

Two changes in `RejectSessionCookieWhenAccountNotInCacheEvents.cs`:

1. **Remove `SignOutAsync()` from all catch blocks** — `context.RejectPrincipal()` alone is sufficient. The cookie auth middleware handles the redirect to Azure AD login naturally. `SignOutAsync()` triggers a full OIDC end-session flow that, combined with a broken token cache, creates the loop. Microsoft's own `RejectSessionCookieWhenAccountNotInCacheEvents` samples never call `SignOutAsync()` from `ValidatePrincipal`.

2. **Add null-principal guard** — if `context.Principal` is null or unauthenticated, return immediately. Defense-in-depth against any future path that could call `ValidatePrincipal` with an unauthenticated context.

## What Is Preserved

- Real MSAL cache misses still trigger `RejectPrincipal` → user is redirected to login
- The `IsTokenCacheCollision` check using stable `MsalError` constants is retained
- Issue #81 (stale collided tokens after app recycle) is still handled

## Files Changed

- `src/JosephGuadagno.Broadcasting.Web/RejectSessionCookieWhenAccountNotInCacheEvents.cs`
  - Removed `SignOutAsync()` from all three catch blocks
  - Added null/unauthenticated principal guard at method entry

## References

- Regressed by: PR #648
- Original issue: #81