### PR TITLE
fix: replace DateTime.UtcNow with DateTimeOffset.UtcNow in Web controllers

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/EngagementsController.cs
@@ -203,7 +203,7 @@ public class EngagementsController : Controller
     public IActionResult Add()
     {
         return View(new EngagementViewModel
-            { StartDateTime = DateTime.UtcNow, EndDateTime = DateTime.UtcNow.AddHours(1) });
+            { StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddHours(1) });
     }
 
     /// <summary>

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs
@@ -143,8 +143,8 @@ public class LinkedInController : Controller
         }
         
         // Save the token and expiration to KeyVault
-        var tokenExpiration = DateTime.UtcNow.AddSeconds(tokenResponse.ExpiresIn); 
-        await _keyVault.UpdateSecretValueAndPropertiesAsync(KeyVaultSecretName, tokenResponse.AccessToken, tokenExpiration);
+        var tokenExpiration = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
+        await _keyVault.UpdateSecretValueAndPropertiesAsync(KeyVaultSecretName, tokenResponse.AccessToken, tokenExpiration.DateTime);
         
         _logger.LogInformation("Saved new token '{KeyVaultSecretName}' to KeyVault", KeyVaultSecretName);
 
@@ -152,9 +152,9 @@ public class LinkedInController : Controller
         if (!string.IsNullOrEmpty(tokenResponse.RefreshToken))
         {
             var refreshTokenExpiration = tokenResponse.RefreshTokenExpiresIn.HasValue
-                ? DateTime.UtcNow.AddSeconds(tokenResponse.RefreshTokenExpiresIn.Value)
-                : DateTime.UtcNow.AddDays(365);
-            await _keyVault.UpdateSecretValueAndPropertiesAsync(KeyVaultRefreshTokenSecretName, tokenResponse.RefreshToken, refreshTokenExpiration);
+                ? DateTimeOffset.UtcNow.AddSeconds(tokenResponse.RefreshTokenExpiresIn.Value)
+                : DateTimeOffset.UtcNow.AddDays(365);
+            await _keyVault.UpdateSecretValueAndPropertiesAsync(KeyVaultRefreshTokenSecretName, tokenResponse.RefreshToken, refreshTokenExpiration.DateTime);
             _logger.LogInformation("Saved new refresh token '{KeyVaultRefreshTokenSecretName}' to KeyVault", KeyVaultRefreshTokenSecretName);
         }
 

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/SchedulesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/SchedulesController.cs
@@ -185,7 +185,7 @@ public class SchedulesController : Controller
     /// <returns>Returns a form to add a <see cref="ScheduledItemViewModel"/></returns>
     public IActionResult Add()
     {
-        return View(new ScheduledItemViewModel{SendOnDateTime = DateTime.UtcNow});
+        return View(new ScheduledItemViewModel{SendOnDateTime = DateTimeOffset.UtcNow});
     }
         
     /// <summary>

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/TalksController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/TalksController.cs
@@ -169,7 +169,7 @@ public class TalksController : Controller
     {
         return View(new TalkViewModel
         {
-            EngagementId = engagementId, StartDateTime = DateTime.UtcNow, EndDateTime = DateTime.UtcNow.AddHours(1)
+            EngagementId = engagementId, StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
         });
     }
 


### PR DESCRIPTION
## Summary

Replaces ``DateTime.UtcNow`` usages with ``DateTimeOffset.UtcNow`` in the Web controllers.

## Changes

- ``EngagementsController.cs`` line 206: replaced ``DateTime.UtcNow`` → ``DateTimeOffset.UtcNow`` (2 occurrences)
- ``SchedulesController.cs`` line 188: replaced ``DateTime.UtcNow`` → ``DateTimeOffset.UtcNow`` (1 occurrence)
- ``TalksController.cs`` line 172: replaced ``DateTime.UtcNow`` → ``DateTimeOffset.UtcNow`` (2 occurrences)
- ``LinkedInController.cs`` lines 146, 155, 156: replaced ``DateTime.UtcNow`` → ``DateTimeOffset.UtcNow`` (3 occurrences) + added ``.DateTime`` conversion for KeyVault API compatibility

## Why

Per project convention: all datetime fields must use ``DateTimeOffset`` in C# (not ``DateTime``) to avoid timezone ambiguity.

Closes #695
