### PR TITLE
feat(#609): Filter data store queries by CreatedByEntraOid (#727)

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -126,3 +126,14 @@
 - **Commit:** e306636 — `fix(data,managers): complete exception logging audit - add missing LogError calls (#713)` (10 files changed, -245 lines from reverted pagination tests).
 - **Pattern:** When fixing reviewer-rejected work on a feature branch, FIRST identify and revert any cross-contamination from unrelated branches (use `git diff main...branch --name-only` and `git checkout main -- path/to/file`), THEN add the fixes requested (logging calls), THEN fix all test constructors to match updated DI signatures. Never commit incomplete logging instrumentation — every catch block that returns an OperationResult MUST log the exception before returning.
 
+
+
+### 2026-04-17 — Sprint 16 #727: Owner-Filtered Data Store Overloads
+
+- **Pattern:** When adding owner-filtered query overloads (e.g., `GetAllAsync(string ownerEntraOid, ...)`) to data stores alongside existing unfiltered methods (`GetAllAsync(CancellationToken)`), maintain BOTH signatures for different use cases: owner-filtered for user-scoped queries, unfiltered for Site Admin and background job access.
+- **Interface design:** Place owner-filtered overloads directly in the derived interface (e.g., `ISyndicationFeedSourceDataStore`), not in the base `IDataStore<T>`. This keeps base interfaces clean and allows each data store to expose domain-specific filtering.
+- **Implementation:** Use `.Where(x => x.CreatedByEntraOid == ownerEntraOid)` in LINQ queries. For paged methods, apply the owner filter before counting and paging.
+- **Test fix:** When adding method overloads, Moq may struggle with overload resolution if tests use `GetAllAsync(default)`. Use `GetAllAsync(It.IsAny<CancellationToken>())` explicitly, or better, call with no parameters (`GetAllAsync()`) and let C# default parameter resolution handle it. After changing test mocks, REBUILD the test project to ensure Moq rebinds correctly.
+- **Scope:** Added owner-filtered overloads to 5 data stores: `SyndicationFeedSourceDataStore`, `YouTubeSourceDataStore`, `EngagementDataStore`, `ScheduledItemDataStore`, `MessageTemplateDataStore`.
+- **Branch:** `squad/727-filter-datasources-by-owner` → PR #735
+- **Commit:** `9558b20` — 275 insertions (12 files changed: 5 interfaces, 5 implementations, 2 test files)

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/EngagementDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/EngagementDataStore.cs
@@ -44,6 +44,14 @@ public class EngagementDataStore(BroadcastingContext broadcastingContext, IMappe
         return mapper.Map<List<Domain.Models.Engagement>>(dbEngagements);
     }
 
+    public async Task<List<Domain.Models.Engagement>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbEngagements = await broadcastingContext.Engagements
+            .Where(e => e.CreatedByEntraOid == ownerEntraOid)
+            .ToListAsync(cancellationToken);
+        return mapper.Map<List<Domain.Models.Engagement>>(dbEngagements);
+    }
+
     public async Task<OperationResult<bool>> DeleteAsync(Domain.Models.Engagement engagement, CancellationToken cancellationToken = default)
     {
         return await DeleteAsync(engagement.Id, cancellationToken);
@@ -217,6 +225,36 @@ public class EngagementDataStore(BroadcastingContext broadcastingContext, IMappe
     public async Task<Domain.Models.PagedResult<Domain.Models.Engagement>> GetAllAsync(int page, int pageSize, string sortBy = "startdate", bool sortDescending = true, string? filter = null, CancellationToken cancellationToken = default)
     {
         IQueryable<Models.Engagement> query = broadcastingContext.Engagements;
+        
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            var lowerFilter = filter.ToLowerInvariant();
+            query = query.Where(e => e.Name.ToLower().Contains(lowerFilter));
+        }
+        
+        query = sortBy?.ToLowerInvariant() switch
+        {
+            "name" => sortDescending ? query.OrderByDescending(e => e.Name) : query.OrderBy(e => e.Name),
+            "enddate" => sortDescending ? query.OrderByDescending(e => e.EndDateTime) : query.OrderBy(e => e.EndDateTime),
+            _ => sortDescending ? query.OrderByDescending(e => e.StartDateTime) : query.OrderBy(e => e.StartDateTime),
+        };
+        
+        var totalCount = await query.CountAsync(cancellationToken);
+        var dbItems = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        return new Domain.Models.PagedResult<Domain.Models.Engagement>
+        {
+            Items = mapper.Map<List<Domain.Models.Engagement>>(dbItems),
+            TotalCount = totalCount
+        };
+    }
+
+    public async Task<Domain.Models.PagedResult<Domain.Models.Engagement>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "startdate", bool sortDescending = true, string? filter = null, CancellationToken cancellationToken = default)
+    {
+        IQueryable<Models.Engagement> query = broadcastingContext.Engagements
+            .Where(e => e.CreatedByEntraOid == ownerEntraOid);
         
         if (!string.IsNullOrWhiteSpace(filter))
         {

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/MessageTemplateDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/MessageTemplateDataStore.cs
@@ -20,6 +20,15 @@ public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, I
         return mapper.Map<List<Domain.Models.MessageTemplate>>(dbMessageTemplates);
     }
 
+    public async Task<List<Domain.Models.MessageTemplate>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbMessageTemplates = await broadcastingContext.MessageTemplates
+            .AsNoTracking()
+            .Where(mt => mt.CreatedByEntraOid == ownerEntraOid)
+            .ToListAsync(cancellationToken);
+        return mapper.Map<List<Domain.Models.MessageTemplate>>(dbMessageTemplates);
+    }
+
     public async Task<Domain.Models.MessageTemplate?> UpdateAsync(Domain.Models.MessageTemplate messageTemplate, CancellationToken cancellationToken = default)
     {
         var existing = await broadcastingContext.MessageTemplates
@@ -37,6 +46,25 @@ public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, I
         var totalCount = await broadcastingContext.MessageTemplates.CountAsync(cancellationToken);
         var dbItems = await broadcastingContext.MessageTemplates
             .AsNoTracking()
+            .OrderBy(mt => mt.SocialMediaPlatformId)
+            .ThenBy(mt => mt.MessageType)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        return new Domain.Models.PagedResult<Domain.Models.MessageTemplate>
+        {
+            Items = mapper.Map<List<Domain.Models.MessageTemplate>>(dbItems),
+            TotalCount = totalCount
+        };
+    }
+
+    public async Task<Domain.Models.PagedResult<Domain.Models.MessageTemplate>> GetAllAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var query = broadcastingContext.MessageTemplates
+            .AsNoTracking()
+            .Where(mt => mt.CreatedByEntraOid == ownerEntraOid);
+        var totalCount = await query.CountAsync(cancellationToken);
+        var dbItems = await query
             .OrderBy(mt => mt.SocialMediaPlatformId)
             .ThenBy(mt => mt.MessageType)
             .Skip((page - 1) * pageSize)

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/ScheduledItemDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/ScheduledItemDataStore.cs
@@ -40,6 +40,14 @@ public class ScheduledItemDataStore(BroadcastingContext broadcastingContext, IMa
         return mapper.Map<List<Domain.Models.ScheduledItem>>(dbScheduledItems);
     }
 
