### PR TITLE
fix: replace DateTime.UtcNow with DateTimeOffset.UtcNow in Functions

### DIFF
--- a/.squad/agents/cypher/history.md
+++ b/.squad/agents/cypher/history.md
@@ -1,36 +1,35 @@
-# Cypher - History
+# Cypher — History
 
 ## Core Context
 
 **Role:** DevOps Engineer | CI/CD, GitHub Actions, Azure infrastructure, Bicep IaC, health monitoring
 
 **Key infrastructure facts:**
-- App Service names: api-jjgnet-broadcast, web-jjgnet-broadcast, jjgnet-broadcast (Functions)
-- All 3 apps on same App Service plan (NOT Consumption) -> App Service Health Check /health works for all
-- Health endpoints (ServiceDefaults): /health (readiness) + /alive (liveness)
-- Resource Group: jjgnet | Subscription: 4f42033c-3579-4a94-8023-a3561518ae7f
-- SQL Server: r4bv7wtt6u (westus) | DB: JJGNet | Key Vault: jjgnet-broadcasting (westus2)
-- Storage (main): jjgnet (westus2, RAGRS) | Storage (functions): jjgnetbeb6 (westus, LRS)
-- App Insights/Log Analytics: jjgnet/jjgnet-log-workspace (westus2) | App Service Plan: jjgnet-broadcast (P1v3, westus)
-- Managed Identities: api-jjgnet-broad-id-8130, web-jjgnet-broad-id-8f0f, jjgnet-broadcast-id-8d7d
+- App Service names: `api-jjgnet-broadcast`, `web-jjgnet-broadcast`, `jjgnet-broadcast` (Functions)
+- All 3 apps on same App Service plan (NOT Consumption) → App Service Health Check `/health` works for all
+- Health endpoints (ServiceDefaults): `/health` (readiness) + `/alive` (liveness)
+- Resource Group: `jjgnet` | Subscription: `4f42033c-3579-4a94-8023-a3561518ae7f`
+- SQL Server: `r4bv7wtt6u` (westus) | DB: `JJGNet` | Key Vault: `jjgnet-broadcasting` (westus2)
+- Storage (main): `jjgnet` (westus2, RAGRS) | Storage (functions): `jjgnetbeb6` (westus, LRS)
+- App Insights/Log Analytics: `jjgnet`/`jjgnet-log-workspace` (westus2) | App Service Plan: `jjgnet-broadcast` (P1v3, westus)
+- Managed Identities: `api-jjgnet-broad-id-8130`, `web-jjgnet-broad-id-8f0f`, `jjgnet-broadcast-id-8d7d`
 
 **Bicep IaC patterns:**
-- targetScope = 'resourceGroup' at main.bicep; modules under infrastructure/bicep/modules/{compute,data,security,monitoring}/
-- NEVER listKeys() in module outputs (exposes in ARM history); @secure() on all connection string params
-- NEVER -preview API versions in production
-- GA versions: actionGroups@2023-01-01, components@2020-02-02, workspaces@2022-10-01, metricAlerts@2018-03-01, eventGrid/topics@2022-06-15, sql/servers@2021-11-01, managedIdentities@2023-01-31
-- allowBlobPublicAccess:false; StorageV2 over legacy Storage; ConnectionString over deprecated InstrumentationKey
-- Circular dependency fix: identify dead params (declared but unused in resources) and remove to break cycle
-- event-grid.bicep is in modules/data/ not modules/monitoring/ - always search before assuming paths
-- Hardcode nothing - parameterise emails, notification targets, environment values
+- `targetScope = 'resourceGroup'` at main.bicep; modules under `infrastructure/bicep/modules/{compute,data,security,monitoring}/`
+- NEVER `listKeys()` in module outputs (exposes in ARM history); `@secure()` on all connection string params
+- NEVER `-preview` API versions in production
+- GA versions: actionGroups `@2023-01-01`, components `@2020-02-02`, workspaces `@2022-10-01`, metricAlerts `@2018-03-01`, eventGrid `@2022-06-15`, sql/servers `@2021-11-01`, managedIdentities `@2023-01-31`
+- `allowBlobPublicAccess: false`; `StorageV2` over legacy `Storage`; `ConnectionString` over deprecated `InstrumentationKey`
+- Circular dependency fix: identify dead params (declared but not used in resources) and remove to break cycle
+- Hardcode nothing — parameterise emails, notification targets; `event-grid.bicep` is in `modules/data/` not `modules/monitoring/`
 
 **GitHub Actions patterns:**
