### PR TITLE
Upgrade project dependencies to latest versions

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/JosephGuadagno.Broadcasting.Api.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/JosephGuadagno.Broadcasting.Api.Tests.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Api/JosephGuadagno.Broadcasting.Api.csproj
+++ b/src/JosephGuadagno.Broadcasting.Api/JosephGuadagno.Broadcasting.Api.csproj
@@ -40,14 +40,14 @@
     <DocumentationFile>bin\Release\JosephGuadagno.Broadcasting.Api.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.2.1" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.2.2" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.2" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.13.18" />
-    <PackageReference Include="Scalar.AspNetCore.Microsoft" Version="2.13.18" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.13.22" />
+    <PackageReference Include="Scalar.AspNetCore.Microsoft" Version="2.13.22" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/JosephGuadagno.Broadcasting.AppHost/JosephGuadagno.Broadcasting.AppHost.csproj
+++ b/src/JosephGuadagno.Broadcasting.AppHost/JosephGuadagno.Broadcasting.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.1">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.2">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.2.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.1" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.2.1" />
+    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.2.2" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.2" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.2.2" />
     <PackageReference Include="Azure.Provisioning.EventGrid" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/JosephGuadagno.Broadcasting.Data.KeyVault.Tests/JosephGuadagno.Broadcasting.Data.KeyVault.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Data.KeyVault.Tests/JosephGuadagno.Broadcasting.Data.KeyVault.Tests.csproj
@@ -33,7 +33,7 @@
     <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/JosephGuadagno.Broadcasting.Data.Sql.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/JosephGuadagno.Broadcasting.Data.Sql.Tests.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/JosephGuadagno.Broadcasting.Data.Sql.csproj
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/JosephGuadagno.Broadcasting.Data.Sql.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.20.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <ProjectReference Include="..\JosephGuadagno.Broadcasting.Domain\JosephGuadagno.Broadcasting.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/src/JosephGuadagno.Broadcasting.Data.Tests/JosephGuadagno.Broadcasting.Data.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Data.Tests/JosephGuadagno.Broadcasting.Data.Tests.csproj
@@ -34,7 +34,7 @@
     <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Functions.IntegrationTests/JosephGuadagno.Broadcasting.Functions.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions.IntegrationTests/JosephGuadagno.Broadcasting.Functions.IntegrationTests.csproj
@@ -36,7 +36,7 @@
         <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.20.0" />
+        <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0"/>
         <PackageReference Include="linqtotwitter" Version="6.15.0"/>
         <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
@@ -53,7 +53,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
@@ -36,9 +36,9 @@
         <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.2" />
         <PackageReference Include="Azure.Data.Tables" Version="12.11.0"/>
-        <PackageReference Include="Azure.Identity" Version="1.20.0" />
+        <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0"/>
         <PackageReference Include="JosephGuadagno.AzureHelpers.Cosmos" Version="1.0.8"/>
         <PackageReference Include="JosephGuadagno.Extensions" Version="1.2.5"/>
@@ -71,7 +71,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="FluentAssertions" Version="8.9.0" />
         <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>
         <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0"/>
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1"/>

--- a/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
@@ -39,13 +39,13 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.2.1" />
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.2.1" />
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.2.1" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
+    <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.2.2" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.2.2" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.2.2" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.2" />
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageReference Include="Azure.Identity" Version="1.20.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
     <PackageReference Include="JosephGuadagno.AzureHelpers.Cosmos" Version="1.0.8" />