+    public async Task<List<Domain.Models.ScheduledItem>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbScheduledItems = await broadcastingContext.ScheduledItems
+            .Where(si => si.CreatedByEntraOid == ownerEntraOid)
+            .ToListAsync(cancellationToken);
+        return mapper.Map<List<Domain.Models.ScheduledItem>>(dbScheduledItems);
+    }
+
     public async Task<OperationResult<bool>> DeleteAsync(Domain.Models.ScheduledItem scheduledItem, CancellationToken cancellationToken = default)
     {
         return await DeleteAsync(scheduledItem.Id, cancellationToken);
@@ -78,12 +86,30 @@ public class ScheduledItemDataStore(BroadcastingContext broadcastingContext, IMa
         return mapper.Map<List<Domain.Models.ScheduledItem>>(dbScheduledItems);
     }
 
+    public async Task<List<Domain.Models.ScheduledItem>> GetUnsentScheduledItemsAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbScheduledItems = await broadcastingContext.ScheduledItems
+            .Where(si => si.CreatedByEntraOid == ownerEntraOid && si.MessageSent == false)
+            .ToListAsync(cancellationToken);
+        return mapper.Map<List<Domain.Models.ScheduledItem>>(dbScheduledItems);
+    }
+
     public async Task<List<Domain.Models.ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(int year, int month, CancellationToken cancellationToken = default)
     {
         var startDate = new DateTime(year, month, 1, 0, 0, 0);
         var endDate = new DateTime(year, month, DateTime.DaysInMonth(year, month), 11, 59, 59);
         var dbScheduledItems = await broadcastingContext.ScheduledItems
             .Where(si => si.SendOnDateTime >= startDate && si.SendOnDateTime <= endDate)
+            .ToListAsync(cancellationToken);
+        return mapper.Map<List<Domain.Models.ScheduledItem>>(dbScheduledItems);
+    }
+
+    public async Task<List<Domain.Models.ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(string ownerEntraOid, int year, int month, CancellationToken cancellationToken = default)
+    {
+        var startDate = new DateTime(year, month, 1, 0, 0, 0);
+        var endDate = new DateTime(year, month, DateTime.DaysInMonth(year, month), 11, 59, 59);
+        var dbScheduledItems = await broadcastingContext.ScheduledItems
+            .Where(si => si.CreatedByEntraOid == ownerEntraOid && si.SendOnDateTime >= startDate && si.SendOnDateTime <= endDate)
             .ToListAsync(cancellationToken);
         return mapper.Map<List<Domain.Models.ScheduledItem>>(dbScheduledItems);
     }
