### PR TITLE
feat(#678): Web admin UI for SocialMediaPlatforms

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SocialMediaPlatformsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SocialMediaPlatformsController.cs
@@ -39,19 +39,22 @@ public class SocialMediaPlatformsController : ControllerBase
         value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
     /// <summary>
-    /// Gets all active social media platforms
+    /// Gets social media platforms
     /// </summary>
-    /// <returns>A list of active social media platforms</returns>
+    /// <param name='includeInactive'>When true, returns all platforms including inactive ones. Default is false (active only).</param>
+    /// <returns>A list of social media platforms</returns>
     /// <response code="200">If the call was successful</response>
     /// <response code="401">If the current user was unauthorized to access this endpoint</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<SocialMediaPlatformResponse>))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<ActionResult<List<SocialMediaPlatformResponse>>> GetAllAsync()
+    public async Task<ActionResult<List<SocialMediaPlatformResponse>>> GetAllAsync([FromQuery] bool includeInactive = false)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.SocialMediaPlatforms.List, Domain.Scopes.SocialMediaPlatforms.All);
 
-        var platforms = await _socialMediaPlatformManager.GetAllAsync();
+        var platforms = includeInactive
+            ? await _socialMediaPlatformManager.GetAllIncludingInactiveAsync()
+            : await _socialMediaPlatformManager.GetAllAsync();
         var response = _mapper.Map<List<SocialMediaPlatformResponse>>(platforms);
         return Ok(response);
     }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISocialMediaPlatformManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISocialMediaPlatformManager.cs
@@ -15,6 +15,13 @@ public interface ISocialMediaPlatformManager
     Task<List<SocialMediaPlatform>> GetAllAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Get all social media platforms including inactive ones (for admin use)
+    /// </summary>
+    /// <param name='cancellationToken'>Cancellation token</param>
+    /// <returns>List of all social media platforms including inactive</returns>
+    Task<List<SocialMediaPlatform>> GetAllIncludingInactiveAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get a social media platform by ID
     /// </summary>
     /// <param name="id">The platform ID</param>

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/SocialMediaPlatformManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/SocialMediaPlatformManagerTests.cs
@@ -7,246 +7,346 @@ namespace JosephGuadagno.Broadcasting.Managers.Tests;
 
 public class SocialMediaPlatformManagerTests
 {
-    private readonly Mock<ISocialMediaPlatformDataStore> _dataStoreMock;
-    private readonly SocialMediaPlatformManager _manager;
+    private readonly Mock<ISocialMediaPlatformDataStore> _dataStore;
+    private readonly SocialMediaPlatformManager _sut;
 
     public SocialMediaPlatformManagerTests()
     {
-        _dataStoreMock = new Mock<ISocialMediaPlatformDataStore>();
-        _manager = new SocialMediaPlatformManager(_dataStoreMock.Object);
+        _dataStore = new Mock<ISocialMediaPlatformDataStore>();
+        _sut = new SocialMediaPlatformManager(_dataStore.Object);
     }
 
-    // -------------------------------------------------------------------------
-    // GetAllAsync
-    // -------------------------------------------------------------------------
+    // ── GetAllAsync ───────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task GetAllAsync_ShouldCallDataStoreWithIncludeInactiveFalse()
+    public async Task GetAllAsync_WhenPlatformsExist_ShouldReturnOnlyActivePlatforms()
     {
         // Arrange
         var platforms = new List<SocialMediaPlatform>
         {
-            new() { Id = 1, Name = "Twitter", Url = "https://twitter.com", IsActive = true },
-            new() { Id = 2, Name = "BlueSky", Url = "https://bsky.app", IsActive = true }
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true },
+            new SocialMediaPlatform { Id = 2, Name = "BlueSky", IsActive = true }
         };
-        _dataStoreMock.Setup(d => d.GetAllAsync(false, default)).ReturnsAsync(platforms);
+        _dataStore
+            .Setup(d => d.GetAllAsync(false, default))
+            .ReturnsAsync(platforms);
 
         // Act
-        var result = await _manager.GetAllAsync();
+        var result = await _sut.GetAllAsync();
 
         // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2);
         result.Should().BeEquivalentTo(platforms);
-        _dataStoreMock.Verify(d => d.GetAllAsync(false, default), Times.Once);
-        _dataStoreMock.Verify(d => d.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Never);
+        _dataStore.Verify(d => d.GetAllAsync(false, default), Times.Once);
     }
 
     [Fact]
-    public async Task GetAllAsync_WhenEmpty_ShouldReturnEmptyList()
+    public async Task GetAllAsync_WhenNoActivePlatformsExist_ShouldReturnEmptyList()
     {
         // Arrange
-        _dataStoreMock.Setup(d => d.GetAllAsync(false, default))
+        _dataStore
+            .Setup(d => d.GetAllAsync(false, default))
             .ReturnsAsync(new List<SocialMediaPlatform>());
 
         // Act
-        var result = await _manager.GetAllAsync();
+        var result = await _sut.GetAllAsync();
 
         // Assert
         result.Should().NotBeNull();
         result.Should().BeEmpty();
-        _dataStoreMock.Verify(d => d.GetAllAsync(false, default), Times.Once);
+        _dataStore.Verify(d => d.GetAllAsync(false, default), Times.Once);
     }
 
-    // -------------------------------------------------------------------------
-    // GetByIdAsync
-    // -------------------------------------------------------------------------
-
     [Fact]
-    public async Task GetByIdAsync_WhenFound_ShouldReturnPlatform()
+    public async Task GetAllAsync_ShouldPassIncludeInactiveFalseToDataStore()
     {
         // Arrange
-        var platform = new SocialMediaPlatform { Id = 1, Name = "Twitter", Url = "https://twitter.com", IsActive = true };
-        _dataStoreMock.Setup(d => d.GetAsync(1, default)).ReturnsAsync(platform);
+        _dataStore
+            .Setup(d => d.GetAllAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SocialMediaPlatform>());
 
         // Act
-        var result = await _manager.GetByIdAsync(1);
+        await _sut.GetAllAsync();
+
+        // Assert — ensure inactive platforms are excluded by passing false
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Once);
+        _dataStore.Verify(d => d.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── GetAllIncludingInactiveAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllIncludingInactiveAsync_WhenPlatformsExist_ShouldReturnAllPlatforms()
+    {
+        // Arrange
+        var platforms = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true },
+            new SocialMediaPlatform { Id = 2, Name = "MySpace", IsActive = false }
+        };
+        _dataStore
+            .Setup(d => d.GetAllAsync(true, default))
+            .ReturnsAsync(platforms);
+
+        // Act
+        var result = await _sut.GetAllIncludingInactiveAsync();
 
         // Assert
         result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(platform);
-        _dataStoreMock.Verify(d => d.GetAsync(1, default), Times.Once);
+        result.Should().HaveCount(2);
+        result.Should().BeEquivalentTo(platforms);
+        _dataStore.Verify(d => d.GetAllAsync(true, default), Times.Once);
     }
 
     [Fact]
