### PR TITLE
feat(#679): Engagement social media platform selector

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SocialMediaPlatformsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SocialMediaPlatformsControllerTests.cs
@@ -80,7 +80,7 @@ public class SocialMediaPlatformsControllerTests
             new() { Id = 2, Name = "BlueSky",  Url = "https://bsky.app",     IsActive = true },
             new() { Id = 3, Name = "LinkedIn", Url = "https://linkedin.com", IsActive = true }
         };
-        _managerMock.Setup(m => m.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(platforms);
+        _managerMock.Setup(m => m.GetAllAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(platforms);
 
         var sut = CreateSut(Domain.Scopes.SocialMediaPlatforms.All);
 
@@ -92,14 +92,14 @@ public class SocialMediaPlatformsControllerTests
         var response = okResult.Value.Should().BeAssignableTo<List<SocialMediaPlatformResponse>>().Subject;
         response.Should().HaveCount(3);
         response.Should().BeEquivalentTo(platforms, opts => opts.ExcludingMissingMembers());
-        _managerMock.Verify(m => m.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _managerMock.Verify(m => m.GetAllAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetAllAsync_WhenEmpty_ShouldReturn200WithEmptyList()
     {
         // Arrange
-        _managerMock.Setup(m => m.GetAllAsync(It.IsAny<CancellationToken>()))
+        _managerMock.Setup(m => m.GetAllAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<SocialMediaPlatform>());
 
         var sut = CreateSut(Domain.Scopes.SocialMediaPlatforms.List);
@@ -111,7 +111,7 @@ public class SocialMediaPlatformsControllerTests
         var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         var response = okResult.Value.Should().BeAssignableTo<List<SocialMediaPlatformResponse>>().Subject;
         response.Should().BeEmpty();
-        _managerMock.Verify(m => m.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _managerMock.Verify(m => m.GetAllAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // -------------------------------------------------------------------------

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
@@ -17,6 +17,7 @@ namespace JosephGuadagno.Broadcasting.Api.Controllers;
 [IgnoreAntiforgeryToken]
 [Route("[controller]")]
 [Produces("application/json")]
+[IgnoreAntiforgeryToken]
 public class EngagementsController: ControllerBase
 {
     private readonly IEngagementManager _engagementManager;

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
@@ -358,17 +358,7 @@ public class EngagementsController: ControllerBase
         return new NotFoundResult();
     }
 
-    // =========================================================================
-    // Social Media Platform sub-resource endpoints
-    // =========================================================================
-
-    /// <summary>
-    /// Gets all social media platforms associated with an engagement
-    /// </summary>
-    /// <param name="engagementId">The identifier of the engagement</param>
-    /// <returns>A list of engagement-platform associations</returns>
-    /// <response code="200">If the call was successful</response>
-    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    // ==================================================================    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
     [HttpGet("{engagementId:int}/platforms")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<EngagementSocialMediaPlatformResponse>))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
@@ -17,7 +17,6 @@ namespace JosephGuadagno.Broadcasting.Api.Controllers;
 [IgnoreAntiforgeryToken]
 [Route("[controller]")]
 [Produces("application/json")]
-[IgnoreAntiforgeryToken]
 public class EngagementsController: ControllerBase
 {
     private readonly IEngagementManager _engagementManager;

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISocialMediaPlatformManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISocialMediaPlatformManager.cs
@@ -8,11 +8,12 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 public interface ISocialMediaPlatformManager
 {
     /// <summary>
-    /// Get all active social media platforms
+    /// Get all social media platforms
     /// </summary>
+    /// <param name="includeInactive">Whether to include inactive platforms (default: false)</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>List of active social media platforms</returns>
-    Task<List<SocialMediaPlatform>> GetAllAsync(CancellationToken cancellationToken = default);
+    /// <returns>List of social media platforms</returns>
+    Task<List<SocialMediaPlatform>> GetAllAsync(bool includeInactive = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get all social media platforms including inactive ones (for admin use)

--- a/src/JosephGuadagno.Broadcasting.Managers/SocialMediaPlatformManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/SocialMediaPlatformManager.cs
@@ -16,9 +16,9 @@ public class SocialMediaPlatformManager : ISocialMediaPlatformManager
         _dataStore = dataStore;
     }
 
-    public async Task<List<SocialMediaPlatform>> GetAllAsync(CancellationToken cancellationToken = default)
+    public async Task<List<SocialMediaPlatform>> GetAllAsync(bool includeInactive = false, CancellationToken cancellationToken = default)
     {
-        return await _dataStore.GetAllAsync(includeInactive: false, cancellationToken);
+        return await _dataStore.GetAllAsync(includeInactive: includeInactive, cancellationToken);
     }
 
     public async Task<List<SocialMediaPlatform>> GetAllIncludingInactiveAsync(CancellationToken cancellationToken = default)

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/EngagementsControllerTests.cs
@@ -18,14 +18,16 @@ namespace JosephGuadagno.Broadcasting.Web.Tests.Controllers;
 public class EngagementsControllerTests
 {
     private readonly Mock<IEngagementService> _engagementService;
+    private readonly Mock<ISocialMediaPlatformService> _socialMediaPlatformService;
     private readonly Mock<IMapper> _mapper;
     private readonly EngagementsController _controller;
 
     public EngagementsControllerTests()
     {
         _engagementService = new Mock<IEngagementService>();
+        _socialMediaPlatformService = new Mock<ISocialMediaPlatformService>();
         _mapper = new Mock<IMapper>();
-        _controller = new EngagementsController(_engagementService.Object, _mapper.Object);
+        _controller = new EngagementsController(_engagementService.Object, _socialMediaPlatformService.Object, _mapper.Object);
         
         // Initialize TempData
         var httpContext = new DefaultHttpContext();
@@ -91,7 +93,11 @@ public class EngagementsControllerTests
         var engagement = new Engagement { Id = 1 };
         var viewModel = new EngagementViewModel { Id = 1 };
         _engagementService.Setup(s => s.GetEngagementAsync(1)).ReturnsAsync(engagement);
+        _engagementService.Setup(s => s.GetPlatformsForEngagementAsync(1))
+            .ReturnsAsync(new List<EngagementSocialMediaPlatform>());
         _mapper.Setup(m => m.Map<EngagementViewModel>(It.IsAny<object>())).Returns(viewModel);
+        _mapper.Setup(m => m.Map<List<EngagementSocialMediaPlatformViewModel>>(It.IsAny<object>()))
+            .Returns(new List<EngagementSocialMediaPlatformViewModel>());
 
         // Act
         var result = await _controller.Edit(1);

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
@@ -103,6 +103,7 @@ public class EngagementsController : Controller
     /// <param name="engagementViewModel">The <see cref="EngagementViewModel"/> to edit.</param>
     /// <returns>Upon success, redirects to the <see cref="Details"/> page. Upon failure, redirects to the <see cref="Edit(int)"/> page.</returns>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireContributor")]
     public async Task<IActionResult> Edit(EngagementViewModel engagementViewModel)
     {
@@ -211,6 +212,7 @@ public class EngagementsController : Controller
     /// <param name="engagementViewModel">The <see cref="EngagementViewModel"/></param>
     /// <returns>Upon success, redirects to the <see cref="Details"/> page. Upon failure, redirects to the <see cref="Edit(int)"/> page.</returns>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireContributor")]
     public async Task<RedirectToActionResult> Add(EngagementViewModel engagementViewModel)
     {

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
@@ -66,6 +66,11 @@ public class EngagementsController : Controller
         }
 
         var engagementViewModel = _mapper.Map<EngagementViewModel>(engagement);
+
+        // Load platforms for this engagement
+        var platforms = await _engagementService.GetPlatformsForEngagementAsync(id);
+        engagementViewModel.SocialMediaPlatforms = _mapper.Map<List<EngagementSocialMediaPlatformViewModel>>(platforms);
+
         return View(engagementViewModel);
     }
 
@@ -230,7 +235,7 @@ public class EngagementsController : Controller
     [Authorize(Policy = "RequireContributor")]
     public async Task<IActionResult> AddPlatform(int engagementId)
     {
-        var allPlatforms = await _socialMediaPlatformService.GetAllAsync();
+        var allPlatforms = await _socialMediaPlatformService.GetAllAsync(includeInactive: true);
         ViewBag.Platforms = allPlatforms;
         return View(new EngagementSocialMediaPlatformViewModel { EngagementId = engagementId });
     }

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
@@ -17,16 +17,19 @@ namespace JosephGuadagno.Broadcasting.Web.Controllers;
 public class EngagementsController : Controller
 {
     private readonly IEngagementService _engagementService;
+    private readonly ISocialMediaPlatformService _socialMediaPlatformService;
     private readonly IMapper _mapper;
 
     /// <summary>
     /// The constructor for the EngagementsController.
     /// </summary>
     /// <param name="engagementService">The engagement service</param>
+    /// <param name="socialMediaPlatformService">The social media platform service</param>
     /// <param name="mapper">The mapper service</param>
-    public EngagementsController(IEngagementService engagementService, IMapper mapper)
+    public EngagementsController(IEngagementService engagementService, ISocialMediaPlatformService socialMediaPlatformService, IMapper mapper)
     {
         _engagementService = engagementService;
+        _socialMediaPlatformService = socialMediaPlatformService;
         _mapper = mapper;
     }
 
@@ -81,6 +84,11 @@ public class EngagementsController : Controller
         }
 
         var engagementViewModel = _mapper.Map<EngagementViewModel>(engagement);
+
+        // Load platforms for this engagement
+        var platforms = await _engagementService.GetPlatformsForEngagementAsync(id);
+        engagementViewModel.SocialMediaPlatforms = _mapper.Map<List<EngagementSocialMediaPlatformViewModel>>(platforms);
+
         return View(engagementViewModel);
     }
 
@@ -211,5 +219,74 @@ public class EngagementsController : Controller
         }
         TempData["SuccessMessage"] = "Engagement added successfully.";
         return RedirectToAction("Details", new { id = savedEngagement.Id });
+    }
+
+    /// <summary>
+    /// Shows the form to add a social media platform to an engagement.
+    /// </summary>
+    /// <param name="engagementId">The identity of the engagement</param>
+    /// <returns>The add platform view.</returns>
+    [HttpGet]
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> AddPlatform(int engagementId)
+    {
+        var allPlatforms = await _socialMediaPlatformService.GetAllAsync();
+        ViewBag.Platforms = allPlatforms;
+        return View(new EngagementSocialMediaPlatformViewModel { EngagementId = engagementId });
+    }
+
+    /// <summary>
+    /// Adds a social media platform to an engagement.
+    /// </summary>
+    /// <param name="engagementId">The identity of the engagement</param>
+    /// <param name="vm">The platform view model</param>
+    /// <returns>Upon success, redirects to the Edit page.</returns>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> AddPlatform(int engagementId, EngagementSocialMediaPlatformViewModel vm)
+    {
+        if (!ModelState.IsValid)
+        {
+            var allPlatforms = await _socialMediaPlatformService.GetAllAsync();
+            ViewBag.Platforms = allPlatforms;
+            return View(vm);
+        }
+
+        var result = await _engagementService.AddPlatformToEngagementAsync(engagementId, vm.SocialMediaPlatformId, vm.Handle);
+        if (result is null)
+        {
+            TempData["ErrorMessage"] = "Failed to add platform to engagement.";
+        }
+        else
+        {
+            TempData["SuccessMessage"] = "Platform added successfully.";
+        }
+
+        return RedirectToAction("Edit", new { id = engagementId });
+    }
+
+    /// <summary>
+    /// Removes a social media platform from an engagement.
+    /// </summary>
+    /// <param name="engagementId">The identity of the engagement</param>
+    /// <param name="platformId">The identity of the platform to remove</param>
+    /// <returns>Redirects to the Edit page.</returns>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireContributor")]
+    public async Task<IActionResult> RemovePlatform(int engagementId, int platformId)
+    {
+        var result = await _engagementService.RemovePlatformFromEngagementAsync(engagementId, platformId);
+        if (!result)
+        {
+            TempData["ErrorMessage"] = "Failed to remove platform from engagement.";
+        }
+        else
+        {
+            TempData["SuccessMessage"] = "Platform removed successfully.";
+        }
+
+        return RedirectToAction("Edit", new { id = engagementId });
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/IEngagementService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/IEngagementService.cs
@@ -13,4 +13,7 @@ public interface IEngagementService
     Task<Talk?> SaveEngagementTalkAsync(Talk talk);
     Task<Talk?> GetEngagementTalkAsync(int engagementId, int talkId);
     Task<bool> DeleteEngagementTalkAsync(int engagementId, int talkId);
+    Task<List<EngagementSocialMediaPlatform>> GetPlatformsForEngagementAsync(int engagementId);
+    Task<EngagementSocialMediaPlatform?> AddPlatformToEngagementAsync(int engagementId, int socialMediaPlatformId, string? handle);
+    Task<bool> RemovePlatformFromEngagementAsync(int engagementId, int platformId);
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISocialMediaPlatformService.cs
@@ -10,7 +10,8 @@ public interface ISocialMediaPlatformService
     /// <summary>
     /// Gets all social media platforms including inactive ones (for admin use)
     /// </summary>
-    Task<List<SocialMediaPlatform>> GetAllAsync();
+    /// <param name="includeInactive">Whether to include inactive platforms (default: false)</param>
+    Task<List<SocialMediaPlatform>> GetAllAsync(bool includeInactive = false);
 
     /// <summary>
     /// Gets a social media platform by its ID

--- a/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
@@ -30,9 +30,12 @@ public class WebMappingProfile: Profile
 
         CreateMap<Domain.Models.Engagement, Models.EngagementViewModel>()
             .ForMember(destination => destination.TimeZones, options => options.Ignore())
-            .ForMember(destination => destination.BlueSkyHandle, options => options.Ignore())
-            .ForMember(destination => destination.ConferenceHashtag, options => options.Ignore())
-            .ForMember(destination => destination.ConferenceTwitterHandle, options => options.Ignore());
+            .ForMember(destination => destination.SocialMediaPlatforms, options => options.Ignore());
+        CreateMap<Domain.Models.EngagementSocialMediaPlatform, Models.EngagementSocialMediaPlatformViewModel>()
+            .ForMember(destination => destination.PlatformName,
+                options => options.MapFrom(source => source.SocialMediaPlatform != null ? source.SocialMediaPlatform.Name : null))
+            .ForMember(destination => destination.PlatformIcon,
+                options => options.MapFrom(source => source.SocialMediaPlatform != null ? source.SocialMediaPlatform.Icon : null));
         CreateMap<Domain.Models.Talk, Models.TalkViewModel>()
             .ForMember(destination => destination.BlueSkyHandle, options => options.Ignore());
         CreateMap<Domain.Models.ScheduledItem, Models.ScheduledItemViewModel>()

--- a/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
@@ -59,11 +59,5 @@ public class WebMappingProfile: Profile
         CreateMap<Domain.Models.SocialMediaPlatform, Models.SocialMediaPlatformViewModel>();
         CreateMap<Models.SocialMediaPlatformViewModel, Domain.Models.SocialMediaPlatform>();
 
-        // EngagementSocialMediaPlatform mappings (Issue #679 - included here to fix build)
-        CreateMap<Domain.Models.EngagementSocialMediaPlatform, Models.EngagementSocialMediaPlatformViewModel>()
-            .ForMember(destination => destination.PlatformName,
-                options => options.MapFrom(source => source.SocialMediaPlatform != null ? source.SocialMediaPlatform.Name : null))
-            .ForMember(destination => destination.PlatformIcon,
-                options => options.MapFrom(source => source.SocialMediaPlatform != null ? source.SocialMediaPlatform.Icon : null));
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Models/EngagementViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/EngagementViewModel.cs
@@ -52,21 +52,6 @@ public class EngagementViewModel
     /// <remarks>Could be a discount code for the engagement</remarks>
     public string? Comments { get; set; }
 
-    /// <summary>
-    /// The BlueSky handle for the engagement
-    /// </summary>
-    public string? BlueSkyHandle { get; set; }
-
-    /// <summary>
-    /// The hashtag for the conference
-    /// </summary>
-    public string? ConferenceHashtag { get; set; }
-
-    /// <summary>
-    /// The Twitter/X handle for the conference
-    /// </summary>
-    public string? ConferenceTwitterHandle { get; set; }
-
     public DateTimeOffset CreatedOn { get; set; }
     public DateTimeOffset LastUpdatedOn { get; set; }
 

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -250,6 +250,7 @@ void ConfigureApplication(IServiceCollection services)
 {
     services.AddHttpClient();
     services.TryAddScoped<IEngagementService, EngagementService>();
+    services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();
     services.TryAddScoped<IScheduledItemService, ScheduledItemService>();
     services.TryAddScoped<IMessageTemplateService, MessageTemplateService>();
     services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();

--- a/src/JosephGuadagno.Broadcasting.Web/Services/EngagementService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/EngagementService.cs
@@ -142,4 +142,51 @@ public class EngagementService(IDownstreamApi apiClient): IEngagementService
 
         return response is { StatusCode: HttpStatusCode.NoContent };
     }
+
+    /// <summary>
+    /// Gets all social media platforms for a given engagement
+    /// </summary>
+    /// <param name="engagementId">The identifier of the engagement</param>
+    /// <returns>A list of engagement social media platforms</returns>
+    public async Task<List<EngagementSocialMediaPlatform>> GetPlatformsForEngagementAsync(int engagementId)
+    {
+        var platforms = await apiClient.GetForUserAsync<List<EngagementSocialMediaPlatform>>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{EngagementBaseUrl}/{engagementId}/platforms";
+        });
+        return platforms ?? new List<EngagementSocialMediaPlatform>();
+    }
+
+    /// <summary>
+    /// Adds a social media platform to an engagement
+    /// </summary>
+    /// <param name="engagementId">The identifier of the engagement</param>
+    /// <param name="socialMediaPlatformId">The identifier of the social media platform</param>
+    /// <param name="handle">The handle or hashtag</param>
+    /// <returns>The added platform association, or null if failed</returns>
+    public async Task<EngagementSocialMediaPlatform?> AddPlatformToEngagementAsync(int engagementId, int socialMediaPlatformId, string? handle)
+    {
+        var request = new { SocialMediaPlatformId = socialMediaPlatformId, Handle = handle };
+        var result = await apiClient.PostForUserAsync<object, EngagementSocialMediaPlatform>(ApiServiceName, request, options =>
+        {
+            options.RelativePath = $"{EngagementBaseUrl}/{engagementId}/platforms";
+        });
+        return result;
+    }
+
+    /// <summary>
+    /// Removes a social media platform from an engagement
+    /// </summary>
+    /// <param name="engagementId">The identifier of the engagement</param>
+    /// <param name="platformId">The identifier of the platform</param>
+    /// <returns>True if successful, otherwise false</returns>
+    public async Task<bool> RemovePlatformFromEngagementAsync(int engagementId, int platformId)
+    {
+        var response = await apiClient.CallApiForUserAsync<HttpResponseMessage>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{EngagementBaseUrl}/{engagementId}/platforms/{platformId}";
+            options.HttpMethod = HttpMethod.Delete.Method;
+        });
+        return response is { StatusCode: HttpStatusCode.NoContent };
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
@@ -17,7 +17,7 @@ public class SocialMediaPlatformService(IDownstreamApi apiClient, ILogger<Social
     /// <summary>
     /// Gets all social media platforms including inactive ones (for admin use)
     /// </summary>
-    public async Task<List<SocialMediaPlatform>> GetAllAsync()
+    public async Task<List<SocialMediaPlatform>> GetAllAsync(bool includeInactive = false)
     {
         var platforms = await apiClient.GetForUserAsync<List<SocialMediaPlatform>>(ApiServiceName, options =>
         {

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Add.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Add.cshtml
@@ -42,16 +42,6 @@
         <input asp-for="Comments" type="text" class="form-control" autocomplete="off" aria-describedby="val-Comments" />
         <span id="val-Comments" asp-validation-for="Comments" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="ConferenceHashtag" class="form-label">Conference Hashtag</label>
-        <input asp-for="ConferenceHashtag" type="text" class="form-control" autocomplete="off" placeholder="#MyConf2026" aria-describedby="val-ConferenceHashtag" />
-        <span id="val-ConferenceHashtag" asp-validation-for="ConferenceHashtag" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="ConferenceTwitterHandle" class="form-label">Conference Handle</label>
-        <input asp-for="ConferenceTwitterHandle" type="text" class="form-control" autocomplete="off" placeholder="@@MyConference" aria-describedby="val-ConferenceTwitterHandle" />
-        <span id="val-ConferenceTwitterHandle" asp-validation-for="ConferenceTwitterHandle" class="text-danger"></span>
-    </div>
     <br />
     <button type="submit" class="btn btn-primary">
         <i class="bi bi-floppy me-2"></i>Save

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/AddPlatform.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/AddPlatform.cshtml
@@ -1,0 +1,45 @@
+@model JosephGuadagno.Broadcasting.Web.Models.EngagementSocialMediaPlatformViewModel
+
+@{
+    ViewData["Title"] = "Add Social Media Platform";
+    var platforms = ViewBag.Platforms as List<JosephGuadagno.Broadcasting.Domain.Models.SocialMediaPlatform> ?? new List<JosephGuadagno.Broadcasting.Domain.Models.SocialMediaPlatform>();
+}
+
+<h1>Add Social Media Platform</h1>
+<p class="lead">Add a social media platform to this engagement.</p>
+
+<form asp-action="AddPlatform" asp-route-engagementId="@Model.EngagementId" method="post">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <input type="hidden" asp-for="EngagementId" />
+
+    <div class="mb-3">
+        <label asp-for="SocialMediaPlatformId" class="form-label">Platform</label>
+        <select asp-for="SocialMediaPlatformId" class="form-select" aria-describedby="val-SocialMediaPlatformId">
+            <option value="">Please select a platform</option>
+            @foreach (var platform in platforms)
+            {
+                <option value="@platform.Id">@platform.Name</option>
+            }
+        </select>
+        <span id="val-SocialMediaPlatformId" asp-validation-for="SocialMediaPlatformId" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Handle" class="form-label">Handle / Hashtag</label>
+        <input asp-for="Handle" type="text" class="form-control" autocomplete="off" placeholder="e.g. @@MyConference or #DevConf2026" aria-describedby="val-Handle" />
+        <span id="val-Handle" asp-validation-for="Handle" class="text-danger"></span>
+    </div>
+
+    <br />
+    <button type="submit" class="btn btn-primary">
+        <i class="bi bi-plus-circle me-2"></i>Add Platform
+    </button>
+    <a asp-action="Edit" asp-controller="Engagements" asp-route-id="@Model.EngagementId" class="btn btn-secondary ms-2">
+        <i class="bi bi-x-circle me-2"></i>Cancel
+    </a>
+</form>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Details.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Details.cshtml
@@ -19,21 +19,31 @@
     <dd class="col-sm-9"><local-time value="@Model.EndDateTime" /></dd>
     <dt class="col-sm-3">Comments</dt>
     <dd class="col-sm-9">@Model.Comments</dd>
-    @if (!string.IsNullOrEmpty(Model.ConferenceHashtag))
-    {
-        <dt class="col-sm-3">Conference Hashtag</dt>
-        <dd class="col-sm-9">@Model.ConferenceHashtag</dd>
-    }
-    @if (!string.IsNullOrEmpty(Model.ConferenceTwitterHandle))
-    {
-        <dt class="col-sm-3">Conference Handle</dt>
-        <dd class="col-sm-9">@Model.ConferenceTwitterHandle</dd>
-    }
     <dt class="col-sm-3">Created On</dt>
     <dd class="col-sm-9"><local-time value="@Model.CreatedOn" /></dd>
     <dt class="col-sm-3">Last Updated On</dt>
     <dd class="col-sm-9"><local-time value="@Model.LastUpdatedOn" /></dd>
 </dl>
+@if (Model.SocialMediaPlatforms is not null && Model.SocialMediaPlatforms.Count > 0)
+{
+    <h3>Social Media Platforms</h3>
+    <ul class="list-group mb-3">
+        @foreach (var platform in Model.SocialMediaPlatforms)
+        {
+            <li class="list-group-item">
+                @if (!string.IsNullOrEmpty(platform.PlatformIcon))
+                {
+                    <i class="bi @platform.PlatformIcon me-2"></i>
+                }
+                <strong>@platform.PlatformName</strong>
+                @if (!string.IsNullOrEmpty(platform.Handle))
+                {
+                    <span class="ms-2 text-muted">@platform.Handle</span>
+                }
+            </li>
+        }
+    </ul>
+}
 @if (Model.Talks is not null && Model.Talks.Count > 0)
 {
     <h3>Talks</h3>

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Edit.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Edit.cshtml
@@ -42,16 +42,6 @@
         <input asp-for="Comments" type="text" class="form-control" autocomplete="off" aria-describedby="val-Comments" />
         <span id="val-Comments" asp-validation-for="Comments" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="ConferenceHashtag" class="form-label">Conference Hashtag</label>
-        <input asp-for="ConferenceHashtag" type="text" class="form-control" autocomplete="off" placeholder="#MyConf2026" aria-describedby="val-ConferenceHashtag" />
-        <span id="val-ConferenceHashtag" asp-validation-for="ConferenceHashtag" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="ConferenceTwitterHandle" class="form-label">Conference Handle</label>
-        <input asp-for="ConferenceTwitterHandle" type="text" class="form-control" autocomplete="off" placeholder="@@MyConference" aria-describedby="val-ConferenceTwitterHandle" />
-        <span id="val-ConferenceTwitterHandle" asp-validation-for="ConferenceTwitterHandle" class="text-danger"></span>
-    </div>
     <br />
     <button type="submit" class="btn btn-primary">
         <i class="bi bi-floppy me-2"></i>Save
@@ -99,6 +89,50 @@
 
 <a asp-action="Add" asp-controller="Talks" asp-route-engagementId="@Model.Id" class="btn btn-primary">
     <i class="bi bi-easel me-2"></i>Add New Talk
+</a>
+
+<h2 class="pt-4">Social Media Platforms</h2>
+<table class="table table-striped">
+    <thead>
+    <tr>
+        <th scope="col">Platform</th>
+        <th scope="col">Handle</th>
+        <th scope="col">&nbsp;</th>
+    </tr>
+    </thead>
+    <tbody>
+    @if (Model.SocialMediaPlatforms is null || Model.SocialMediaPlatforms.Count == 0)
+    {
+        <tr><td colspan="3">No social media platforms configured for this engagement</td></tr>
+    }
+    else
+    {
+        @foreach (var platform in Model.SocialMediaPlatforms)
+        {
+            <tr>
+                <td>
+                    @if (!string.IsNullOrEmpty(platform.PlatformIcon))
+                    {
+                        <i class="bi @platform.PlatformIcon me-1"></i>
+                    }
+                    @platform.PlatformName
+                </td>
+                <td>@platform.Handle</td>
+                <td class="text-end">
+                    <form asp-action="RemovePlatform" asp-route-engagementId="@Model.Id" asp-route-platformId="@platform.SocialMediaPlatformId" method="post" class="d-inline">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="btn btn-danger btn-sm">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </form>
+                </td>
+            </tr>
+        }
+    }
+    </tbody>
+</table>
+<a asp-action="AddPlatform" asp-controller="Engagements" asp-route-engagementId="@Model.Id" class="btn btn-secondary">
+    <i class="bi bi-plus-circle me-2"></i>Add Platform
 </a>
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }


### PR DESCRIPTION
Closes #679
Part of #667

## Summary

Implements the social media platform selector on the Engagement edit page, replacing the legacy flat fields (`BlueSkyHandle`, `ConferenceHashtag`, `ConferenceTwitterHandle`) with a proper relational platform-association model.

## Changes

### API
- **3 new endpoints** on `EngagementsController`:
  - `GET /engagements/{engagementId}/platforms` -- list platforms for an engagement
  - `POST /engagements/{engagementId}/platforms` -- add a platform to an engagement
  - `DELETE /engagements/{engagementId}/platforms/{platformId}` -- remove a platform
- Added `EngagementSocialMediaPlatformResponse` AutoMapper mapping

### Web -- Models
- Created `EngagementSocialMediaPlatformViewModel` (`EngagementId`, `SocialMediaPlatformId`, `Handle`, `PlatformName`, `PlatformIcon`)
- Created `SocialMediaPlatformViewModel`
- **Removed** legacy `BlueSkyHandle`, `ConferenceHashtag`, `ConferenceTwitterHandle` from `EngagementViewModel`
- **Added** `List<EngagementSocialMediaPlatformViewModel>?` `SocialMediaPlatforms` to `EngagementViewModel`

### Web -- Services
- Created `ISocialMediaPlatformService` + `SocialMediaPlatformService`
- Added `GetPlatformsForEngagementAsync`, `AddPlatformToEngagementAsync`, `RemovePlatformFromEngagementAsync` to `IEngagementService` + `EngagementService`

### Web -- Controllers
- Updated `EngagementsController`: inject `ISocialMediaPlatformService`, load platforms in Edit GET, added `AddPlatform` GET/POST and `RemovePlatform` POST
- Created `SocialMediaPlatformsController` (full CRUD admin for managing platform definitions)

### Web -- Views
- `Edit.cshtml`: removed legacy fields, added Social Media Platforms table with remove buttons
- `Add.cshtml`: removed legacy fields
- `Details.cshtml`: removed legacy fields, added platforms display section
- New `AddPlatform.cshtml`: dropdown selector + handle input
- New `SocialMediaPlatforms/` admin views (Index, Add, Edit, Delete)

### AutoMapper
- `WebMappingProfile`: removed stale `Ignore()` calls for removed properties; added `EngagementSocialMediaPlatform -> EngagementSocialMediaPlatformViewModel` and `SocialMediaPlatform -> SocialMediaPlatformViewModel` mappings

### Tests
- Fixed `EngagementsControllerTests` to inject `ISocialMediaPlatformService` mock and set up platform call stubs

## Test Results
- Web.Tests: 105/105 passed
- Api.Tests: 43/43 passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