@@ -116,6 +142,25 @@ public class ScheduledItemDataStore(BroadcastingContext broadcastingContext, IMa
         return mapper.Map<IEnumerable<Domain.Models.ScheduledItem>>(dbScheduledItems);
     }
 
+    public async Task<IEnumerable<Domain.Models.ScheduledItem>> GetOrphanedScheduledItemsAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbScheduledItems = await broadcastingContext.ScheduledItems
+            .Where(s => s.CreatedByEntraOid == ownerEntraOid)
+            .Where(s =>
+                (s.ItemTableName == ScheduledItemType.Engagements.ToString() &&
+                 !broadcastingContext.Engagements.Any(e => e.Id == s.ItemPrimaryKey)) ||
+                (s.ItemTableName == ScheduledItemType.Talks.ToString() &&
+                 !broadcastingContext.Talks.Any(t => t.Id == s.ItemPrimaryKey)) ||
+                (s.ItemTableName == ScheduledItemType.SyndicationFeedSources.ToString() &&
+                 !broadcastingContext.SyndicationFeedSources.Any(sf => sf.Id == s.ItemPrimaryKey)) ||
+                (s.ItemTableName == ScheduledItemType.YouTubeSources.ToString() &&
+                 !broadcastingContext.YouTubeSources.Any(y => y.Id == s.ItemPrimaryKey))
+            )
+            .ToListAsync(cancellationToken);
+
+        return mapper.Map<IEnumerable<Domain.Models.ScheduledItem>>(dbScheduledItems);
+    }
+
     public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetAllAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var totalCount = await broadcastingContext.ScheduledItems.CountAsync(cancellationToken);
@@ -131,9 +176,41 @@ public class ScheduledItemDataStore(BroadcastingContext broadcastingContext, IMa
         };
     }
 
+    public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetAllAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var query = broadcastingContext.ScheduledItems.Where(si => si.CreatedByEntraOid == ownerEntraOid);
+        var totalCount = await query.CountAsync(cancellationToken);
+        var dbItems = await query
+            .OrderBy(si => si.SendOnDateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        return new Domain.Models.PagedResult<Domain.Models.ScheduledItem>
+        {
+            Items = mapper.Map<List<Domain.Models.ScheduledItem>>(dbItems),
+            TotalCount = totalCount
+        };
+    }
+
     public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetUnsentScheduledItemsAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = broadcastingContext.ScheduledItems.Where(si => !si.MessageSent);
+        var totalCount = await query.CountAsync(cancellationToken);
+        var dbItems = await query
+            .OrderBy(si => si.SendOnDateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        return new Domain.Models.PagedResult<Domain.Models.ScheduledItem>
+        {
+            Items = mapper.Map<List<Domain.Models.ScheduledItem>>(dbItems),
+            TotalCount = totalCount
+        };
+    }
+
+    public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetUnsentScheduledItemsAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var query = broadcastingContext.ScheduledItems.Where(si => si.CreatedByEntraOid == ownerEntraOid && !si.MessageSent);
         var totalCount = await query.CountAsync(cancellationToken);
         var dbItems = await query
             .OrderBy(si => si.SendOnDateTime)
@@ -183,9 +260,55 @@ public class ScheduledItemDataStore(BroadcastingContext broadcastingContext, IMa
         };
     }
 
