### PR TITLE
feat(#609): add CreatedByEntraOid to SyndicationFeedSources and YouTubeSources

### DIFF
--- a/scripts/database/migrations/2026-04-17-add-owner-to-sources.sql
+++ b/scripts/database/migrations/2026-04-17-add-owner-to-sources.sql
@@ -1,0 +1,50 @@
+-- Migration: Add CreatedByEntraOid ownership columns to source tables
+-- Issue: #725
+-- Date: 2026-04-17
+-- Description: Extends RBAC ownership tracking to SyndicationFeedSources and YouTubeSources
+--              to support ownership-based delete rules: Contributors can delete only their
+--              own content, Administrators can delete any content.
+--              Column is nullable to handle existing records gracefully.
+
+USE JJGNet;
+GO
+
+-- ============================================================
+-- Add CreatedByEntraOid to SyndicationFeedSources
+-- ============================================================
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'[dbo].[SyndicationFeedSources]')
+      AND name = 'CreatedByEntraOid')
+BEGIN
+    ALTER TABLE [dbo].[SyndicationFeedSources]
+        ADD [CreatedByEntraOid] NVARCHAR(36) NULL;
+END
+GO
+
+-- ============================================================
+-- Add CreatedByEntraOid to YouTubeSources
+-- ============================================================
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'[dbo].[YouTubeSources]')
+      AND name = 'CreatedByEntraOid')
+BEGIN
+    ALTER TABLE [dbo].[YouTubeSources]
+        ADD [CreatedByEntraOid] NVARCHAR(36) NULL;
+END
+GO
+
+-- ============================================================
+-- NOTES ON NULLABLE COLUMN DECISION
+-- ============================================================
+-- CreatedByEntraOid is nullable for backward compatibility with existing data.
+-- New content created after deployment will capture the creator's
+-- Entra Object ID from the authenticated user's oid claim.
+-- 
+-- Existing records without ownership:
+-- - Can be deleted by Administrators
+-- - Cannot be deleted by Contributors (no ownership = not their content)
+-- 
+-- Issue #726 provides a backfill migration to assign ownership to existing records.
+-- ============================================================

--- a/scripts/database/migrations/2026-04-17-backfill-owner-oid.sql
+++ b/scripts/database/migrations/2026-04-17-backfill-owner-oid.sql
@@ -1,0 +1,106 @@
+-- Migration: Backfill CreatedByEntraOid for all existing records
+-- Issue: #726
+-- Date: 2026-04-17
+-- Description: Sets CreatedByEntraOid on all existing rows with NULL values.
+--              All existing content was created by Joseph Guadagno (the only current user).
+--              This migration is idempotent - only NULL rows are updated, safe to re-run.
+--
+-- REQUIRED ACTION BEFORE RUNNING:
+--   Replace 'PLACEHOLDER_OID' below with Joseph Guadagno's actual Entra Object ID (oid claim).
+--   You can find this value in Azure Portal > Entra ID > Users > Joseph Guadagno > Object ID
+--   or by inspecting the oid claim from an authenticated session.
+
+USE JJGNet;
+GO
+
+-- ============================================================
+-- Configuration - UPDATE THIS VALUE BEFORE RUNNING
+-- ============================================================
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- Validate that a real OID was provided
+IF @OwnerOid = 'PLACEHOLDER_OID'
+BEGIN
+    RAISERROR('ERROR: @OwnerOid must be updated with the actual Entra Object ID before running this script.', 16, 1);
+    RETURN;
+END
+GO
+
+-- Re-declare for each batch
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- ============================================================
+-- Backfill Engagements
+-- ============================================================
+UPDATE [dbo].[Engagements]
+SET [CreatedByEntraOid] = @OwnerOid
+WHERE [CreatedByEntraOid] IS NULL;
+
+PRINT CONCAT('Updated ', @@ROWCOUNT, ' Engagements records');
+GO
+
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- ============================================================
+-- Backfill Talks
+-- ============================================================
+UPDATE [dbo].[Talks]
+SET [CreatedByEntraOid] = @OwnerOid
+WHERE [CreatedByEntraOid] IS NULL;
+
+PRINT CONCAT('Updated ', @@ROWCOUNT, ' Talks records');
+GO
+
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- ============================================================
+-- Backfill ScheduledItems
+-- ============================================================
+UPDATE [dbo].[ScheduledItems]
+SET [CreatedByEntraOid] = @OwnerOid
+WHERE [CreatedByEntraOid] IS NULL;
+
+PRINT CONCAT('Updated ', @@ROWCOUNT, ' ScheduledItems records');
+GO
+
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- ============================================================
+-- Backfill MessageTemplates
+-- ============================================================
+UPDATE [dbo].[MessageTemplates]
+SET [CreatedByEntraOid] = @OwnerOid
+WHERE [CreatedByEntraOid] IS NULL;
+
+PRINT CONCAT('Updated ', @@ROWCOUNT, ' MessageTemplates records');
+GO
+
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- ============================================================
+-- Backfill SyndicationFeedSources
+-- ============================================================
+UPDATE [dbo].[SyndicationFeedSources]
+SET [CreatedByEntraOid] = @OwnerOid
+WHERE [CreatedByEntraOid] IS NULL;
+
+PRINT CONCAT('Updated ', @@ROWCOUNT, ' SyndicationFeedSources records');
+GO
+
+DECLARE @OwnerOid NVARCHAR(36) = 'PLACEHOLDER_OID';
+
+-- ============================================================
+-- Backfill YouTubeSources
+-- ============================================================
+UPDATE [dbo].[YouTubeSources]
+SET [CreatedByEntraOid] = @OwnerOid
+WHERE [CreatedByEntraOid] IS NULL;
+
+PRINT CONCAT('Updated ', @@ROWCOUNT, ' YouTubeSources records');
+GO
+
+-- ============================================================
+-- Summary
+-- ============================================================
+PRINT 'Backfill complete. All NULL CreatedByEntraOid values have been updated.';
+GO