-    public async Task GetByIdAsync_WhenNotFound_ShouldReturnNull()
+    public async Task GetAllIncludingInactiveAsync_ShouldPassIncludeInactiveTrueToDataStore()
     {
         // Arrange
-        _dataStoreMock.Setup(d => d.GetAsync(99, default)).ReturnsAsync((SocialMediaPlatform?)null);
+        _dataStore
+            .Setup(d => d.GetAllAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SocialMediaPlatform>());
 
         // Act
-        var result = await _manager.GetByIdAsync(99);
+        await _sut.GetAllIncludingInactiveAsync();
+
+        // Assert — both active and inactive platforms should be requested
+        _dataStore.Verify(d => d.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── GetByIdAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByIdAsync_WhenPlatformExists_ShouldReturnPlatform()
+    {
+        // Arrange
+        var platform = new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true };
+        _dataStore
+            .Setup(d => d.GetAsync(1, default))
+            .ReturnsAsync(platform);
+
+        // Act
+        var result = await _sut.GetByIdAsync(1);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(1);
+        result.Name.Should().Be("Twitter");
+        _dataStore.Verify(d => d.GetAsync(1, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenPlatformDoesNotExist_ShouldReturnNull()
+    {
+        // Arrange
+        _dataStore
+            .Setup(d => d.GetAsync(99, default))
+            .ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act
+        var result = await _sut.GetByIdAsync(99);
 
         // Assert
         result.Should().BeNull();
-        _dataStoreMock.Verify(d => d.GetAsync(99, default), Times.Once);
+        _dataStore.Verify(d => d.GetAsync(99, default), Times.Once);
     }
 
-    // -------------------------------------------------------------------------
-    // GetByNameAsync
-    // -------------------------------------------------------------------------
+    // ── GetByNameAsync ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task GetByNameAsync_WhenFound_ShouldReturnPlatform()
+    public async Task GetByNameAsync_WhenPlatformExists_ShouldReturnPlatform()
     {
         // Arrange
-        var platform = new SocialMediaPlatform { Id = 3, Name = "Mastodon", Url = "https://mastodon.social", IsActive = true };
-        _dataStoreMock.Setup(d => d.GetByNameAsync("Mastodon", default)).ReturnsAsync(platform);
+        var platform = new SocialMediaPlatform { Id = 3, Name = "BlueSky", IsActive = true };
+        _dataStore
+            .Setup(d => d.GetByNameAsync("BlueSky", default))
+            .ReturnsAsync(platform);
 
         // Act
-        var result = await _manager.GetByNameAsync("Mastodon");
+        var result = await _sut.GetByNameAsync("BlueSky");
 
         // Assert
         result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(platform);
-        _dataStoreMock.Verify(d => d.GetByNameAsync("Mastodon", default), Times.Once);
+        result!.Name.Should().Be("BlueSky");
+        _dataStore.Verify(d => d.GetByNameAsync("BlueSky", default), Times.Once);
     }
 
     [Fact]
-    public async Task GetByNameAsync_WhenNotFound_ShouldReturnNull()
+    public async Task GetByNameAsync_WhenPlatformDoesNotExist_ShouldReturnNull()
     {
         // Arrange
-        _dataStoreMock.Setup(d => d.GetByNameAsync("NonExistent", default)).ReturnsAsync((SocialMediaPlatform?)null);
+        _dataStore
+            .Setup(d => d.GetByNameAsync("NonExistent", default))
+            .ReturnsAsync((SocialMediaPlatform?)null);
 
         // Act
-        var result = await _manager.GetByNameAsync("NonExistent");
+        var result = await _sut.GetByNameAsync("NonExistent");
 
         // Assert
         result.Should().BeNull();
-        _dataStoreMock.Verify(d => d.GetByNameAsync("NonExistent", default), Times.Once);
+        _dataStore.Verify(d => d.GetByNameAsync("NonExistent", default), Times.Once);
     }
 
-    // -------------------------------------------------------------------------
-    // AddAsync
-    // -------------------------------------------------------------------------
+    // ── AddAsync ──────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task AddAsync_ShouldDelegateToDataStore()
+    public async Task AddAsync_WhenPlatformIsValid_ShouldReturnCreatedPlatform()
     {
         // Arrange
-        var request = new SocialMediaPlatform { Name = "LinkedIn", Url = "https://linkedin.com", IsActive = true };
-        var saved = new SocialMediaPlatform { Id = 5, Name = "LinkedIn", Url = "https://linkedin.com", IsActive = true };
-        _dataStoreMock.Setup(d => d.AddAsync(request, default)).ReturnsAsync(saved);
+        var input = new SocialMediaPlatform { Name = "Mastodon", Url = "https://mastodon.social", IsActive = true };
+        var created = new SocialMediaPlatform { Id = 10, Name = "Mastodon", Url = "https://mastodon.social", IsActive = true };
+        _dataStore
+            .Setup(d => d.AddAsync(input, default))
+            .ReturnsAsync(created);
 
         // Act
-        var result = await _manager.AddAsync(request);
+        var result = await _sut.AddAsync(input);
 
         // Assert
         result.Should().NotBeNull();
-        result!.Id.Should().Be(5);
-        result!.Name.Should().Be("LinkedIn");
-        _dataStoreMock.Verify(d => d.AddAsync(request, default), Times.Once);
+        result!.Id.Should().Be(10);
+        result.Name.Should().Be("Mastodon");
+        _dataStore.Verify(d => d.AddAsync(input, default), Times.Once);
     }
 
     [Fact]
     public async Task AddAsync_WhenDataStoreFails_ShouldReturnNull()
     {
         // Arrange
-        var request = new SocialMediaPlatform { Name = "Facebook", IsActive = true };
-        _dataStoreMock.Setup(d => d.AddAsync(request, default)).ReturnsAsync((SocialMediaPlatform?)null);
+        var input = new SocialMediaPlatform { Name = "Mastodon" };
+        _dataStore
+            .Setup(d => d.AddAsync(It.IsAny<SocialMediaPlatform>(), default))
+            .ReturnsAsync((SocialMediaPlatform?)null);
 
         // Act
-        var result = await _manager.AddAsync(request);
+        var result = await _sut.AddAsync(input);
 
         // Assert
         result.Should().BeNull();
-        _dataStoreMock.Verify(d => d.AddAsync(request, default), Times.Once);
+        _dataStore.Verify(d => d.AddAsync(input, default), Times.Once);
     }
 
-    // -------------------------------------------------------------------------
-    // UpdateAsync
-    // -------------------------------------------------------------------------
-
     [Fact]
-    public async Task UpdateAsync_ShouldDelegateToDataStore()
+    public async Task AddAsync_ShouldForwardCancellationTokenToDataStore()
     {
         // Arrange
-        var platform = new SocialMediaPlatform { Id = 2, Name = "Mastodon", Url = "https://mastodon.social", IsActive = true };
-        _dataStoreMock.Setup(d => d.UpdateAsync(platform, default)).ReturnsAsync(platform);
+        var platform = new SocialMediaPlatform { Name = "LinkedIn" };
+        var cts = new CancellationTokenSource();
+        _dataStore
+            .Setup(d => d.AddAsync(platform, cts.Token))
+            .ReturnsAsync(platform);
 
         // Act
-        var result = await _manager.UpdateAsync(platform);
+        await _sut.AddAsync(platform, cts.Token);
+
+        // Assert
+        _dataStore.Verify(d => d.AddAsync(platform, cts.Token), Times.Once);
+    }
+
+    // ── UpdateAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_WhenPlatformExists_ShouldReturnUpdatedPlatform()
+    {
+        // Arrange
+        var input = new SocialMediaPlatform { Id = 5, Name = "Twitter", Url = "https://x.com", IsActive = true };
+        var updated = new SocialMediaPlatform { Id = 5, Name = "Twitter", Url = "https://x.com", IsActive = true };
+        _dataStore
+            .Setup(d => d.UpdateAsync(input, default))
+            .ReturnsAsync(updated);
+
+        // Act
+        var result = await _sut.UpdateAsync(input);
 
         // Assert
         result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(platform);
-        _dataStoreMock.Verify(d => d.UpdateAsync(platform, default), Times.Once);
+        result!.Id.Should().Be(5);
+        result.Url.Should().Be("https://x.com");
+        _dataStore.Verify(d => d.UpdateAsync(input, default), Times.Once);
     }
 
     [Fact]
-    public async Task UpdateAsync_WhenNotFound_ShouldReturnNull()
+    public async Task UpdateAsync_WhenPlatformDoesNotExist_ShouldReturnNull()
     {
         // Arrange
-        var platform = new SocialMediaPlatform { Id = 999, Name = "Ghost Platform", IsActive = true };
-        _dataStoreMock.Setup(d => d.UpdateAsync(platform, default)).ReturnsAsync((SocialMediaPlatform?)null);
+        var input = new SocialMediaPlatform { Id = 999, Name = "Ghost" };
+        _dataStore
+            .Setup(d => d.UpdateAsync(It.IsAny<SocialMediaPlatform>(), default))
+            .ReturnsAsync((SocialMediaPlatform?)null);
 
         // Act
-        var result = await _manager.UpdateAsync(platform);
+        var result = await _sut.UpdateAsync(input);
 
         // Assert
         result.Should().BeNull();
-        _dataStoreMock.Verify(d => d.UpdateAsync(platform, default), Times.Once);
+        _dataStore.Verify(d => d.UpdateAsync(input, default), Times.Once);
     }
 
-    // -------------------------------------------------------------------------
-    // DeleteAsync
-    // -------------------------------------------------------------------------
-
     [Fact]
-    public async Task DeleteAsync_WhenFound_ShouldReturnTrue()
+    public async Task UpdateAsync_ShouldForwardCancellationTokenToDataStore()
     {
         // Arrange
-        _dataStoreMock.Setup(d => d.DeleteAsync(3, default)).ReturnsAsync(true);
+        var platform = new SocialMediaPlatform { Id = 1, Name = "LinkedIn" };
+        var cts = new CancellationTokenSource();
+        _dataStore
+            .Setup(d => d.UpdateAsync(platform, cts.Token))
+            .ReturnsAsync(platform);
 
         // Act
-        var result = await _manager.DeleteAsync(3);
+        await _sut.UpdateAsync(platform, cts.Token);
 
         // Assert
-        result.Should().BeTrue();
-        _dataStoreMock.Verify(d => d.DeleteAsync(3, default), Times.Once);
+        _dataStore.Verify(d => d.UpdateAsync(platform, cts.Token), Times.Once);
     }
 
-    [Fact]
-    public async Task DeleteAsync_WhenNotFound_ShouldReturnFalse()
-    {
-        // Arrange
-        _dataStoreMock.Setup(d => d.DeleteAsync(999, default)).ReturnsAsync(false);
-
-        // Act
-        var result = await _manager.DeleteAsync(999);
-
-        // Assert
-        result.Should().BeFalse();
-        _dataStoreMock.Verify(d => d.DeleteAsync(999, default), Times.Once);
-    }
+    // ── DeleteAsync ───────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task DeleteAsync_ShouldToggleIsActive_ByDelegatingToDataStore()
+    public async Task DeleteAsync_WhenPlatformExists_ShouldReturnTrue()
     {
         // Arrange
-        // The manager delegates the soft-delete (IsActive = false) responsibility to the
-        // data store. Verify the data store is called with the correct ID and reports success.
-        const int platformId = 7;
-        var beforeDelete = new SocialMediaPlatform { Id = platformId, Name = "Pinterest", IsActive = true };
-
-        _dataStoreMock.Setup(d => d.DeleteAsync(platformId, default))
-            .Callback(() => beforeDelete.IsActive = false)   // simulate soft-delete side-effect
+        _dataStore
+            .Setup(d => d.DeleteAsync(7, default))
             .ReturnsAsync(true);
 
         // Act
-        var deleted = await _manager.DeleteAsync(platformId);
+        var result = await _sut.DeleteAsync(7);
 
         // Assert
-        deleted.Should().BeTrue();
-        beforeDelete.IsActive.Should().BeFalse("the data store performs a soft delete by setting IsActive to false");
-        _dataStoreMock.Verify(d => d.DeleteAsync(platformId, default), Times.Once);
+        result.Should().BeTrue();
+        _dataStore.Verify(d => d.DeleteAsync(7, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenPlatformDoesNotExist_ShouldReturnFalse()
+    {
+        // Arrange
+        _dataStore
+            .Setup(d => d.DeleteAsync(999, default))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _sut.DeleteAsync(999);
+
+        // Assert
+        result.Should().BeFalse();
+        _dataStore.Verify(d => d.DeleteAsync(999, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldForwardCancellationTokenToDataStore()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        _dataStore
+            .Setup(d => d.DeleteAsync(1, cts.Token))
+            .ReturnsAsync(true);
+
+        // Act
+        await _sut.DeleteAsync(1, cts.Token);
+
+        // Assert
+        _dataStore.Verify(d => d.DeleteAsync(1, cts.Token), Times.Once);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/SocialMediaPlatformManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/SocialMediaPlatformManager.cs
@@ -21,6 +21,11 @@ public class SocialMediaPlatformManager : ISocialMediaPlatformManager
         return await _dataStore.GetAllAsync(includeInactive: false, cancellationToken);
     }
 
+    public async Task<List<SocialMediaPlatform>> GetAllIncludingInactiveAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dataStore.GetAllAsync(includeInactive: true, cancellationToken);
+    }
+
     public async Task<SocialMediaPlatform?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
     {
         return await _dataStore.GetAsync(id, cancellationToken);

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/SocialMediaPlatformsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/SocialMediaPlatformsControllerTests.cs
@@ -1,0 +1,410 @@
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Web.Controllers;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using JosephGuadagno.Broadcasting.Web.Models;
+
+namespace JosephGuadagno.Broadcasting.Web.Tests.Controllers;
+
+public class SocialMediaPlatformsControllerTests
+{
+    private readonly Mock<ISocialMediaPlatformService> _platformService;
+    private readonly Mock<IMapper> _mapper;
+    private readonly SocialMediaPlatformsController _controller;
+
+    public SocialMediaPlatformsControllerTests()
+    {
+        _platformService = new Mock<ISocialMediaPlatformService>();
+        _mapper = new Mock<IMapper>();
+        _controller = new SocialMediaPlatformsController(_platformService.Object, _mapper.Object);
+
+        // Initialise TempData (required by actions that set TempData["…"])
+        var httpContext = new DefaultHttpContext();
+        var tempDataProvider = new Mock<ITempDataProvider>();
+        var tempDataDictionaryFactory = new TempDataDictionaryFactory(tempDataProvider.Object);
+        _controller.TempData = tempDataDictionaryFactory.GetTempData(httpContext);
+    }
+
+    // ── Index ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Index_ShouldReturnViewWithListOfViewModels()
+    {
+        // Arrange
+        var platforms = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true },
+            new SocialMediaPlatform { Id = 2, Name = "BlueSky", IsActive = false }
+        };
+        var viewModels = new List<SocialMediaPlatformViewModel>
+        {
+            new SocialMediaPlatformViewModel { Id = 1, Name = "Twitter", IsActive = true },
+            new SocialMediaPlatformViewModel { Id = 2, Name = "BlueSky", IsActive = false }
+        };
+        _platformService.Setup(s => s.GetAllAsync()).ReturnsAsync(platforms);
+        _mapper.Setup(m => m.Map<List<SocialMediaPlatformViewModel>>(platforms)).Returns(viewModels);
+
+        // Act
+        var result = await _controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().BeEquivalentTo(viewModels);
+        _platformService.Verify(s => s.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Index_WhenNoPlatformsExist_ShouldReturnViewWithEmptyList()
+    {
+        // Arrange
+        var emptyList = new List<SocialMediaPlatform>();
+        var emptyViewModels = new List<SocialMediaPlatformViewModel>();
+        _platformService.Setup(s => s.GetAllAsync()).ReturnsAsync(emptyList);
+        _mapper.Setup(m => m.Map<List<SocialMediaPlatformViewModel>>(emptyList)).Returns(emptyViewModels);
+
+        // Act
+        var result = await _controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().BeEquivalentTo(emptyViewModels);
+    }
+
+    // ── Add GET ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Add_Get_ShouldReturnViewWithIsActiveTrueByDefault()
+    {
+        // Act
+        var result = _controller.Add();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SocialMediaPlatformViewModel>(viewResult.Model);
+        model.IsActive.Should().BeTrue("new platforms default to active");
+    }
+
+    [Fact]
+    public void Add_Get_ShouldReturnViewWithNewViewModel()
+    {
+        // Act
+        var result = _controller.Add();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().NotBeNull();
+        viewResult.Model.Should().BeOfType<SocialMediaPlatformViewModel>();
+    }
+
+    // ── Add POST ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Add_Post_WhenModelStateIsValid_AndServiceSucceeds_ShouldRedirectToIndex()
+    {
+        // Arrange
+        var viewModel = new SocialMediaPlatformViewModel { Name = "Mastodon", IsActive = true };
+        var domain = new SocialMediaPlatform { Name = "Mastodon", IsActive = true };
+        var created = new SocialMediaPlatform { Id = 42, Name = "Mastodon", IsActive = true };
+        _mapper.Setup(m => m.Map<SocialMediaPlatform>(viewModel)).Returns(domain);
+        _platformService.Setup(s => s.AddAsync(domain)).ReturnsAsync(created);
+
+        // Act
+        var result = await _controller.Add(viewModel);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        redirectResult.ActionName.Should().Be(nameof(SocialMediaPlatformsController.Index));
+        _platformService.Verify(s => s.AddAsync(domain), Times.Once);
+    }
+
+    [Fact]
+    public async Task Add_Post_WhenModelStateIsValid_AndServiceReturnsNull_ShouldReturnViewWithViewModel()
+    {
+        // Arrange
+        var viewModel = new SocialMediaPlatformViewModel { Name = "Mastodon", IsActive = true };
+        var domain = new SocialMediaPlatform { Name = "Mastodon" };
+        _mapper.Setup(m => m.Map<SocialMediaPlatform>(viewModel)).Returns(domain);
+        _platformService.Setup(s => s.AddAsync(It.IsAny<SocialMediaPlatform>())).ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act
+        var result = await _controller.Add(viewModel);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _controller.TempData["ErrorMessage"].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Add_Post_WhenModelStateIsInvalid_ShouldReturnViewWithoutCallingService()
+    {
+        // Arrange
+        var viewModel = new SocialMediaPlatformViewModel(); // Name is required but empty
+        _controller.ModelState.AddModelError("Name", "Name is required");
+
+        // Act
+        var result = await _controller.Add(viewModel);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _platformService.Verify(s => s.AddAsync(It.IsAny<SocialMediaPlatform>()), Times.Never);
+    }
+
+    // ── Edit GET ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Edit_Get_WhenPlatformExists_ShouldReturnViewWithViewModel()
+    {
+        // Arrange
+        var platform = new SocialMediaPlatform { Id = 1, Name = "LinkedIn", IsActive = true };
+        var viewModel = new SocialMediaPlatformViewModel { Id = 1, Name = "LinkedIn", IsActive = true };
+        _platformService.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(platform);
+        _mapper.Setup(m => m.Map<SocialMediaPlatformViewModel>(platform)).Returns(viewModel);
+
+        // Act
+        var result = await _controller.Edit(1);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _platformService.Verify(s => s.GetByIdAsync(1), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WhenPlatformDoesNotExist_ShouldReturnNotFound()
+    {
+        // Arrange
+        _platformService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act
+        var result = await _controller.Edit(99);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+        _platformService.Verify(s => s.GetByIdAsync(99), Times.Once);
+    }
+
+    // ── Edit POST ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Edit_Post_WhenModelStateIsValid_AndServiceSucceeds_ShouldRedirectToIndex()
+    {
+        // Arrange
+        var viewModel = new SocialMediaPlatformViewModel { Id = 5, Name = "Twitter", IsActive = true };
+        var domain = new SocialMediaPlatform { Id = 5, Name = "Twitter", IsActive = true };
+        var updated = new SocialMediaPlatform { Id = 5, Name = "Twitter", IsActive = true };
+        _mapper.Setup(m => m.Map<SocialMediaPlatform>(viewModel)).Returns(domain);
+        _platformService.Setup(s => s.UpdateAsync(domain)).ReturnsAsync(updated);
+
+        // Act
+        var result = await _controller.Edit(viewModel);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        redirectResult.ActionName.Should().Be(nameof(SocialMediaPlatformsController.Index));
+        _platformService.Verify(s => s.UpdateAsync(domain), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Post_WhenModelStateIsValid_AndServiceReturnsNull_ShouldReturnViewWithViewModel()
+    {
+        // Arrange
+        var viewModel = new SocialMediaPlatformViewModel { Id = 5, Name = "Twitter" };
+        var domain = new SocialMediaPlatform { Id = 5, Name = "Twitter" };
+        _mapper.Setup(m => m.Map<SocialMediaPlatform>(viewModel)).Returns(domain);
+        _platformService.Setup(s => s.UpdateAsync(It.IsAny<SocialMediaPlatform>())).ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act
+        var result = await _controller.Edit(viewModel);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _controller.TempData["ErrorMessage"].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Edit_Post_WhenModelStateIsInvalid_ShouldReturnViewWithoutCallingService()
+    {
+        // Arrange
+        var viewModel = new SocialMediaPlatformViewModel { Id = 5 }; // Name is required
+        _controller.ModelState.AddModelError("Name", "Name is required");
+
+        // Act
+        var result = await _controller.Edit(viewModel);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _platformService.Verify(s => s.UpdateAsync(It.IsAny<SocialMediaPlatform>()), Times.Never);
+    }
+
+    // ── ToggleActive POST ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ToggleActive_WhenToggleSucceeds_ShouldRedirectToIndex()
+    {
+        // Arrange
+        _platformService.Setup(s => s.ToggleActiveAsync(3)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.ToggleActive(3);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        redirectResult.ActionName.Should().Be(nameof(SocialMediaPlatformsController.Index));
+        _controller.TempData["SuccessMessage"].Should().NotBeNull();
+        _platformService.Verify(s => s.ToggleActiveAsync(3), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToggleActive_WhenToggleFails_ShouldRedirectToIndexWithError()
+    {
+        // Arrange
+        _platformService.Setup(s => s.ToggleActiveAsync(99)).ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.ToggleActive(99);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        redirectResult.ActionName.Should().Be(nameof(SocialMediaPlatformsController.Index));
+        _controller.TempData["ErrorMessage"].Should().NotBeNull();
+    }
+
+    // ── Delete GET ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_Get_WhenPlatformExists_ShouldReturnConfirmationView()
+    {
+        // Arrange
+        var platform = new SocialMediaPlatform { Id = 7, Name = "Facebook", IsActive = true };
+        var viewModel = new SocialMediaPlatformViewModel { Id = 7, Name = "Facebook", IsActive = true };
+        _platformService.Setup(s => s.GetByIdAsync(7)).ReturnsAsync(platform);
+        _mapper.Setup(m => m.Map<SocialMediaPlatformViewModel>(platform)).Returns(viewModel);
+
+        // Act
+        var result = await _controller.Delete(7);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _platformService.Verify(s => s.GetByIdAsync(7), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WhenPlatformDoesNotExist_ShouldReturnNotFound()
+    {
+        // Arrange
+        _platformService.Setup(s => s.GetByIdAsync(999)).ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act
+        var result = await _controller.Delete(999);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    // ── DeleteConfirmed POST ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteConfirmed_WhenDeleteSucceeds_ShouldRedirectToIndexWithSuccess()
+    {
+        // Arrange
+        _platformService.Setup(s => s.DeleteAsync(8)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.DeleteConfirmed(8);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        redirectResult.ActionName.Should().Be(nameof(SocialMediaPlatformsController.Index));
+        _controller.TempData["SuccessMessage"].Should().NotBeNull();
+        _platformService.Verify(s => s.DeleteAsync(8), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WhenDeleteFails_AndPlatformStillExists_ShouldReturnViewWithError()
+    {
+        // Arrange
+        var platform = new SocialMediaPlatform { Id = 8, Name = "Threads", IsActive = true };
+        var viewModel = new SocialMediaPlatformViewModel { Id = 8, Name = "Threads", IsActive = true };
+        _platformService.Setup(s => s.DeleteAsync(8)).ReturnsAsync(false);
+        _platformService.Setup(s => s.GetByIdAsync(8)).ReturnsAsync(platform);
+        _mapper.Setup(m => m.Map<SocialMediaPlatformViewModel>(platform)).Returns(viewModel);
+
+        // Act
+        var result = await _controller.DeleteConfirmed(8);
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.Model.Should().Be(viewModel);
+        _controller.ModelState.ErrorCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WhenDeleteFails_AndPlatformNoLongerFound_ShouldRedirectToIndexWithError()
+    {
+        // Arrange
+        _platformService.Setup(s => s.DeleteAsync(8)).ReturnsAsync(false);
+        _platformService.Setup(s => s.GetByIdAsync(8)).ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act
+        var result = await _controller.DeleteConfirmed(8);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        redirectResult.ActionName.Should().Be(nameof(SocialMediaPlatformsController.Index));
+        _controller.TempData["ErrorMessage"].Should().NotBeNull();
+    }
+
+    // ── Authorization attribute assertions ────────────────────────────────────
+
+    [Fact]
+    public void SocialMediaPlatformsController_ClassLevel_ShouldRequireViewerPolicy()
+    {
+        // Arrange & Act
+        var attributes = typeof(SocialMediaPlatformsController)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false);
+
+        // Assert
+        attributes.Should().NotBeEmpty();
+        var authorizeAttribute = (AuthorizeAttribute)attributes.First();
+        authorizeAttribute.Policy.Should().Be("RequireViewer");
+    }
+
+    [Fact]
+    public void Add_Get_Action_ShouldRequireContributorPolicy()
+    {
+        // Arrange & Act
+        var method = typeof(SocialMediaPlatformsController).GetMethod("Add", Type.EmptyTypes);
+
+        // Assert
+        method.Should().NotBeNull();
+        var attributes = method!.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false);
+        attributes.Should().NotBeEmpty();
+        var authorizeAttribute = (AuthorizeAttribute)attributes.First();
+        authorizeAttribute.Policy.Should().Be("RequireContributor");
+    }
+
+    [Fact]
+    public void Delete_Get_Action_ShouldRequireAdministratorPolicy()
+    {
+        // Arrange & Act
+        var method = typeof(SocialMediaPlatformsController).GetMethod("Delete", new[] { typeof(int) });
+
+        // Assert
+        method.Should().NotBeNull();
+        var attributes = method!.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false);
+        attributes.Should().NotBeEmpty();
+        var authorizeAttribute = (AuthorizeAttribute)attributes.First();
+        authorizeAttribute.Policy.Should().Be("RequireAdministrator");
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/SocialMediaPlatformsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/SocialMediaPlatformsController.cs
@@ -47,6 +47,7 @@ public class SocialMediaPlatformsController : Controller
     /// Creates a new social media platform.
     /// </summary>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireContributor")]
     public async Task<IActionResult> Add(SocialMediaPlatformViewModel viewModel)
     {
@@ -87,6 +88,7 @@ public class SocialMediaPlatformsController : Controller
     /// Saves changes to an existing social media platform.
     /// </summary>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireContributor")]
     public async Task<IActionResult> Edit(SocialMediaPlatformViewModel viewModel)
     {

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/SocialMediaPlatformsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/SocialMediaPlatformsController.cs
@@ -1,0 +1,175 @@
+using AutoMapper;
+using JosephGuadagno.Broadcasting.Web.Models;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Web.Controllers;
+
+/// <summary>
+/// Controller for managing social media platforms in the admin UI.
+/// </summary>
+[Authorize(Policy = "RequireViewer")]
+public class SocialMediaPlatformsController : Controller
+{
+    private readonly ISocialMediaPlatformService _platformService;
+    private readonly IMapper _mapper;
+
+    /// <summary>
+    /// Constructor for SocialMediaPlatformsController.
+    /// </summary>
+    public SocialMediaPlatformsController(ISocialMediaPlatformService platformService, IMapper mapper)
+    {
+        _platformService = platformService;
+        _mapper = mapper;
+    }
+
+    /// <summary>
+    /// Lists all social media platforms (active and inactive).
+    /// </summary>
+    public async Task<IActionResult> Index()
+    {
+        var platforms = await _platformService.GetAllAsync();
+        var viewModels = _mapper.Map<List<SocialMediaPlatformViewModel>>(platforms);
+        return View(viewModels);
+    }
+
+    /// <summary>
+    /// Shows the form to add a new social media platform.
+    /// </summary>
+    [Authorize(Policy = "RequireContributor")]
+    public IActionResult Add()
+    {
+        return View(new SocialMediaPlatformViewModel { IsActive = true });
+    }
+
+    /// <summary>
+    /// Creates a new social media platform.
+    /// </summary>
+    [HttpPost]
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> Add(SocialMediaPlatformViewModel viewModel)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(viewModel);
+        }
+
+        var platform = _mapper.Map<Domain.Models.SocialMediaPlatform>(viewModel);
+        var created = await _platformService.AddAsync(platform);
+        if (created is null)
+        {
+            TempData["ErrorMessage"] = "Failed to add the social media platform.";
+            return View(viewModel);
+        }
+
+        TempData["SuccessMessage"] = $"Social media platform '{created.Name}' added successfully.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Shows the edit form for a social media platform.
+    /// </summary>
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> Edit(int id)
+    {
+        var platform = await _platformService.GetByIdAsync(id);
+        if (platform is null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = _mapper.Map<SocialMediaPlatformViewModel>(platform);
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Saves changes to an existing social media platform.
+    /// </summary>
+    [HttpPost]
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> Edit(SocialMediaPlatformViewModel viewModel)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(viewModel);
+        }
+
+        var platform = _mapper.Map<Domain.Models.SocialMediaPlatform>(viewModel);
+        var updated = await _platformService.UpdateAsync(platform);
+        if (updated is null)
+        {
+            TempData["ErrorMessage"] = "Failed to update the social media platform.";
+            return View(viewModel);
+        }
+
+        TempData["SuccessMessage"] = $"Social media platform '{updated.Name}' updated successfully.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Toggles the IsActive status of a social media platform (soft delete / reactivate).
+    /// </summary>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> ToggleActive(int id)
+    {
+        var success = await _platformService.ToggleActiveAsync(id);
+        if (!success)
+        {
+            TempData["ErrorMessage"] = "Failed to toggle the platform's active status.";
+        }
+        else
+        {
+            TempData["SuccessMessage"] = "Platform active status toggled successfully.";
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Shows the delete confirmation page for a social media platform.
+    /// </summary>
+    [HttpGet]
+    [Authorize(Policy = "RequireAdministrator")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var platform = await _platformService.GetByIdAsync(id);
+        if (platform is null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = _mapper.Map<SocialMediaPlatformViewModel>(platform);
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Permanently deletes a social media platform after confirmation.
+    /// </summary>
+    [HttpPost]
+    [ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireAdministrator")]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var result = await _platformService.DeleteAsync(id);
+        if (result)
+        {
+            TempData["SuccessMessage"] = "Social media platform deleted successfully.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var platform = await _platformService.GetByIdAsync(id);
+        if (platform is not null)
+        {
+            var viewModel = _mapper.Map<SocialMediaPlatformViewModel>(platform);
+            ModelState.AddModelError(string.Empty, "Failed to delete the social media platform.");
+            return View(viewModel);
+        }
+
+        TempData["ErrorMessage"] = "Failed to delete the social media platform.";
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISocialMediaPlatformService.cs
@@ -1,0 +1,39 @@
+using JosephGuadagno.Broadcasting.Domain.Models;
+
+namespace JosephGuadagno.Broadcasting.Web.Interfaces;
+
+/// <summary>
+/// Service interface for interacting with the Social Media Platforms API
+/// </summary>
+public interface ISocialMediaPlatformService
+{
+    /// <summary>
+    /// Gets all social media platforms including inactive ones (for admin use)
+    /// </summary>
+    Task<List<SocialMediaPlatform>> GetAllAsync();
+
+    /// <summary>
+    /// Gets a social media platform by its ID
+    /// </summary>
+    Task<SocialMediaPlatform?> GetByIdAsync(int id);
+
+    /// <summary>
+    /// Adds a new social media platform
+    /// </summary>
+    Task<SocialMediaPlatform?> AddAsync(SocialMediaPlatform platform);
+
+    /// <summary>
+    /// Updates an existing social media platform
+    /// </summary>
+    Task<SocialMediaPlatform?> UpdateAsync(SocialMediaPlatform platform);
+
+    /// <summary>
+    /// Toggles the IsActive status of a social media platform (soft delete / reactivate)
+    /// </summary>
+    Task<bool> ToggleActiveAsync(int id);
+
+    /// <summary>
+    /// Deletes a social media platform via the API
+    /// </summary>
+    Task<bool> DeleteAsync(int id);
+}

--- a/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
@@ -51,5 +51,16 @@ public class WebMappingProfile: Profile
         
         // RBAC Phase 2 mappings
         CreateMap<Domain.Models.Role, Models.RoleViewModel>();
+
+        // SocialMediaPlatform mappings (Issue #678)
+        CreateMap<Domain.Models.SocialMediaPlatform, Models.SocialMediaPlatformViewModel>();
+        CreateMap<Models.SocialMediaPlatformViewModel, Domain.Models.SocialMediaPlatform>();
+
+        // EngagementSocialMediaPlatform mappings (Issue #679 - included here to fix build)
+        CreateMap<Domain.Models.EngagementSocialMediaPlatform, Models.EngagementSocialMediaPlatformViewModel>()
+            .ForMember(destination => destination.PlatformName,
+                options => options.MapFrom(source => source.SocialMediaPlatform != null ? source.SocialMediaPlatform.Name : null))
+            .ForMember(destination => destination.PlatformIcon,
+                options => options.MapFrom(source => source.SocialMediaPlatform != null ? source.SocialMediaPlatform.Icon : null));
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Models/EngagementSocialMediaPlatformViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/EngagementSocialMediaPlatformViewModel.cs
@@ -1,0 +1,32 @@
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+/// <summary>
+/// View model representing a social media platform associated with an engagement
+/// </summary>
+public class EngagementSocialMediaPlatformViewModel
+{
+    /// <summary>
+    /// The identifier of the engagement
+    /// </summary>
+    public int EngagementId { get; set; }
+
+    /// <summary>
+    /// The identifier of the social media platform
+    /// </summary>
+    public int SocialMediaPlatformId { get; set; }
+
+    /// <summary>
+    /// The handle or hashtag for this engagement on the platform
+    /// </summary>
+    public string? Handle { get; set; }
+
+    /// <summary>
+    /// The name of the social media platform
+    /// </summary>
+    public string? PlatformName { get; set; }
+
+    /// <summary>
+    /// The Bootstrap icon class for the platform
+    /// </summary>
+    public string? PlatformIcon { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Models/EngagementViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/EngagementViewModel.cs
@@ -76,6 +76,11 @@ public class EngagementViewModel
     public List<TalkViewModel>? Talks { get; set; }
 
     /// <summary>
+    /// A list of social media platforms associated with this engagement
+    /// </summary>
+    public List<EngagementSocialMediaPlatformViewModel>? SocialMediaPlatforms { get; set; }
+
+    /// <summary>
     /// Returns a list of TimeZones
     /// </summary>
     public List<string> TimeZones

--- a/src/JosephGuadagno.Broadcasting.Web/Models/SocialMediaPlatformViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/SocialMediaPlatformViewModel.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+/// <summary>
+/// View model for a social media platform
+/// </summary>
+public class SocialMediaPlatformViewModel
+{
+    /// <summary>
+    /// The unique identifier for the social media platform
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The name of the social media platform (e.g., Twitter, BlueSky, LinkedIn)
+    /// </summary>
+    [Required(ErrorMessage = "Name is required")]
+    [MaxLength(100, ErrorMessage = "Name cannot exceed 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The canonical URL for the platform (e.g., https://twitter.com)
+    /// </summary>
+    [Url(ErrorMessage = "Please enter a valid URL")]
+    [MaxLength(500, ErrorMessage = "URL cannot exceed 500 characters")]
+    public string? Url { get; set; }
+
+    /// <summary>
+    /// The Bootstrap icon class name for the platform (e.g., bi-twitter-x)
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Icon class cannot exceed 100 characters")]
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// Indicates if the platform is active (soft delete)
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -249,6 +249,7 @@ void ConfigureApplication(IServiceCollection services)
     services.TryAddScoped<IEngagementService, EngagementService>();
     services.TryAddScoped<IScheduledItemService, ScheduledItemService>();
     services.TryAddScoped<IMessageTemplateService, MessageTemplateService>();
+    services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();
 
     // RBAC Phase 1
     services.TryAddScoped<IApplicationUserDataStore, ApplicationUserDataStore>();

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -158,6 +159,8 @@ builder.Services.AddControllersWithViews(options =>
         .RequireAuthenticatedUser()
         .Build();
     options.Filters.Add(new AuthorizeFilter(policy));
+    // Validate antiforgery tokens on all unsafe methods (POST/PUT/DELETE) globally
+    options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
 }).AddMicrosoftIdentityUI();
 
 // Configure authorization policies

--- a/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
@@ -9,7 +9,7 @@ namespace JosephGuadagno.Broadcasting.Web.Services;
 /// <summary>
 /// Calls out to the Social Media Platforms API
 /// </summary>
-public class SocialMediaPlatformService(IDownstreamApi apiClient) : ISocialMediaPlatformService
+public class SocialMediaPlatformService(IDownstreamApi apiClient, ILogger<SocialMediaPlatformService> logger) : ISocialMediaPlatformService
 {
     private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
     private const string PlatformBaseUrl = "/socialmediaplatforms";
@@ -82,6 +82,12 @@ public class SocialMediaPlatformService(IDownstreamApi apiClient) : ISocialMedia
             options.RelativePath = $"{PlatformBaseUrl}/{id}";
             options.HttpMethod = HttpMethod.Delete.Method;
         });
-        return response is { StatusCode: HttpStatusCode.NoContent };
+
+        if (response is { StatusCode: HttpStatusCode.NoContent or HttpStatusCode.NotFound })
+            return true;
+
+        logger.LogWarning("Unexpected status {StatusCode} deleting platform {PlatformId}",
+            response?.StatusCode, id);
+        return false;
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+
+using Microsoft.Identity.Abstractions;
+
+namespace JosephGuadagno.Broadcasting.Web.Services;
+
+/// <summary>
+/// Calls out to the Social Media Platforms API
+/// </summary>
+public class SocialMediaPlatformService(IDownstreamApi apiClient) : ISocialMediaPlatformService
+{
+    private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
+    private const string PlatformBaseUrl = "/socialmediaplatforms";
+
+    /// <summary>
+    /// Gets all social media platforms including inactive ones (for admin use)
+    /// </summary>
+    public async Task<List<SocialMediaPlatform>> GetAllAsync()
+    {
+        var platforms = await apiClient.GetForUserAsync<List<SocialMediaPlatform>>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{PlatformBaseUrl}?includeInactive=true";
+        });
+        return platforms ?? [];
+    }
+
+    /// <summary>
+    /// Gets a social media platform by its ID
+    /// </summary>
+    public async Task<SocialMediaPlatform?> GetByIdAsync(int id)
+    {
+        return await apiClient.GetForUserAsync<SocialMediaPlatform>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{PlatformBaseUrl}/{id}";
+        });
+    }
+
+    /// <summary>
+    /// Adds a new social media platform
+    /// </summary>
+    public async Task<SocialMediaPlatform?> AddAsync(SocialMediaPlatform platform)
+    {
+        return await apiClient.PostForUserAsync<SocialMediaPlatform, SocialMediaPlatform>(ApiServiceName, platform, options =>
+        {
+            options.RelativePath = PlatformBaseUrl;
+        });
+    }
+
+    /// <summary>
+    /// Updates an existing social media platform
+    /// </summary>
+    public async Task<SocialMediaPlatform?> UpdateAsync(SocialMediaPlatform platform)
+    {
+        return await apiClient.PutForUserAsync<SocialMediaPlatform, SocialMediaPlatform>(ApiServiceName, platform, options =>
+        {
+            options.RelativePath = $"{PlatformBaseUrl}/{platform.Id}";
+        });
+    }
+
+    /// <summary>
+    /// Toggles the IsActive status of a social media platform (soft delete / reactivate)
+    /// </summary>
+    public async Task<bool> ToggleActiveAsync(int id)
+    {
+        var platform = await GetByIdAsync(id);
+        if (platform is null) return false;
+
+        platform.IsActive = !platform.IsActive;
+        var updated = await UpdateAsync(platform);
+        return updated is not null;
+    }
+
+    /// <summary>
+    /// Deletes a social media platform via the API
+    /// </summary>
+    public async Task<bool> DeleteAsync(int id)
+    {
+        var response = await apiClient.CallApiForUserAsync<HttpResponseMessage>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{PlatformBaseUrl}/{id}";
+            options.HttpMethod = HttpMethod.Delete.Method;
+        });
+        return response is { StatusCode: HttpStatusCode.NoContent };
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
@@ -74,6 +74,9 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="MessageTemplates" asp-action="Index">Message Templates</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-controller="SocialMediaPlatforms" asp-action="Index">Platforms</a>
+                        </li>
                         @if (User.IsInRole("Administrator"))
                         {
                             <li class="nav-item dropdown">

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
@@ -74,9 +74,12 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="MessageTemplates" asp-action="Index">Message Templates</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="SocialMediaPlatforms" asp-action="Index">Platforms</a>
-                        </li>
+                        @if (User.IsInRole("Administrator") || User.IsInRole("Contributor"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-area="" asp-controller="SocialMediaPlatforms" asp-action="Index">Platforms</a>
+                            </li>
+                        }
                         @if (User.IsInRole("Administrator"))
                         {
                             <li class="nav-item dropdown">

--- a/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Add.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Add.cshtml
@@ -1,0 +1,82 @@
+@model JosephGuadagno.Broadcasting.Web.Models.SocialMediaPlatformViewModel
+@{
+    ViewData["Title"] = "Add Social Media Platform";
+}
+
+<h1>
+    <i class="bi bi-plus-circle me-2"></i>Add Social Media Platform
+</h1>
+<p class="lead">Enter the details for the new social media platform.</p>
+
+<div class="row">
+    <div class="col-md-8">
+        <form asp-action="Add">
+            <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+            <div class="mb-3">
+                <label asp-for="Name" class="form-label">Name <span class="text-danger">*</span></label>
+                <input asp-for="Name" type="text" class="form-control" autocomplete="off"
+                       placeholder="e.g. Twitter, BlueSky, LinkedIn" aria-describedby="val-Name" />
+                <span id="val-Name" asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Url" class="form-label">URL</label>
+                <input asp-for="Url" type="url" class="form-control" autocomplete="url"
+                       placeholder="https://twitter.com" aria-describedby="val-Url" />
+                <div class="form-text">The canonical URL for the platform homepage.</div>
+                <span id="val-Url" asp-validation-for="Url" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Icon" class="form-label">Bootstrap Icon Class</label>
+                <div class="input-group">
+                    <span class="input-group-text">
+                        <i id="icon-preview" class="bi bi-question-circle"></i>
+                    </span>
+                    <input asp-for="Icon" type="text" class="form-control" autocomplete="off"
+                           placeholder="e.g. bi-twitter-x" aria-describedby="val-Icon"
+                           id="icon-input" />
+                </div>
+                <div class="form-text">
+                    Enter a <a href="https://icons.getbootstrap.com/" target="_blank" rel="noopener noreferrer">Bootstrap Icon</a> class name (e.g. <code>bi-twitter-x</code>, <code>bi-linkedin</code>, <code>bi-facebook</code>).
+                </div>
+                <span id="val-Icon" asp-validation-for="Icon" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <div class="form-check">
+                    <input asp-for="IsActive" class="form-check-input" type="checkbox" />
+                    <label asp-for="IsActive" class="form-check-label">Active</label>
+                </div>
+                <div class="form-text">Uncheck to create the platform in an inactive state.</div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-floppy me-2"></i>Save Platform
+                </button>
+                <a asp-action="Index" asp-controller="SocialMediaPlatforms" class="btn btn-secondary">
+                    <i class="bi bi-x me-2"></i>Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+    <script>
+        // Live icon preview
+        const iconInput = document.getElementById('icon-input');
+        const iconPreview = document.getElementById('icon-preview');
+
+        function updateIconPreview() {
+            const iconClass = iconInput.value.trim();
+            iconPreview.className = iconClass ? `bi ${iconClass}` : 'bi bi-question-circle';
+        }
+
+        iconInput.addEventListener('input', updateIconPreview);
+        updateIconPreview();
+    </script>
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Delete.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Delete.cshtml
@@ -1,0 +1,90 @@
+@model JosephGuadagno.Broadcasting.Web.Models.SocialMediaPlatformViewModel
+@{
+    ViewData["Title"] = "Delete Social Media Platform";
+}
+
+<h1>
+    <i class="bi bi-trash me-2 text-danger"></i>Delete Social Media Platform
+</h1>
+
+<div class="alert alert-danger" role="alert">
+    <h4 class="alert-heading">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>Warning — This action is irreversible
+    </h4>
+    <p>You are about to permanently delete this social media platform. This cannot be undone.</p>
+    <hr>
+    <p class="mb-0">
+        <strong>Recommendation:</strong> Consider using the
+        <a asp-action="Index" asp-controller="SocialMediaPlatforms" class="alert-link">Toggle Active</a>
+        button instead to deactivate the platform without permanently removing it.
+    </p>
+</div>
+
+@if (Model != null)
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <strong>Platform Details</strong>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-3">ID</dt>
+                <dd class="col-sm-9">@Model.Id</dd>
+
+                <dt class="col-sm-3">Name</dt>
+                <dd class="col-sm-9">
+                    @if (!string.IsNullOrEmpty(Model.Icon))
+                    {
+                        <i class="bi @Model.Icon me-2"></i>
+                    }
+                    @Model.Name
+                </dd>
+
+                <dt class="col-sm-3">URL</dt>
+                <dd class="col-sm-9">
+                    @if (!string.IsNullOrEmpty(Model.Url))
+                    {
+                        <a href="@Model.Url" target="_blank" rel="noopener noreferrer">@Model.Url</a>
+                    }
+                    else
+                    {
+                        <span class="text-muted fst-italic">—</span>
+                    }
+                </dd>
+
+                <dt class="col-sm-3">Status</dt>
+                <dd class="col-sm-9">
+                    @if (Model.IsActive)
+                    {
+                        <i class="bi bi-check-circle-fill text-success me-1"></i><span class="text-success">Active</span>
+                    }
+                    else
+                    {
+                        <i class="bi bi-x-circle-fill text-danger me-1"></i><span class="text-danger">Inactive</span>
+                    }
+                </dd>
+            </dl>
+        </div>
+    </div>
+
+    @if (!ViewData.ModelState.IsValid)
+    {
+        <div class="alert alert-danger" role="alert">
+            <i class="bi bi-exclamation-circle-fill me-2"></i>
+            Failed to delete the platform. Please try again.
+        </div>
+    }
+
+    <form asp-action="Delete" method="post">
+        @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="Id" />
+        <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-danger">
+                <i class="bi bi-trash me-2"></i>Confirm Delete
+            </button>
+            <a asp-action="Index" asp-controller="SocialMediaPlatforms" class="btn btn-secondary">
+                <i class="bi bi-x me-2"></i>Cancel
+            </a>
+        </div>
+    </form>
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Edit.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Edit.cshtml
@@ -1,0 +1,82 @@
+@model JosephGuadagno.Broadcasting.Web.Models.SocialMediaPlatformViewModel
+@{
+    ViewData["Title"] = "Edit Social Media Platform";
+}
+
+<h1>
+    <i class="bi bi-pencil-square me-2"></i>Edit Social Media Platform
+</h1>
+<p class="lead">Update the details for <strong>@Model.Name</strong>.</p>
+
+<div class="row">
+    <div class="col-md-8">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+            <input type="hidden" asp-for="Id" />
+
+            <div class="mb-3">
+                <label asp-for="Name" class="form-label">Name <span class="text-danger">*</span></label>
+                <input asp-for="Name" type="text" class="form-control" autocomplete="off"
+                       aria-describedby="val-Name" />
+                <span id="val-Name" asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Url" class="form-label">URL</label>
+                <input asp-for="Url" type="url" class="form-control" autocomplete="url"
+                       aria-describedby="val-Url" />
+                <div class="form-text">The canonical URL for the platform homepage.</div>
+                <span id="val-Url" asp-validation-for="Url" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Icon" class="form-label">Bootstrap Icon Class</label>
+                <div class="input-group">
+                    <span class="input-group-text">
+                        <i id="icon-preview" class="bi @(string.IsNullOrEmpty(Model.Icon) ? "bi-question-circle" : Model.Icon)"></i>
+                    </span>
+                    <input asp-for="Icon" type="text" class="form-control" autocomplete="off"
+                           placeholder="e.g. bi-twitter-x" aria-describedby="val-Icon"
+                           id="icon-input" />
+                </div>
+                <div class="form-text">
+                    Enter a <a href="https://icons.getbootstrap.com/" target="_blank" rel="noopener noreferrer">Bootstrap Icon</a> class name (e.g. <code>bi-twitter-x</code>, <code>bi-linkedin</code>, <code>bi-facebook</code>).
+                </div>
+                <span id="val-Icon" asp-validation-for="Icon" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <div class="form-check">
+                    <input asp-for="IsActive" class="form-check-input" type="checkbox" />
+                    <label asp-for="IsActive" class="form-check-label">Active</label>
+                </div>
+                <div class="form-text">Uncheck to deactivate this platform without deleting it.</div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-floppy me-2"></i>Save Changes
+                </button>
+                <a asp-action="Index" asp-controller="SocialMediaPlatforms" class="btn btn-secondary">
+                    <i class="bi bi-x me-2"></i>Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+    <script>
+        // Live icon preview
+        const iconInput = document.getElementById('icon-input');
+        const iconPreview = document.getElementById('icon-preview');
+
+        function updateIconPreview() {
+            const iconClass = iconInput.value.trim();
+            iconPreview.className = iconClass ? `bi ${iconClass}` : 'bi bi-question-circle';
+        }
+
+        iconInput.addEventListener('input', updateIconPreview);
+    </script>
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/SocialMediaPlatforms/Index.cshtml
@@ -1,0 +1,111 @@
+@model List<JosephGuadagno.Broadcasting.Web.Models.SocialMediaPlatformViewModel>
+@{
+    ViewData["Title"] = "Social Media Platforms";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>
+        <i class="bi bi-share me-2"></i>Social Media Platforms
+    </h1>
+    @if (User.IsInRole("Administrator") || User.IsInRole("Contributor"))
+    {
+        <a asp-action="Add" asp-controller="SocialMediaPlatforms" class="btn btn-primary">
+            <i class="bi bi-plus-circle me-2"></i>Add New Platform
+        </a>
+    }
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th scope="col" class="col-1">Icon</th>
+                <th scope="col">Name</th>
+                <th scope="col">URL</th>
+                <th scope="col" class="col-1 text-center">Active</th>
+                <th scope="col" class="col-3 text-end">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var platform in Model)
+            {
+                <tr class="@(platform.IsActive ? string.Empty : "table-secondary text-muted")">
+                    <td class="text-center">
+                        @if (!string.IsNullOrEmpty(platform.Icon))
+                        {
+                            <i class="bi @platform.Icon fs-4" title="@platform.Icon"></i>
+                        }
+                        else
+                        {
+                            <i class="bi bi-question-circle fs-4 text-muted" title="No icon set"></i>
+                        }
+                    </td>
+                    <td>@platform.Name</td>
+                    <td>
+                        @if (!string.IsNullOrEmpty(platform.Url))
+                        {
+                            <a href="@platform.Url" target="_blank" rel="noopener noreferrer">
+                                @platform.Url
+                                <i class="bi bi-box-arrow-up-right ms-1 small"></i>
+                            </a>
+                        }
+                        else
+                        {
+                            <span class="text-muted fst-italic">—</span>
+                        }
+                    </td>
+                    <td class="text-center">
+                        @if (platform.IsActive)
+                        {
+                            <i class="bi bi-check-circle-fill text-success fs-5" title="Active"></i>
+                        }
+                        else
+                        {
+                            <i class="bi bi-x-circle-fill text-danger fs-5" title="Inactive"></i>
+                        }
+                    </td>
+                    <td class="text-end">
+                        @if (User.IsInRole("Administrator") || User.IsInRole("Contributor"))
+                        {
+                            <a asp-action="Edit" asp-controller="SocialMediaPlatforms" asp-route-id="@platform.Id"
+                               class="btn btn-sm btn-outline-secondary" title="Edit">
+                                <i class="bi bi-pencil-square"></i>
+                            </a>
+
+                            <form asp-action="ToggleActive" asp-controller="SocialMediaPlatforms"
+                                  asp-route-id="@platform.Id" method="post" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <button type="submit"
+                                        class="btn btn-sm @(platform.IsActive ? "btn-outline-warning" : "btn-outline-success")"
+                                        title="@(platform.IsActive ? "Deactivate" : "Reactivate")">
+                                    <i class="bi @(platform.IsActive ? "bi-toggle-on" : "bi-toggle-off")"></i>
+                                </button>
+                            </form>
+                        }
+                        @if (User.IsInRole("Administrator"))
+                        {
+                            <a asp-action="Delete" asp-controller="SocialMediaPlatforms" asp-route-id="@platform.Id"
+                               class="btn btn-sm btn-danger" title="Delete">
+                                <i class="bi bi-trash"></i>
+                            </a>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>
+
+@if (!Model.Any())
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-share fs-1 mb-3 d-block"></i>
+        <p>No social media platforms found.</p>
+        @if (User.IsInRole("Administrator") || User.IsInRole("Contributor"))
+        {
+            <a asp-action="Add" asp-controller="SocialMediaPlatforms" class="btn btn-primary">
+                <i class="bi bi-plus-circle me-2"></i>Add the first platform
+            </a>
+        }
+    </div>
+}


### PR DESCRIPTION
## Summary

Implements the Web admin UI for managing social media platforms.

Closes #678
Part of #667

## Changes

### New Files
- **Web Controller**: `SocialMediaPlatformsController.cs` -- Index, Add, Edit, ToggleActive (soft-delete/reactivate), Delete actions
- **Interface**: `ISocialMediaPlatformService.cs` -- API-backed service contract
- **Service**: `SocialMediaPlatformService.cs` -- calls API via `IDownstreamApi` (follows EngagementService pattern)
- **ViewModel**: `SocialMediaPlatformViewModel.cs` -- with `[Required]` and `[Url]` validation
- **Views**: `Views/SocialMediaPlatforms/` -- Index, Add, Edit, Delete (Bootstrap 5, Bootstrap Icons)
- **ViewModel**: `EngagementSocialMediaPlatformViewModel.cs` -- included to fix broken build from PR #684

### Modified Files
- **`ISocialMediaPlatformManager.cs`** -- added `GetAllIncludingInactiveAsync()` (admin list shows all)
- **`SocialMediaPlatformManager.cs`** -- implemented `GetAllIncludingInactiveAsync()`
- **API `SocialMediaPlatformsController.cs`** -- added `?includeInactive=true` query param
- **`WebMappingProfile.cs`** -- added `SocialMediaPlatform -> SocialMediaPlatformViewModel` mappings and `EngagementSocialMediaPlatform -> EngagementSocialMediaPlatformViewModel` mapping
- **`EngagementViewModel.cs`** -- added `SocialMediaPlatforms` property (fixes broken build from PR #684)
- **`Program.cs`** -- registered `ISocialMediaPlatformService -> SocialMediaPlatformService`
- **`_Layout.cshtml`** -- added Platforms nav link

## Build Fix (from PR #684)
PR #684 introduced `WebMappingProfile.cs` references to `EngagementViewModel.SocialMediaPlatforms` without adding that property to the ViewModel. This PR fixes the broken build by adding the missing property and its backing type `EngagementSocialMediaPlatformViewModel`.

## Acceptance Criteria
- [x] Create SocialMediaPlatformsController MVC controller
- [x] Index action/view: list all platforms with active/inactive indicator
- [x] Create action/view: form to add new platform (Name, Url, Icon class, IsActive)
- [x] Edit action/view: form to edit existing platform
- [x] Soft-delete action: toggle IsActive status (ToggleActive POST action)
- [x] Display Bootstrap icons for each platform using the Icon class
- [x] Bootstrap styling consistent with existing admin pages
- [x] Validation: required fields, URL format
- [x] All tests pass (0 failures, integration tests skipped as expected)

## Test Results
- Build succeeded
- 0 test failures (all unit tests pass)
- Network integration tests skipped (expected)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