-- environment: production creates approval gate if GitHub Settings has required reviewers
-- "Stop staging slot" step after swap (before informational steps): az webapp stop --slot staging
+- `environment: production` creates approval gate if GitHub Settings has required reviewers
+- "Stop staging slot" step after swap: `az webapp stop --slot staging` / `az functionapp stop --slot staging`
 
 **Completed work:**
 - PR #557: Production approval gate + staging slot cleanup in all 3 workflows
-- Issue #635: App Service Health Check + Availability Tests runbook posted
+- Issue #635: App Service Health Check + Availability Tests runbook posted  
 - Issue #637: Full modular Bicep scaffold (PR #645); circular dependency fixed; preview APIs pinned to GA
 
 **Team standing rules:** Only Joseph merges PRs; All mapping via AutoMapper; Paging at data layer only

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -92,20 +92,23 @@
 ### Squad Upgrade Cleanup & History Compaction (2026-04-11)
 
 **Files removed (stray duplicates from commit 0629a27):**
-- Casting state at .squad/ root: casting-history.json, casting-policy.json, casting-registry.json
-- Template duplicates at .squad/ root: 14 files (charter.md, constraint-tracking.md, copilot-instructions.md, history.md, issue-lifecycle.md, mcp-config.md, multi-agent-format.md, orchestration-log.md, plugin-marketplace.md, raw-agent-output.md, roster.md, run-output.md, scribe-charter.md, skill.md)
-- Casting state in .squad/templates/: casting-history.json, casting-policy.json, casting-registry.json
-- Deleted .squad/templates/identity/now.md (real copy at .squad/identity/now.md)
+- Casting state at `.squad/` root: casting-history.json, casting-policy.json, casting-registry.json
+- Template duplicates at `.squad/` root: charter.md, constraint-tracking.md, copilot-instructions.md, history.md, issue-lifecycle.md, mcp-config.md, multi-agent-format.md, orchestration-log.md, plugin-marketplace.md, raw-agent-output.md, roster.md, run-output.md, scribe-charter.md, skill.md
+- Casting state in `.squad/templates/`: casting-history.json, casting-policy.json, casting-registry.json
+- Deleted `.squad/templates/identity/now.md` (real copy at `.squad/identity/now.md`)
 
 **Files moved to correct locations:**
-- .squad/templates/identity/wisdom.md -> .squad/identity/wisdom.md
-- .squad/templates/casting/Futurama.json -> .squad/casting/Futurama.json
+- `.squad/templates/identity/wisdom.md` → `.squad/identity/wisdom.md`
+- `.squad/templates/casting/Futurama.json` → `.squad/casting/Futurama.json`
 
 **History files compacted (originals archived):**
-- Neo: 41.5KB -> ~10KB | archive: .squad/agents/neo/history-archive.md
-- Tank: 39KB -> ~11KB | archive: .squad/agents/tank/history-archive.md
-- Trinity: 30.7KB -> ~9KB | archive: .squad/agents/trinity/history-archive.md
-- Morpheus: 12.5KB -> ~6KB | archive: .squad/agents/morpheus/history-archive.md
-- Cypher: 12.3KB -> ~6KB | archive: .squad/agents/cypher/history-archive.md
+| Agent | Before | After | Archive |
+|-------|--------|-------|---------|
+| Neo | 41.5KB | ~12KB | `.squad/agents/neo/history-archive.md` |
+| Tank | 39KB | ~8KB | `.squad/agents/tank/history-archive.md` |
+| Trinity | 30.7KB | ~9KB | `.squad/agents/trinity/history-archive.md` |
+| Morpheus | 12.5KB | ~6KB | `.squad/agents/morpheus/history-archive.md` |
+| Cypher | 12.3KB | ~6KB | `.squad/agents/cypher/history-archive.md` |
 
-**Policy:** Full original content in history-archive.md beside each agent. Compact versions: dense Core Context + 2-3 most recent sessions verbatim.
+**Policy:** Full original content in `history-archive.md` beside each agent. Compact versions have dense Core Context + 2-3 most recent sessions verbatim.
+

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewRandomPost.cs
@@ -18,7 +18,7 @@ public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedS
     [QueueOutput(Queues.BlueskyPostToSend)]
     public async Task<BlueskyPostMessage?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.BlueskyProcessRandomPostFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSyndicationDataFired.cs