+    public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(string ownerEntraOid, int year, int month, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var startDate = new DateTime(year, month, 1, 0, 0, 0);
+        var endDate = new DateTime(year, month, DateTime.DaysInMonth(year, month), 11, 59, 59);
+        var query = broadcastingContext.ScheduledItems
+            .Where(si => si.CreatedByEntraOid == ownerEntraOid && si.SendOnDateTime >= startDate && si.SendOnDateTime <= endDate);
+        var totalCount = await query.CountAsync(cancellationToken);
+        var dbItems = await query
+            .OrderBy(si => si.SendOnDateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        return new Domain.Models.PagedResult<Domain.Models.ScheduledItem>
+        {
+            Items = mapper.Map<List<Domain.Models.ScheduledItem>>(dbItems),
+            TotalCount = totalCount
+        };
+    }
+
     public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetOrphanedScheduledItemsAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = broadcastingContext.ScheduledItems
+            .Where(s =>
+                (s.ItemTableName == ScheduledItemType.Engagements.ToString() &&
+                 !broadcastingContext.Engagements.Any(e => e.Id == s.ItemPrimaryKey)) ||
+                (s.ItemTableName == ScheduledItemType.Talks.ToString() &&
+                 !broadcastingContext.Talks.Any(t => t.Id == s.ItemPrimaryKey)) ||
+                (s.ItemTableName == ScheduledItemType.SyndicationFeedSources.ToString() &&
+                 !broadcastingContext.SyndicationFeedSources.Any(sf => sf.Id == s.ItemPrimaryKey)) ||
+                (s.ItemTableName == ScheduledItemType.YouTubeSources.ToString() &&
+                 !broadcastingContext.YouTubeSources.Any(y => y.Id == s.ItemPrimaryKey))
+            );
+        var totalCount = await query.CountAsync(cancellationToken);
+        var dbItems = await query
+            .OrderBy(si => si.SendOnDateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        return new Domain.Models.PagedResult<Domain.Models.ScheduledItem>
+        {
+            Items = mapper.Map<List<Domain.Models.ScheduledItem>>(dbItems),
+            TotalCount = totalCount
+        };
+    }
+
+    public async Task<Domain.Models.PagedResult<Domain.Models.ScheduledItem>> GetOrphanedScheduledItemsAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var query = broadcastingContext.ScheduledItems
+            .Where(s => s.CreatedByEntraOid == ownerEntraOid)
             .Where(s =>
                 (s.ItemTableName == ScheduledItemType.Engagements.ToString() &&
                  !broadcastingContext.Engagements.Any(e => e.Id == s.ItemPrimaryKey)) ||

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
@@ -76,6 +76,22 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
         return mapper.Map<List<Domain.Models.SyndicationFeedSource>>(dbSyndicationFeedSources);
     }
 
+    public async Task<List<Domain.Models.SyndicationFeedSource>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbSyndicationFeedSources = await broadcastingContext.SyndicationFeedSources
+            .Where(s => s.CreatedByEntraOid == ownerEntraOid)
+            .ToListAsync(cancellationToken);
+        
+        foreach (var source in dbSyndicationFeedSources)
+        {
+            source.SourceTags = await broadcastingContext.SourceTags
+                .Where(st => st.SourceId == source.Id && st.SourceType == SourceType)
+                .ToListAsync(cancellationToken);
+        }
+        
+        return mapper.Map<List<Domain.Models.SyndicationFeedSource>>(dbSyndicationFeedSources);
+    }
+
     public async Task<OperationResult<bool>> DeleteAsync(Domain.Models.SyndicationFeedSource entity, CancellationToken cancellationToken = default)
     {
         return await DeleteAsync(entity.Id, cancellationToken);
@@ -143,6 +159,38 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
     {
         var query = broadcastingContext.SyndicationFeedSources
             .AsNoTracking()
+            .Where(s => s.PublicationDate >= cutoffDate || s.ItemLastUpdatedOn >= cutoffDate);
+
+        if (excludedCategories.Count > 0)
+        {
+            var excludedSourceIds = await broadcastingContext.SourceTags
+                .Where(st => st.SourceType == SourceType && excludedCategories.Contains(st.Tag))
+                .Select(st => st.SourceId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            query = query.Where(s => !excludedSourceIds.Contains(s.Id));
+        }
+
+        var dbSyndicationFeedSource = await query.OrderBy(u => Guid.NewGuid())
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (dbSyndicationFeedSource is not null)
+        {
+            dbSyndicationFeedSource.SourceTags = await broadcastingContext.SourceTags
+                .AsNoTracking()
+                .Where(st => st.SourceId == dbSyndicationFeedSource.Id && st.SourceType == SourceType)
+                .ToListAsync(cancellationToken);
+        }
+
+        return dbSyndicationFeedSource is null ? null : mapper.Map<Domain.Models.SyndicationFeedSource>(dbSyndicationFeedSource);
+    }
+
+    public async Task<Domain.Models.SyndicationFeedSource?> GetRandomSyndicationDataAsync(string ownerEntraOid, DateTimeOffset cutoffDate, List<string> excludedCategories, CancellationToken cancellationToken = default)
+    {
+        var query = broadcastingContext.SyndicationFeedSources
+            .AsNoTracking()
+            .Where(s => s.CreatedByEntraOid == ownerEntraOid)
             .Where(s => s.PublicationDate >= cutoffDate || s.ItemLastUpdatedOn >= cutoffDate);
 
         if (excludedCategories.Count > 0)

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
@@ -75,6 +75,22 @@ public class YouTubeSourceDataStore(BroadcastingContext broadcastingContext, IMa
         return mapper.Map<List<Domain.Models.YouTubeSource>>(dbYouTubeSources);
     }
 
+    public async Task<List<Domain.Models.YouTubeSource>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
+    {
+        var dbYouTubeSources = await broadcastingContext.YouTubeSources
+            .Where(y => y.CreatedByEntraOid == ownerEntraOid)
+            .ToListAsync(cancellationToken);
+        
+        foreach (var source in dbYouTubeSources)
+        {
+            source.SourceTags = await broadcastingContext.SourceTags
+                .Where(st => st.SourceId == source.Id && st.SourceType == SourceType)
+                .ToListAsync(cancellationToken);
+        }
+        
+        return mapper.Map<List<Domain.Models.YouTubeSource>>(dbYouTubeSources);
+    }
+
     public async Task<OperationResult<bool>> DeleteAsync(Domain.Models.YouTubeSource entity, CancellationToken cancellationToken = default)
     {
         return await DeleteAsync(entity.Id, cancellationToken);

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IEngagementDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IEngagementDataStore.cs
@@ -13,6 +13,8 @@ public interface IEngagementDataStore : IDataStore<Engagement>
     public Task<Talk?> GetTalkAsync(int talkId, CancellationToken cancellationToken = default);
     public Task<Engagement?> GetByNameAndUrlAndYearAsync(string name, string url, int year, CancellationToken cancellationToken = default);
     
+    Task<List<Engagement>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
+    Task<PagedResult<Engagement>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "startdate", bool sortDescending = true, string? filter = null, CancellationToken cancellationToken = default);
     Task<PagedResult<Engagement>> GetAllAsync(int page, int pageSize, string sortBy = "startdate", bool sortDescending = true, string? filter = null, CancellationToken cancellationToken = default);
     Task<PagedResult<Talk>> GetTalksForEngagementAsync(int engagementId, int page, int pageSize, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateDataStore.cs
@@ -8,5 +8,7 @@ public interface IMessageTemplateDataStore
     Task<List<MessageTemplate>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<MessageTemplate?> UpdateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default);
     
+    Task<List<MessageTemplate>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
     Task<PagedResult<MessageTemplate>> GetAllAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<MessageTemplate>> GetAllAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IScheduledItemDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IScheduledItemDataStore.cs
@@ -10,9 +10,18 @@ public interface IScheduledItemDataStore : IDataRepository<ScheduledItem>
     public Task<bool> SentScheduledItemAsync(int primaryKey, DateTimeOffset sentOn, CancellationToken cancellationToken = default);
     Task<IEnumerable<Domain.Models.ScheduledItem>> GetOrphanedScheduledItemsAsync(CancellationToken cancellationToken = default);
     
+    Task<List<ScheduledItem>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
+    Task<List<ScheduledItem>> GetUnsentScheduledItemsAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
+    Task<List<ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(string ownerEntraOid, int year, int month, CancellationToken cancellationToken = default);
+    Task<IEnumerable<ScheduledItem>> GetOrphanedScheduledItemsAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
+    
     Task<PagedResult<ScheduledItem>> GetAllAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<ScheduledItem>> GetAllAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<PagedResult<ScheduledItem>> GetUnsentScheduledItemsAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<ScheduledItem>> GetUnsentScheduledItemsAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<PagedResult<ScheduledItem>> GetScheduledItemsToSendAsync(int page, int pageSize, CancellationToken cancellationToken = default);
     Task<PagedResult<ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(int year, int month, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(string ownerEntraOid, int year, int month, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<PagedResult<ScheduledItem>> GetOrphanedScheduledItemsAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<ScheduledItem>> GetOrphanedScheduledItemsAsync(string ownerEntraOid, int page, int pageSize, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/ISyndicationFeedSourceDataStore.cs
@@ -7,4 +7,7 @@ public interface ISyndicationFeedSourceDataStore : IDataStore<SyndicationFeedSou
     public Task<SyndicationFeedSource?> GetByUrlAsync(string url, CancellationToken cancellationToken = default);
     Task<SyndicationFeedSource?> GetByFeedIdentifierAsync(string feedIdentifier, CancellationToken cancellationToken = default);
     Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(DateTimeOffset cutoffDate, List<string> excludedCategories, CancellationToken cancellationToken = default);
+    
+    Task<List<SyndicationFeedSource>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
+    Task<SyndicationFeedSource?> GetRandomSyndicationDataAsync(string ownerEntraOid, DateTimeOffset cutoffDate, List<string> excludedCategories, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IYouTubeSourceDataStore.cs
@@ -4,4 +4,6 @@ public interface IYouTubeSourceDataStore : IDataStore<Domain.Models.YouTubeSourc
 {
     public Task<Domain.Models.YouTubeSource?> GetByUrlAsync(string url, CancellationToken cancellationToken = default);
     Task<Domain.Models.YouTubeSource?> GetByVideoIdAsync(string videoId, CancellationToken cancellationToken = default);
+    
+    Task<List<Domain.Models.YouTubeSource>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
@@ -52,14 +52,14 @@ public class SyndicationFeedSourceManagerTests
     {
         // Arrange
         var sources = new List<SyndicationFeedSource> { new SyndicationFeedSource { Id = 1, FeedIdentifier = "Test", CreatedByEntraOid = "" } };
-        _repository.Setup(r => r.GetAllAsync(default)).ReturnsAsync(sources);
+        _repository.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(sources);
 
         // Act
         var result = await _syndicationFeedSourceManager.GetAllAsync();
 
         // Assert
         Assert.Equal(sources, result);
-        _repository.Verify(r => r.GetAllAsync(default), Times.Once);
+        _repository.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
@@ -52,14 +52,14 @@ public class YouTubeSourceManagerTests
     {
         // Arrange
         var sources = new List<YouTubeSource> { new YouTubeSource { Id = 1, CreatedByEntraOid = "" } };
-        _repository.Setup(r => r.GetAllAsync(default)).ReturnsAsync(sources);
+        _repository.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(sources);
 
         // Act
         var result = await _youTubeSourceManager.GetAllAsync();
 
         // Assert
         Assert.Equal(sources, result);
-        _repository.Verify(r => r.GetAllAsync(default), Times.Once);
+        _repository.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements Sprint 16 of Epic #609 (per-user isolation). Adds owner-filtered query overloads across all data stores so each user sees only their own data.

## Changes

- **Domain interfaces** — Added `GetAllAsync(ownerEntraOid)` overloads to 5 interfaces
- **Data.Sql implementations** — Filter by `.Where(x => x.CreatedByEntraOid == ownerEntraOid)` in each overload
- **Existing methods preserved** — Parameterless methods retained for Site Admin and background job use

## Data Stores Updated

| Data Store | Methods Added |
|---|---|
| `SyndicationFeedSourceDataStore` | `GetAllAsync(ownerEntraOid)`, `GetRandomSyndicationDataAsync(ownerEntraOid, ...)` |
| `YouTubeSourceDataStore` | `GetAllAsync(ownerEntraOid)` |
| `EngagementDataStore` | `GetAllAsync(ownerEntraOid)` (list + paged variants) |
| `ScheduledItemDataStore` | `GetAllAsync`, `GetUnsentScheduledItemsAsync`, `GetScheduledItemsByCalendarMonthAsync`, `GetOrphanedScheduledItemsAsync` (all with owner filter) |
| `MessageTemplateDataStore` | `GetAllAsync(ownerEntraOid)` (list + paged variants) |

## Testing

- All existing tests pass (846 total, 805 passed, 41 skipped)
- Parameterless method behavior unchanged
- Mock setup updated in manager tests for overload resolution

## Dependencies

- Requires #725 + #734 (merged ✅)

Closes #727