--- a/scripts/database/table-create.sql
+++ b/scripts/database/table-create.sql
@@ -131,7 +131,8 @@ create table dbo.SyndicationFeedSources
     PublicationDate   datetimeoffset default getutcdate() not null,
     AddedOn           datetimeoffset default getutcdate() not null,
     ItemLastUpdatedOn datetimeoffset default getutcdate(),
-    LastUpdatedOn     datetimeoffset default getutcdate() not null
+    LastUpdatedOn     datetimeoffset default getutcdate() not null,
+    CreatedByEntraOid nvarchar(36)                        null
 )
 GO
 
@@ -150,7 +151,8 @@ create table dbo.YouTubeSources
     PublicationDate   datetimeoffset default getutcdate() not null,
     AddedOn           datetimeoffset default getutcdate() not null,
     ItemLastUpdatedOn datetimeoffset default getutcdate(),
-    LastUpdatedOn     datetimeoffset default getutcdate() not null
+    LastUpdatedOn     datetimeoffset default getutcdate() not null,
+    CreatedByEntraOid nvarchar(36)                        null
 )
 go
 

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/SyndicationFeedSource.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/SyndicationFeedSource.cs
@@ -29,5 +29,7 @@ public partial class SyndicationFeedSource
 
     public DateTimeOffset LastUpdatedOn { get; set; }
 
+    public string CreatedByEntraOid { get; set; }
+
     public virtual ICollection<SourceTag> SourceTags { get; set; } = new List<SourceTag>();
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/YouTubeSource.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/YouTubeSource.cs
@@ -29,5 +29,7 @@ public partial class YouTubeSource
 
     public DateTimeOffset LastUpdatedOn { get; set; }
 
+    public string CreatedByEntraOid { get; set; }
+
     public virtual ICollection<SourceTag> SourceTags { get; set; } = new List<SourceTag>();
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/SyndicationFeedSource.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/SyndicationFeedSource.cs
@@ -36,4 +36,6 @@ public class SyndicationFeedSource
 
     [Required]
     public DateTimeOffset LastUpdatedOn { get; set; }
+
+    public string? CreatedByEntraOid { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/YouTubeSource.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/YouTubeSource.cs
@@ -38,4 +38,6 @@ public class YouTubeSource
 
     [Required]
     public DateTimeOffset LastUpdatedOn { get; set; }
+
+    public string? CreatedByEntraOid { get; set; }
 }


### PR DESCRIPTION
## Summary

Adds the `CreatedByEntraOid` column to the two content source tables that were missing it, updates the domain and EF Core models, and provides the backfill script.

## Changes

### Schema
- `scripts/database/migrations/2026-04-17-add-owner-to-sources.sql` — idempotent migration adding `CreatedByEntraOid NVARCHAR(36) NULL` to `SyndicationFeedSources` and `YouTubeSources`
- `scripts/database/table-create.sql` — updated CREATE TABLE statements for both tables

### Models
- `Domain.Models.SyndicationFeedSource` — added `CreatedByEntraOid` property
- `Domain.Models.YouTubeSource` — added `CreatedByEntraOid` property
- `Data.Sql.Models.SyndicationFeedSource` — added `CreatedByEntraOid` property
- `Data.Sql.Models.YouTubeSource` — added `CreatedByEntraOid` property

### Backfill
- `scripts/database/migrations/2026-04-17-backfill-owner-oid.sql` — parameterized backfill for all 6 tables (update `@OwnerOid` before running)

## Testing
- Build passes
- Migration scripts are idempotent

Closes #725
Closes #726