@@ -21,7 +21,7 @@ public class ProcessNewSyndicationDataFired(
     {
         try
         {
-            var startedAt = DateTime.UtcNow;
+            var startedAt = DateTimeOffset.UtcNow;
             logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
                 ConfigurationFunctionNames.BlueskyProcessNewSyndicationDataFired, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewYouTubeDataFired.cs
@@ -21,7 +21,7 @@ public class ProcessNewYouTubeDataFired(
     {
         try
         {
-            var startedAt = DateTime.UtcNow;
+            var startedAt = DateTimeOffset.UtcNow;
             logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
                 ConfigurationFunctionNames.BlueskyProcessNewYouTubeDataFired, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadAllSpeakingEngagements.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadAllSpeakingEngagements.cs
@@ -23,12 +23,12 @@ public class LoadAllSpeakingEngagements(
         HttpRequest req,
         string checkFrom)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.CollectorsSpeakingEngagementsLoadAll, startedAt);
 
         // Check for the date to check from
-        var dateToCheckFrom = DateTime.MinValue;
+        var dateToCheckFrom = DateTimeOffset.MinValue;
 
         if (!string.IsNullOrEmpty(checkFrom))
         {

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SpeakingEngagement/LoadNewSpeakingEngagements.cs
@@ -32,7 +32,7 @@ public class LoadNewSpeakingEngagements(
     public async Task<IActionResult> RunAsync(
         [TimerTrigger("%collectors_speaking_engagements_load_new_speaking_engagements_cron_settings%")] TimerInfo myTimer)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.CollectorsSpeakingEngagementsLoadNew, startedAt);
 
@@ -44,7 +44,7 @@ public class LoadNewSpeakingEngagements(
             {
                 Name = ConfigurationFunctionNames.CollectorsSpeakingEngagementsLoadNew,
                 LastCheckedFeed = startedAt,
-                LastItemAddedOrUpdated = DateTime.MinValue
+                LastItemAddedOrUpdated = DateTimeOffset.MinValue
             };
 
             // Check for new items
@@ -111,7 +111,7 @@ public class LoadNewSpeakingEngagements(
 
             // Save the last checked value
             feedCheck.LastCheckedFeed = startedAt;
-            feedCheck.LastUpdatedOn = DateTime.UtcNow;
+            feedCheck.LastUpdatedOn = DateTimeOffset.UtcNow;
             var latestAdded = newItems.Max(item => item.CreatedOn);
             var latestUpdated = newItems.Max(item => item.LastUpdatedOn);
             feedCheck.LastItemAddedOrUpdated = latestUpdated > latestAdded

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs
@@ -29,7 +29,7 @@ public class LoadAllPosts(
         HttpRequest req,
         string checkFrom)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.CollectorsFeedLoadAllPosts, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs
@@ -38,7 +38,7 @@ public class LoadNewPosts(
     public async Task<IActionResult> RunAsync(
         [TimerTrigger("%collectors_feed_load_new_posts_cron_settings%")] TimerInfo myTimer)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.CollectorsFeedLoadNewPosts, startedAt);
 
@@ -47,7 +47,7 @@ public class LoadNewPosts(
             var feedCheck = await feedCheckManager.GetByNameAsync(
                                     ConfigurationFunctionNames.CollectorsFeedLoadNewPosts
                                 ) ??
-                                new FeedCheck { LastCheckedFeed = startedAt, LastItemAddedOrUpdated = DateTime.MinValue };
+                                new FeedCheck { LastCheckedFeed = startedAt, LastItemAddedOrUpdated = DateTimeOffset.MinValue };
 
             // Check for new items
             logger.LogDebug("Checking the syndication feed for posts since '{LastItemAddedOrUpdated}'", feedCheck.LastItemAddedOrUpdated);
@@ -115,7 +115,7 @@ public class LoadNewPosts(
 
             // Save the last checked value
             feedCheck.LastCheckedFeed = startedAt;
-            feedCheck.LastUpdatedOn = DateTime.UtcNow;
+            feedCheck.LastUpdatedOn = DateTimeOffset.UtcNow;
             var latestAdded = newItems.Max(item => item.PublicationDate);
             var latestUpdated = newItems.Max(item => item.LastUpdatedOn);
             feedCheck.LastItemAddedOrUpdated = latestUpdated > latestAdded

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs
@@ -29,12 +29,12 @@ public class LoadAllVideos(
         HttpRequest req, 
         string checkFrom)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.CollectorsYouTubeLoadAllVideos, startedAt);
 
         // Check for the date to check from
-        var dateToCheckFrom = DateTime.MinValue;
+        var dateToCheckFrom = DateTimeOffset.MinValue;
 
         if (!checkFrom.IsNullOrEmpty())
         {

--- a/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs
@@ -38,7 +38,7 @@ public class LoadNewVideos(
     public async Task<IActionResult> RunAsync(
         [TimerTrigger("%collectors_youtube_load_new_videos_cron_settings%")] TimerInfo myTimer)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.CollectorsYouTubeLoadNewVideos, startedAt);
 
@@ -47,7 +47,7 @@ public class LoadNewVideos(
             var feedCheck = await feedCheckManager.GetByNameAsync(
                                 ConfigurationFunctionNames.CollectorsYouTubeLoadNewVideos
                             ) ??
-                            new FeedCheck { LastCheckedFeed = startedAt, LastItemAddedOrUpdated = DateTime.MinValue };
+                            new FeedCheck { LastCheckedFeed = startedAt, LastItemAddedOrUpdated = DateTimeOffset.MinValue };
 
             // Check for new items
             logger.LogDebug("Checking playlist for videos since '{LastItemAddedOrUpdated}'",
@@ -117,7 +117,7 @@ public class LoadNewVideos(
 
             // Save the last checked value
             feedCheck.LastCheckedFeed = startedAt;
-            feedCheck.LastUpdatedOn = DateTime.UtcNow;
+            feedCheck.LastUpdatedOn = DateTimeOffset.UtcNow;
             var latestAdded = newItems.Max(item => item.PublicationDate);
             var latestUpdated = newItems.Max(item => item.LastUpdatedOn);
             feedCheck.LastItemAddedOrUpdated = latestUpdated > latestAdded

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/PostPageStatus.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/PostPageStatus.cs
@@ -14,7 +14,7 @@ public class PostPageStatus(IFacebookManager facebookManager, ILogger<PostPageSt
         [QueueTrigger(Queues.FacebookPostStatusToPage)]
         Domain.Models.Messages.FacebookPostStatus facebookPostStatus)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookPostPageStatus, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewRandomPost.cs
@@ -18,7 +18,7 @@ public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedS
     [QueueOutput(Queues.FacebookPostStatusToPage)]
     public async Task<FacebookPostStatus?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookProcessRandomPostFired, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSyndicationDataFired.cs
@@ -26,7 +26,7 @@ public class ProcessNewSyndicationDataFired(
     public async Task<FacebookPostStatus?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
         
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookProcessNewSyndicationDataFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewYouTubeDataFired.cs
@@ -27,7 +27,7 @@ public class ProcessNewYouTubeDataFired(
         [EventGridTrigger] EventGridEvent eventGridEvent)
     {
         
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookProcessNewYouTubeDataFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/RefreshTokens.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/RefreshTokens.cs
@@ -20,7 +20,7 @@ public class RefreshTokens(
     [Function(ConfigurationFunctionNames.FacebookTokenRefresh)]
     public async Task Run([TimerTrigger("%facebook_refresh_tokens_cron_settings%")] TimerInfo myTimer)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.FacebookTokenRefresh, startedAt);
 
@@ -43,12 +43,12 @@ public class RefreshTokens(
                                 new TokenRefresh
                                 {
                                     Name = tokenType.DisplayName(),
-                                    LastRefreshed = DateTime.MinValue,
-                                    LastChecked = DateTime.MinValue,
-                                    Expires = DateTime.MinValue
+                                    LastRefreshed = DateTimeOffset.MinValue,
+                                    LastChecked = DateTimeOffset.MinValue,
+                                    Expires = DateTimeOffset.MinValue
                                 };
         
-        if (tokenInfo.Expires < DateTime.UtcNow || tokenInfo.Expires.AddDays(-5) < DateTime.UtcNow)
+        if (tokenInfo.Expires < DateTimeOffset.UtcNow || tokenInfo.Expires.AddDays(-5) < DateTimeOffset.UtcNow)
         {
             // Refresh the token
             logger.LogDebug("{DisplayName} is expired or will expire soon. Refreshing the token", tokenType.DisplayName());
@@ -63,7 +63,7 @@ public class RefreshTokens(
                 await keyVault.UpdateSecretValueAndPropertiesAsync(secretName, newToken.AccessToken, newToken.ExpiresOn);
                 
                 // Save the token refresh info to the database
-                tokenInfo.LastRefreshed = tokenInfo.LastChecked = DateTime.UtcNow;
+                tokenInfo.LastRefreshed = tokenInfo.LastChecked = DateTimeOffset.UtcNow;
                 tokenInfo.Expires = newToken.ExpiresOn;
                 await tokenRefreshManager.SaveAsync(tokenInfo);
                 

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostText.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/PostText.cs
@@ -15,7 +15,7 @@ public class PostText(ILinkedInManager linkedInManager, ILogger<PostText> logger
         [QueueTrigger(Queues.LinkedInPostText)]
         LinkedInPostText linkedInPostText)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInPostText, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewRandomPost.cs
@@ -22,7 +22,7 @@ public class ProcessNewRandomPost(
     [QueueOutput(Queues.LinkedInPostLink)]
     public async Task<LinkedInPostLink?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInProcessRandomPostFired, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs
@@ -27,7 +27,7 @@ public class ProcessNewSyndicationDataFired(
     [QueueOutput(Queues.LinkedInPostLink)]
     public async Task<LinkedInPostLink?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInProcessNewSyndicationDataFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewYouTubeDataFired.cs
@@ -27,7 +27,7 @@ public class ProcessNewYouTubeDataFired(
     [QueueOutput(Queues.LinkedInPostLink)]
     public async Task<LinkedInPostLink?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInProcessNewYouTubeDataFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/Maintenance/ClearOldLogs.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Maintenance/ClearOldLogs.cs
@@ -17,7 +17,7 @@ public class ClearOldLogs(ILogger<ClearOldLogs> logger)
     {
         // 0 */2 * * * * - Every 2 minutes
         // 0 23 * * 0 - Run at 11pm on Sunday
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.MaintenanceClearOldLogs, startedAt);
         var numberOfItemsDeleted = 0;
@@ -25,9 +25,9 @@ public class ClearOldLogs(ILogger<ClearOldLogs> logger)
 
         // Get all the log messages older than a week
         #if DEBUG
-        var dateTimeAsString = DateTime.UtcNow.AddMinutes(-2).ToString("s");
+        var dateTimeAsString = DateTimeOffset.UtcNow.AddMinutes(-2).ToString("s");
         #else
-        var dateTimeAsString = DateTime.UtcNow.AddDays(-7).ToString("s");
+        var dateTimeAsString = DateTimeOffset.UtcNow.AddDays(-7).ToString("s");
         #endif
         var filter = $"Timestamp le datetime'{dateTimeAsString}'";
         AsyncPageable<TableEntity> queryResults = tableClient.QueryAsync<TableEntity>(filter: filter);

--- a/src/JosephGuadagno.Broadcasting.Functions/Publishers/RandomPosts.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Publishers/RandomPosts.cs
@@ -18,14 +18,14 @@ public class RandomPosts(
     public async Task Run(
         [TimerTrigger("%publishers_random_post_cron_settings%")] TimerInfo myTimer)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.PublishersRandomPosts, startedAt);
 
         // Get the feed items
         // Check for the from date
         var cutoffDate = DateTimeOffset.MinValue;
-        if (randomPostSettings.CutoffDate != DateTime.MinValue)
+        if (randomPostSettings.CutoffDate != DateTimeOffset.MinValue)
         {
             cutoffDate = randomPostSettings.CutoffDate;
         }

--- a/src/JosephGuadagno.Broadcasting.Functions/Publishers/ScheduledItems.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Publishers/ScheduledItems.cs
@@ -18,14 +18,14 @@ public class ScheduledItems(
     [Function(ConfigurationFunctionNames.PublishersScheduledItems)]
     public async Task RunAsync([TimerTrigger("%publishers_scheduled_items_cron_settings%")] TimerInfo myTimer, ILogger log)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.PublishersScheduledItems, startedAt);
 
         var configuration = await feedCheckManager.GetByNameAsync(
                                 ConfigurationFunctionNames.PublishersScheduledItems
                             ) ??
-                            new FeedCheck { LastCheckedFeed = startedAt, LastItemAddedOrUpdated = DateTime.MinValue };
+                            new FeedCheck { LastCheckedFeed = startedAt, LastItemAddedOrUpdated = DateTimeOffset.MinValue };
 
         // Check for items that are due to be fired
         logger.LogDebug("Checking for scheduled items that have not been fired");

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewRandomPost.cs
@@ -17,7 +17,7 @@ public class ProcessNewRandomPost(ISyndicationFeedSourceManager syndicationFeedS
     [QueueOutput(Queues.TwitterTweetsToSend)]
     public async Task<TwitterTweetMessage?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.TwitterProcessRandomPostFired, startedAt);
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSyndicationDataFired.cs
@@ -28,7 +28,7 @@ public class ProcessNewSyndicationDataFired(
     public async Task<TwitterTweetMessage?> RunAsync(
         [EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.TwitterProcessNewSyndicationDataFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewYouTubeData.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewYouTubeData.cs
@@ -27,7 +27,7 @@ public class ProcessNewYouTubeDataFired(
     [QueueOutput(Queues.TwitterTweetsToSend)] 
     public async Task<TwitterTweetMessage?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.TwitterProcessNewYouTubeDataFired, startedAt);
         

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessScheduledItemFired.cs
@@ -34,7 +34,7 @@ public class ProcessScheduledItemFired(
     [QueueOutput(Queues.TwitterTweetsToSend)]
     public async Task<TwitterTweetMessage?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        var startedAt = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.TwitterProcessScheduledItemFired, startedAt);
         
@@ -116,7 +116,7 @@ public class ProcessScheduledItemFired(
         }
         finally
         {
-            var endedAt = DateTime.UtcNow;
+            var endedAt = DateTimeOffset.UtcNow;
             logger.LogDebug("{FunctionName} ended at: {EndedAt:f}",
                 ConfigurationFunctionNames.TwitterProcessScheduledItemFired, endedAt);
         }


### PR DESCRIPTION
## Summary

Replaces all ``DateTime.UtcNow`` usages with ``DateTimeOffset.UtcNow`` across the Azure Functions project.

## Changes

- Replaced ``DateTime.UtcNow`` → ``DateTimeOffset.UtcNow`` in all affected Functions files (43 occurrences)
- Updated ``DateTime.MinValue`` → ``DateTimeOffset.MinValue`` where used for timestamps
- Updated local variable types from ``DateTime`` to ``DateTimeOffset`` where storing timestamps

## Files Changed (22 files)

### Facebook Functions
- RefreshTokens.cs (6 occurrences)
- ProcessNewYouTubeDataFired.cs
- ProcessNewSyndicationDataFired.cs
- ProcessNewRandomPost.cs
- PostPageStatus.cs

### LinkedIn Functions
- ProcessNewYouTubeDataFired.cs
- ProcessNewSyndicationDataFired.cs
- ProcessNewRandomPost.cs
- PostText.cs

### Bluesky Functions
- ProcessNewYouTubeDataFired.cs
- ProcessNewRandomPost.cs
- ProcessNewSyndicationDataFired.cs

### Twitter Functions
- ProcessNewRandomPost.cs
- ProcessNewYouTubeData.cs
- ProcessNewSyndicationDataFired.cs
- ProcessScheduledItemFired.cs (2 occurrences)

### Collectors
- SpeakingEngagement/LoadNewSpeakingEngagements.cs (3 occurrences)
- SpeakingEngagement/LoadAllSpeakingEngagements.cs (2 occurrences)
- YouTube/LoadNewVideos.cs (3 occurrences)
- YouTube/LoadAllVideos.cs (2 occurrences)
- SyndicationFeed/LoadNewPosts.cs (3 occurrences)
- SyndicationFeed/LoadAllPosts.cs

### Publishers
- ScheduledItems.cs (2 occurrences)
- RandomPosts.cs (2 occurrences)

### Maintenance
- ClearOldLogs.cs (3 occurrences)

## Why

Per project convention: all datetime fields must use ``DateTimeOffset`` in C# (not ``DateTime``) to avoid timezone ambiguity.

Closes #694