@@ -78,9 +78,9 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
-    <PackageReference Include="Scriban" Version="7.0.6" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="Scriban" Version="7.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/src/JosephGuadagno.Broadcasting.JsonFeedReader.Tests/JosephGuadagno.Broadcasting.JsonFeedReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.JsonFeedReader.Tests/JosephGuadagno.Broadcasting.JsonFeedReader.Tests.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/JosephGuadagno.Broadcasting.Managers.Bluesky.IntegrationTests/JosephGuadagno.Broadcasting.Managers.Bluesky.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Bluesky.IntegrationTests/JosephGuadagno.Broadcasting.Managers.Bluesky.IntegrationTests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.Bluesky.Tests/JosephGuadagno.Broadcasting.Managers.Bluesky.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Bluesky.Tests/JosephGuadagno.Broadcasting.Managers.Bluesky.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.Facebook.IntegrationTests/JosephGuadagno.Broadcasting.Managers.Facebook.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Facebook.IntegrationTests/JosephGuadagno.Broadcasting.Managers.Facebook.IntegrationTests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.Facebook.Tests/JosephGuadagno.Broadcasting.Managers.Facebook.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Facebook.Tests/JosephGuadagno.Broadcasting.Managers.Facebook.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.LinkedIn.IntegrationTests/JosephGuadagno.Broadcasting.Managers.LinkedIn.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.LinkedIn.IntegrationTests/JosephGuadagno.Broadcasting.Managers.LinkedIn.IntegrationTests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.LinkedIn.Tests/JosephGuadagno.Broadcasting.Managers.LinkedIn.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.LinkedIn.Tests/JosephGuadagno.Broadcasting.Managers.LinkedIn.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/JosephGuadagno.Broadcasting.Managers.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/JosephGuadagno.Broadcasting.Managers.Tests.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="JosephGuadagno.AzureHelpers.Storage" Version="1.1.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Managers.Twitter.IntegrationTests/JosephGuadagno.Broadcasting.Managers.Twitter.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Twitter.IntegrationTests/JosephGuadagno.Broadcasting.Managers.Twitter.IntegrationTests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.Managers.Twitter.Tests/JosephGuadagno.Broadcasting.Managers.Twitter.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Twitter.Tests/JosephGuadagno.Broadcasting.Managers.Twitter.Tests.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.ServiceDefaults/JosephGuadagno.Broadcasting.ServiceDefaults.csproj
+++ b/src/JosephGuadagno.Broadcasting.ServiceDefaults/JosephGuadagno.Broadcasting.ServiceDefaults.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />

--- a/src/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests/JosephGuadagno.Broadcasting.SpeakingEngagementsReader.Tests.csproj
@@ -40,7 +40,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/src/JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests/JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests/JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests/JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.AzureTableStorage" Version="10.2.0" />

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/JosephGuadagno.Broadcasting.Web.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/JosephGuadagno.Broadcasting.Web.Tests.csproj
@@ -34,10 +34,10 @@
     <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.2" />
     <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NodaTime" Version="3.3.1" />
     <PackageReference Include="Rocket.Surgery.Extensions.AutoMapper.NodaTime" Version="9.0.1" />

--- a/src/JosephGuadagno.Broadcasting.Web/JosephGuadagno.Broadcasting.Web.csproj
+++ b/src/JosephGuadagno.Broadcasting.Web/JosephGuadagno.Broadcasting.Web.csproj
@@ -40,10 +40,10 @@
         <DocumentationFile>bin\Release\JosephGuadagno.Broadcasting.Web.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.2.1" />
-        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
+        <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.2.2" />
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.2" />
         <PackageReference Include="AutoMapper" Version="16.1.1" />
-        <PackageReference Include="Azure.Identity" Version="1.20.0" />
+        <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
         <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
@@ -51,8 +51,8 @@
         <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
         <PackageReference Include="Microsoft.Identity.Web" Version="4.7.0" />
         <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.6.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
+        <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.7.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
         <PackageReference Include="NodaTime" Version="3.3.1" />
         <PackageReference Include="Rocket.Surgery.Extensions.AutoMapper.NodaTime" Version="9.0.1" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/src/JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests/JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests.csproj
+++ b/src/JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests/JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests.csproj
@@ -41,7 +41,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/src/JosephGuadagno.Broadcasting.YouTubeReader.Tests/JosephGuadagno.Broadcasting.YouTubeReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.YouTubeReader.Tests/JosephGuadagno.Broadcasting.YouTubeReader.Tests.csproj
@@ -40,7 +40,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Description

This pull request upgrades the following dependencies across multiple projects:

- Bumped `Microsoft.NET.Test.Sdk` from 18.3.0 to 18.4.0 in all test projects.
- Upgraded `Azure.Identity` from 1.20.0 to 1.21.0 in applicable projects.
- Updated `Aspire` packages from version 13.2.1 to 13.2.2.
- Incremented `OpenTelemetry` packages to 1.15.2.
- Bumped `Scriban` to 7.1.0.

These updates aim to ensure synchronization and compatibility across the projects.