### PR TITLE
feat(#729): enforce owner isolation in API controllers

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -255,3 +255,24 @@ For breaking database migrations involving PK rebuilds or column drops:
 - Cross-check claimed scope against actual diff
 
 **Verdict:** REJECTED — Assigned to Morpheus to fix (Trinity lockout per rejection rules).
+
+## Learnings — PR #736 Code Review (2026-04-17)
+
+**Context:** Review of PR #736 (feat(#728): Thread owner OID through manager business logic) — Sprint 17 of Epic #609 per-user data isolation.
+
+**Scope:** 25 files, +448/-66 lines. Manager interfaces + implementations, reader interfaces + implementations, Functions Settings, collector Functions, and tests.
+
+**Key review points verified:**
+1. **Reader overload pattern:** New `ownerOid` overloads call parameterless version, then apply `ApplyOwnerOid()` helper that sets `CreatedByEntraOid = ownerOid`
+2. **Manager pass-through:** All manager `ownerEntraOid` overloads are single-line delegations to data stores — no OID resolution logic
+3. **Functions Settings:** `ISettings.OwnerEntraOid` added as `required string` with XML docs — fails fast if config missing
+4. **Collector updates:** All 4 collectors (LoadAllPosts, LoadNewPosts, LoadAllVideos, LoadNewVideos) pass `settingsOptions.Value.OwnerEntraOid`
+5. **Backward compatibility:** Parameterless methods preserved with `string.Empty` for admin/background processing contexts
+6. **Test updates:** All 4 collector test files updated mock setups to pass `OwnerEntraOid` constant
+
+**Pattern confirmed:**
+- For owner-aware overloads: call existing parameterless method, then post-process to apply ownership
+- This preserves existing behavior while adding new capability
+- `required string` on Settings properties catches missing config at startup, not runtime
+
+**Verdict:** ✅ APPROVED — Clean implementation, all acceptance criteria met, no invariant violations.

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -1,5 +1,24 @@
 # Neo - History
 
+## Learnings — PR #739 Final Review (2026-04-18)
+
+**Context:** Third and final review of PR #739 (feat(#729): enforce owner isolation in API controllers). Previous rejections were for missing non-owner 403 tests (Round 1: zero tests, Round 2: Talks/Platforms sub-actions missing).
+
+**Final state after Tank's Round 2 additions:**
+- **Total tests:** 93/93 passing
+- **Security tests added:** 20 total (11 Round 1 + 9 Round 2)
+
+**Coverage verified:**
+- All 17 `Forbid()` call sites across 3 controllers now have non-owner `ForbidResult` tests
+- All 3 `IsSiteAdministrator()` branching locations have SiteAdmin unfiltered-overload tests
+- Entity OID (`owner-oid-12345`) ≠ User OID (`non-owner-oid-99999`) pattern consistently applied
+- No magic strings — all constants from `Domain.Constants.*` and `Domain.Scopes.*`
+- Moq patterns correct (`Times.Never` on side-effectful calls when authorization fails)
+
+**Platforms test design note:** The `EngagementsController_PlatformsTests` constructor sets up a default mock returning `BuildEngagement(id)` with OID `test-oid-12345`. Security tests then create the SUT with `ownerOid: "non-owner-oid-99999"` to ensure the ownership check fails. This is a clean pattern that avoids per-test mock setup boilerplate.
+
+**Verdict:** ✅ APPROVED — All ownership-guarded paths covered. Ready for Joseph to merge.
+
 ## Core Context
 
 **Role:** Lead Reviewer & Architect | Architecture, code reviews, issue triage, sprint planning, CI/CD
@@ -276,3 +295,27 @@ For breaking database migrations involving PK rebuilds or column drops:
 - `required string` on Settings properties catches missing config at startup, not runtime
 
 **Verdict:** ✅ APPROVED — Clean implementation, all acceptance criteria met, no invariant violations.
+
+## Learnings — PR #739 Follow-up Review (2026-04-18)
+
+**Context:** Re-review of PR #739 (feat(#729): enforce owner isolation in API controllers) after Tank added 11 security tests across 3 test files on branch `issue-729`. Previous rejection was for zero 403/ForbidResult and SiteAdmin bypass tests.
+
+**Test run:** 84/84 green. All new tests pass correctly.
+
+**What Tank got right:**
+- `SchedulesController`: All 4 guarded actions covered (GetScheduledItem, UpdateScheduledItem, DeleteScheduledItem non-owner + GetAll SiteAdmin) ✅
+- `MessageTemplatesController`: All 3 guarded actions covered (Get, Update non-owner + GetAll SiteAdmin) ✅ (new test file)
+- `EngagementsController` top-level CRUD: All 4 covered (GetEngagement, UpdateEngagement, DeleteEngagement non-owner + GetEngagements SiteAdmin) ✅
+- Correct pattern: entity OID ≠ user OID → `ForbidResult`, side-effectful calls verified `Times.Never` ✅
+- No magic strings — `Domain.Constants.ApplicationClaimTypes.EntraObjectId`, `RoleNames.SiteAdministrator`, `Domain.Scopes.*` constants used ✅
+- Moq `It.IsAny<CancellationToken>()` pattern correct ✅
+
+**What Tank missed — BLOCKERS:**
+`EngagementsController` has 9 more ownership-guarded actions with zero non-owner 403 tests:
+- **Talks sub-actions (5):** `GetTalksForEngagementAsync`, `CreateTalkAsync`, `UpdateTalkAsync`, `GetTalkAsync`, `DeleteTalkAsync`
+- **Platforms sub-actions (4):** `GetPlatformsForEngagementAsync`, `GetPlatformForEngagementAsync`, `AddPlatformToEngagementAsync`, `RemovePlatformFromEngagementAsync`
+All 9 have the identical `if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid()) return Forbid();` pattern, but no non-owner test exercises it.
+
+**Verdict:** ❌ REJECTED — Talks and Platforms sub-resource ownership paths uncovered. PR comment #739 posted with specific tests required.
+
+**Pattern reinforced:** When reviewing ownership-guarded controllers, grep for ALL `Forbid()` call sites, not just the primary CRUD actions. Sub-resource actions on the same entity share the same ownership gate and need the same test coverage.

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -2,6 +2,34 @@
 
 ## Learnings
 
+### 2026-04-17 — Issue #729: API Owner Isolation
+**Status:** ✅ COMPLETE & BUILD VERIFIED — PR #739
+
+**Task:** Enforce per-user owner isolation in API controllers (sub-issue of multi-tenancy epic #609).
+
+**Changes Made:**
+1. **Helper Methods:** Added `GetOwnerOid()` and `IsSiteAdministrator()` to EngagementsController, SchedulesController, MessageTemplatesController
+2. **GET List Endpoints:** Site Admins call unfiltered `GetAllAsync(page, pageSize, ...)`, regular users call owner-filtered `GetAllAsync(ownerOid, page, pageSize, ...)`
+3. **GET by ID:** After fetching record, verify `record.CreatedByEntraOid == ownerOid` — return `403 Forbid` if non-admin user attempts cross-owner access
+4. **POST:** Set `entity.CreatedByEntraOid = GetOwnerOid()` before calling `SaveAsync`
+5. **PUT:** Fetch existing record, verify ownership, preserve `CreatedByEntraOid` during update
+6. **DELETE:** Fetch record first, verify ownership, then call `DeleteAsync`
+7. **Talk/Platform Sub-Resources:** All operations verify parent engagement ownership before proceeding
+8. **SocialMediaPlatformsController:** No changes (global catalog, managed by Site Admin)
+
+**Test Updates:**
+- Updated `CreateControllerContext` helper in test files to include `ApplicationClaimTypes.EntraObjectId` claim
+- Updated all mock setups to use owner-filtered method signatures (e.g., `GetAllAsync(string, int, int, ...)`)
+- Added `CreatedByEntraOid = "test-oid-12345"` to all test domain objects
+- Added missing `GetAsync` mocks for DELETE/PUT operations (ownership check before mutation)
+
+**Build Status:** 0 errors, 846/846 tests passing (excluding network-dependent SyndicationFeedReader tests).
+
+**Rationale:** This completes the API layer of multi-tenancy isolation. JWT bearer tokens carry Entra OID; controllers extract it via `ApplicationClaimTypes.EntraObjectId` constant and pass to managers. Site Admin role bypass ensures support staff can troubleshoot all records.
+
+**PR:** #739  
+**Decision Filed:** `.squad/decisions/inbox/trinity-729-api-owner-isolation.md`
+
 ### 2026-04-17 — Issue #719: Role Restructure
 **Status:** ✅ COMPLETE & BUILD VERIFIED
 

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
@@ -19,20 +19,16 @@ public class EngagementsControllerTests
     private readonly Mock<IEngagementManager> _engagementManagerMock;
     private readonly Mock<IEngagementSocialMediaPlatformDataStore> _engagementSocialMediaPlatformDataStoreMock;
     private readonly Mock<ILogger<EngagementsController>> _loggerMock;
-    private readonly IMapper _mapper;
+
+    // Use the assembly-wide shared mapper to avoid AutoMapper profile-registry races
+    // when xUnit runs test classes in parallel.  See ApiTestMapper for details.
+    private static readonly IMapper _mapper = ApiTestMapper.Instance;
 
     public EngagementsControllerTests()
     {
         _engagementManagerMock = new Mock<IEngagementManager>();
         _engagementSocialMediaPlatformDataStoreMock = new Mock<IEngagementSocialMediaPlatformDataStore>();
         _loggerMock = new Mock<ILogger<EngagementsController>>();
-        
-        // Configure AutoMapper with the API profile
-        var mapperConfig = new MapperConfiguration(cfg =>
-        {
-            cfg.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>();
-        }, new LoggerFactory());
-        _mapper = mapperConfig.CreateMapper();
     }
 
     // -------------------------------------------------------------------------
@@ -67,6 +63,22 @@ public class EngagementsControllerTests
         var httpContext = new DefaultHttpContext { User = user };
         return new ControllerContext { HttpContext = httpContext };
     }
+
+    /// <summary>
+    /// Builds an <see cref="Engagement"/> with <see cref="Engagement.CreatedByEntraOid"/>
+    /// matching the default owner OID used in <see cref="CreateControllerContext"/> so that
+    /// ownership checks inside the controller pass without requiring a SiteAdministrator role.
+    /// </summary>
+    private static Engagement BuildEngagement(int id, string oid = "test-oid-12345") => new()
+    {
+        Id = id,
+        Name = $"Conference {id}",
+        Url = $"https://conf-{id}.example.com",
+        StartDateTime = DateTimeOffset.UtcNow,
+        EndDateTime = DateTimeOffset.UtcNow.AddDays(id),
+        TimeZoneId = "UTC",
+        CreatedByEntraOid = oid
+    };
 
     // -------------------------------------------------------------------------
     // GetEngagementsAsync
@@ -103,7 +115,7 @@ public class EngagementsControllerTests
     public async Task GetEngagementsAsync_WhenNoEngagementsExist_ReturnsEmptyList()
     {
         // Arrange
-        _engagementManagerMock.Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+        _engagementManagerMock.Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()))
             .ReturnsAsync(new PagedResult<Engagement> { Items = new List<Engagement>(), TotalCount = 0 });
 
         var sut = CreateSut(Domain.Scopes.Engagements.All);
@@ -115,7 +127,7 @@ public class EngagementsControllerTests
         result.Value.Should().NotBeNull();
         result.Value!.Items.Should().BeEmpty();
         result.Value!.TotalCount.Should().Be(0);
-        _engagementManagerMock.Verify(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+        _engagementManagerMock.Verify(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()), Times.Once);
     }
 
     // -------------------------------------------------------------------------
@@ -133,7 +145,9 @@ public class EngagementsControllerTests
             Url = "https://conf-a.example.com",
             StartDateTime = DateTimeOffset.UtcNow,
             EndDateTime = DateTimeOffset.UtcNow.AddDays(2),
-            TimeZoneId = "UTC"
+            TimeZoneId = "UTC",
+            // Must match the ownerOid from CreateControllerContext so the ownership check passes.
+            CreatedByEntraOid = "test-oid-12345"
         };
         _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(engagement);
 
@@ -287,6 +301,8 @@ public class EngagementsControllerTests
             EndDateTime = request.EndDateTime,
             TimeZoneId = request.TimeZoneId
         };
+        // GetAsync is called first to load the existing engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(BuildEngagement(1));
         _engagementManagerMock.Setup(m => m.SaveAsync(It.IsAny<Engagement>())).ReturnsAsync(OperationResult<Engagement>.Success(savedEngagement));
 
         var sut = CreateSut(Domain.Scopes.Engagements.All);
@@ -315,6 +331,8 @@ public class EngagementsControllerTests
             EndDateTime = DateTimeOffset.UtcNow.AddDays(1),
             TimeZoneId = "UTC"
         };
+        // GetAsync is called first to load the existing engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(BuildEngagement(1));
         _engagementManagerMock.Setup(m => m.SaveAsync(It.IsAny<Engagement>())).ReturnsAsync(OperationResult<Engagement>.Failure("Save failed"));
 
         var sut = CreateSut(Domain.Scopes.Engagements.All);
@@ -335,6 +353,8 @@ public class EngagementsControllerTests
     public async Task DeleteEngagementAsync_WhenEngagementExists_ReturnsNoContent()
     {
         // Arrange
+        // GetAsync is called first to load the existing engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(BuildEngagement(1));
         _engagementManagerMock.Setup(m => m.DeleteAsync(1)).ReturnsAsync(OperationResult<bool>.Success(true));
 
         var sut = CreateSut(Domain.Scopes.Engagements.All);
@@ -347,11 +367,13 @@ public class EngagementsControllerTests
         _engagementManagerMock.Verify(m => m.DeleteAsync(1), Times.Once);
     }
 
-    [Fact]
+        [Fact]
     public async Task DeleteEngagementAsync_WhenEngagementNotFound_ReturnsNotFound()
     {
         // Arrange
-        _engagementManagerMock.Setup(m => m.DeleteAsync(99)).ReturnsAsync(OperationResult<bool>.Failure("Not found"));
+        // The controller now fetches the engagement first (ownership check).  When
+        // GetAsync returns null it short-circuits with NotFound - DeleteAsync is never invoked.
+        _engagementManagerMock.Setup(m => m.GetAsync(99)).Returns(Task.FromResult<Engagement?>(null));
 
         var sut = CreateSut(Domain.Scopes.Engagements.All);
 
@@ -360,7 +382,8 @@ public class EngagementsControllerTests
 
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();
-        _engagementManagerMock.Verify(m => m.DeleteAsync(99), Times.Once);
+        _engagementManagerMock.Verify(m => m.GetAsync(99), Times.Once);
+        _engagementManagerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never);
     }
 
     // -------------------------------------------------------------------------
@@ -376,6 +399,8 @@ public class EngagementsControllerTests
             new() { Id = 1, EngagementId = 10, Name = "Talk 1", UrlForConferenceTalk = "https://conf.example.com/talk1", UrlForTalk = "https://example.com/talk1", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddHours(1) },
             new() { Id = 2, EngagementId = 10, Name = "Talk 2", UrlForConferenceTalk = "https://conf.example.com/talk2", UrlForTalk = "https://example.com/talk2", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddHours(1) }
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.GetTalksForEngagementAsync(10, It.IsAny<int>(), It.IsAny<int>()))
             .ReturnsAsync(new PagedResult<Talk> { Items = talks, TotalCount = talks.Count });
 
@@ -396,6 +421,8 @@ public class EngagementsControllerTests
     public async Task GetTalksForEngagementAsync_WhenNoTalksExist_ReturnsEmptyList()
     {
         // Arrange
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.GetTalksForEngagementAsync(10, It.IsAny<int>(), It.IsAny<int>()))
             .ReturnsAsync(new PagedResult<Talk> { Items = new List<Talk>(), TotalCount = 0 });
 
@@ -453,6 +480,8 @@ public class EngagementsControllerTests
             StartDateTime = request.StartDateTime,
             EndDateTime = request.EndDateTime
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.SaveTalkAsync(It.IsAny<Talk>())).ReturnsAsync(OperationResult<Talk>.Success(savedTalk));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -481,6 +510,8 @@ public class EngagementsControllerTests
             StartDateTime = DateTimeOffset.UtcNow,
             EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.SaveTalkAsync(It.IsAny<Talk>())).ReturnsAsync(OperationResult<Talk>.Failure("Save failed"));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -535,6 +566,8 @@ public class EngagementsControllerTests
             StartDateTime = request.StartDateTime,
             EndDateTime = request.EndDateTime
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.SaveTalkAsync(It.IsAny<Talk>())).ReturnsAsync(OperationResult<Talk>.Success(savedTalk));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -561,6 +594,8 @@ public class EngagementsControllerTests
             StartDateTime = DateTimeOffset.UtcNow,
             EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.SaveTalkAsync(It.IsAny<Talk>())).ReturnsAsync(OperationResult<Talk>.Failure("Save failed"));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -591,6 +626,8 @@ public class EngagementsControllerTests
             StartDateTime = DateTimeOffset.UtcNow,
             EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.GetTalkAsync(5)).ReturnsAsync(talk);
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -608,6 +645,8 @@ public class EngagementsControllerTests
     public async Task GetTalkAsync_WhenTalkNotFound_ReturnsNotFound()
     {
         // Arrange
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.GetTalkAsync(99)).Returns(Task.FromResult<Talk?>(null));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -634,6 +673,8 @@ public class EngagementsControllerTests
             StartDateTime = DateTimeOffset.UtcNow,
             EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
         };
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.GetTalkAsync(5)).ReturnsAsync(talk);
 
         var sut = CreateSut(Domain.Scopes.Talks.View);
@@ -654,6 +695,8 @@ public class EngagementsControllerTests
     public async Task DeleteTalkAsync_WhenTalkExists_ReturnsNoContent()
     {
         // Arrange
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.RemoveTalkFromEngagementAsync(5)).ReturnsAsync(OperationResult<bool>.Success(true));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);
@@ -670,6 +713,8 @@ public class EngagementsControllerTests
     public async Task DeleteTalkAsync_WhenTalkNotFound_ReturnsNotFound()
     {
         // Arrange
+        // GetAsync is called first to load the engagement for the ownership check.
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(BuildEngagement(10));
         _engagementManagerMock.Setup(m => m.RemoveTalkFromEngagementAsync(99)).ReturnsAsync(OperationResult<bool>.Failure("Not found"));
 
         var sut = CreateSut(Domain.Scopes.Talks.All);

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
@@ -55,12 +55,13 @@ public class EngagementsControllerTests
     /// Both the short "scp" claim and the full URI claim type are set for maximum
     /// compatibility with different versions of Microsoft.Identity.Web.
     /// </summary>
-    private static ControllerContext CreateControllerContext(string scopeClaimValue)
+    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345")
     {
         var user = new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim("scp", scopeClaimValue),
-            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue)
+            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
+            new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
         ], "TestAuthentication"));
 
         var httpContext = new DefaultHttpContext { User = user };
@@ -77,10 +78,10 @@ public class EngagementsControllerTests
         // Arrange
         var engagements = new List<Engagement>
         {
-            new() { Id = 1, Name = "Conference A", Url = "https://conf-a.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(2), TimeZoneId = "UTC" },
-            new() { Id = 2, Name = "Conference B", Url = "https://conf-b.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(3), TimeZoneId = "UTC" }
+            new() { Id = 1, Name = "Conference A", Url = "https://conf-a.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(2), TimeZoneId = "UTC", CreatedByEntraOid = "test-oid-12345" },
+            new() { Id = 2, Name = "Conference B", Url = "https://conf-b.example.com", StartDateTime = DateTimeOffset.UtcNow, EndDateTime = DateTimeOffset.UtcNow.AddDays(3), TimeZoneId = "UTC", CreatedByEntraOid = "test-oid-12345" }
         };
-        _engagementManagerMock.Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+        _engagementManagerMock.Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()))
             .ReturnsAsync(new PagedResult<Engagement> { Items = engagements, TotalCount = engagements.Count });
 
         var sut = CreateSut(Domain.Scopes.Engagements.All);
@@ -95,7 +96,7 @@ public class EngagementsControllerTests
             .ExcludingMissingMembers()
             .Excluding(e => e.Talks));
         result.Value!.TotalCount.Should().Be(2);
-        _engagementManagerMock.Verify(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+        _engagementManagerMock.Verify(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()), Times.Once);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
@@ -795,6 +795,118 @@ public class EngagementsControllerTests
     }
 
     // -------------------------------------------------------------------------
+    // Security: non-owner → 403 ForbidResult (Talks sub-actions)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetTalksForEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Entity is owned by "owner-oid-12345"; the calling user has a different OID.
+        var engagement = BuildEngagement(10, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(engagement);
+
+        var sut = CreateSut(Domain.Scopes.Talks.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetTalksForEngagementAsync(10);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(
+            m => m.GetTalksForEngagementAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetTalkAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Entity is owned by "owner-oid-12345"; the calling user has a different OID.
+        var engagement = BuildEngagement(10, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(engagement);
+
+        var sut = CreateSut(Domain.Scopes.Talks.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetTalkAsync(10, 5);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.GetTalkAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateTalkAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Entity is owned by "owner-oid-12345"; the calling user has a different OID.
+        var engagement = BuildEngagement(10, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(engagement);
+
+        var request = new TalkRequest
+        {
+            Name = "New Talk",
+            UrlForConferenceTalk = "https://conf.example.com/talk",
+            UrlForTalk = "https://example.com/talk",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        var sut = CreateSut(Domain.Scopes.Talks.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.CreateTalkAsync(10, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.SaveTalkAsync(It.IsAny<Talk>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTalkAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Entity is owned by "owner-oid-12345"; the calling user has a different OID.
+        var engagement = BuildEngagement(10, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(engagement);
+
+        var request = new TalkRequest
+        {
+            Name = "Updated Talk",
+            UrlForConferenceTalk = "https://conf.example.com/talk",
+            UrlForTalk = "https://example.com/talk",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        var sut = CreateSut(Domain.Scopes.Talks.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.UpdateTalkAsync(10, 5, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.SaveTalkAsync(It.IsAny<Talk>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteTalkAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Entity is owned by "owner-oid-12345"; the calling user has a different OID.
+        var engagement = BuildEngagement(10, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(10)).ReturnsAsync(engagement);
+
+        var sut = CreateSut(Domain.Scopes.Talks.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.DeleteTalkAsync(10, 5);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.RemoveTalkFromEngagementAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    // -------------------------------------------------------------------------
     // Security: SiteAdmin list → unfiltered GetAll
     // -------------------------------------------------------------------------
 

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
@@ -35,11 +35,11 @@ public class EngagementsControllerTests
     // Helpers
     // -------------------------------------------------------------------------
 
-    private EngagementsController CreateSut(string scopeClaimValue)
+    private EngagementsController CreateSut(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
     {
         var controller = new EngagementsController(_engagementManagerMock.Object, _engagementSocialMediaPlatformDataStoreMock.Object, _loggerMock.Object, _mapper)
         {
-            ControllerContext = CreateControllerContext(scopeClaimValue),
+            ControllerContext = CreateControllerContext(scopeClaimValue, ownerOid, isSiteAdmin),
             ProblemDetailsFactory = new TestProblemDetailsFactory()
         };
         return controller;
@@ -51,15 +51,18 @@ public class EngagementsControllerTests
     /// Both the short "scp" claim and the full URI claim type are set for maximum
     /// compatibility with different versions of Microsoft.Identity.Web.
     /// </summary>
-    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345")
+    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
     {
-        var user = new ClaimsPrincipal(new ClaimsIdentity(
-        [
+        var claims = new List<Claim>
+        {
             new Claim("scp", scopeClaimValue),
             new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
             new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
-        ], "TestAuthentication"));
+        };
+        if (isSiteAdmin)
+            claims.Add(new Claim(ClaimTypes.Role, Domain.Constants.RoleNames.SiteAdministrator));
 
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuthentication"));
         var httpContext = new DefaultHttpContext { User = user };
         return new ControllerContext { HttpContext = httpContext };
     }
@@ -725,5 +728,102 @@ public class EngagementsControllerTests
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();
         _engagementManagerMock.Verify(m => m.RemoveTalkFromEngagementAsync(99), Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: non-owner → 403 ForbidResult
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Entity is owned by "owner-oid-12345"; the calling user has a different OID.
+        var engagement = BuildEngagement(1, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(engagement);
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetEngagementAsync(1);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.GetAsync(1), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        var engagement = BuildEngagement(1, oid: "owner-oid-12345");
+        var request = new EngagementRequest
+        {
+            Name = "Updated Conference",
+            Url = "https://updated-conf.example.com",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddDays(2),
+            TimeZoneId = "UTC"
+        };
+        _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(engagement);
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.UpdateEngagementAsync(1, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.SaveAsync(It.IsAny<Engagement>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        var engagement = BuildEngagement(1, oid: "owner-oid-12345");
+        _engagementManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(engagement);
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.DeleteEngagementAsync(1);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _engagementManagerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: SiteAdmin list → unfiltered GetAll
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetEngagementsAsync_WhenSiteAdmin_CallsUnfilteredGetAll()
+    {
+        // Arrange
+        var engagements = new List<Engagement> { BuildEngagement(1) };
+        // Set up the unfiltered overload (no ownerOid, first param is int page).
+        _engagementManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()))
+            .ReturnsAsync(new PagedResult<Engagement> { Items = engagements, TotalCount = engagements.Count });
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All, isSiteAdmin: true);
+
+        // Act
+        var result = await sut.GetEngagementsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.TotalCount.Should().Be(1);
+
+        // Unfiltered overload must be invoked exactly once …
+        _engagementManagerMock.Verify(
+            m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()),
+            Times.Once);
+        // … and the owner-filtered overload must never be called.
+        _engagementManagerMock.Verify(
+            m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()),
+            Times.Never);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsController_PlatformsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsController_PlatformsTests.cs
@@ -31,7 +31,10 @@ public class EngagementsController_PlatformsTests
     private readonly Mock<IEngagementManager> _engagementManagerMock;
     private readonly Mock<IEngagementSocialMediaPlatformDataStore> _dataStoreMock;
     private readonly Mock<ILogger<EngagementsController>> _loggerMock;
-    private readonly IMapper _mapper;
+
+    // Use the assembly-wide shared mapper to avoid AutoMapper profile-registry races
+    // when xUnit runs test classes in parallel.  See ApiTestMapper for details.
+    private static readonly IMapper _mapper = ApiTestMapper.Instance;
 
     public EngagementsController_PlatformsTests()
     {
@@ -39,11 +42,12 @@ public class EngagementsController_PlatformsTests
         _dataStoreMock = new Mock<IEngagementSocialMediaPlatformDataStore>();
         _loggerMock = new Mock<ILogger<EngagementsController>>();
 
-        var mapperConfig = new MapperConfiguration(cfg =>
-        {
-            cfg.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>();
-        }, new LoggerFactory());
-        _mapper = mapperConfig.CreateMapper();
+        // Every platform endpoint fetches the engagement first for the ownership check.
+        // Set up a default that returns a valid owned engagement for any ID so tests
+        // don't need per-test boilerplate.  Individual tests may override for specific IDs.
+        _engagementManagerMock
+            .Setup(m => m.GetAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((int id, CancellationToken _) => Task.FromResult<Engagement?>(BuildEngagement(id)));
     }
 
     // =========================================================================
@@ -55,12 +59,14 @@ public class EngagementsController_PlatformsTests
     /// carries the supplied OAuth scope value so that
     /// <c>HttpContext.VerifyUserHasAnyAcceptedScope</c> succeeds.
     /// </summary>
-    private EngagementsController CreateSut(string scopeClaimValue)
+    private EngagementsController CreateSut(string scopeClaimValue, string ownerOid = "test-oid-12345")
     {
         var user = new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim("scp", scopeClaimValue),
-            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue)
+            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
+            // Required: GetOwnerOid() reads this claim; must match BuildEngagement(id).CreatedByEntraOid.
+            new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
         ], "TestAuthentication"));
 
         var httpContext = new DefaultHttpContext { User = user };
@@ -76,6 +82,23 @@ public class EngagementsController_PlatformsTests
             ProblemDetailsFactory = new TestProblemDetailsFactory()
         };
     }
+
+
+    /// <summary>
+    /// Builds a minimal <see cref="Engagement"/> with <see cref="Engagement.CreatedByEntraOid"/>
+    /// matching the default owner OID set in <see cref="CreateSut"/>.
+    /// Used as the default return value of <c>GetAsync</c> so the per-endpoint ownership check passes.
+    /// </summary>
+    private static Engagement BuildEngagement(int id, string oid = "test-oid-12345") => new()
+    {
+        Id = id,
+        Name = $"Conference {id}",
+        Url = $"https://conf-{id}.example.com",
+        StartDateTime = DateTimeOffset.UtcNow,
+        EndDateTime = DateTimeOffset.UtcNow.AddDays(id),
+        TimeZoneId = "UTC",
+        CreatedByEntraOid = oid
+    };
 
     /// <summary>Builds a minimal <see cref="EngagementSocialMediaPlatform"/> for testing.</summary>
     private static EngagementSocialMediaPlatform BuildEsmp(

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsController_PlatformsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsController_PlatformsTests.cs
@@ -593,4 +593,83 @@ public class EngagementsController_PlatformsTests
         _dataStoreMock.Verify(d => d.GetByEngagementIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
         _dataStoreMock.Verify(d => d.AddAsync(It.IsAny<EngagementSocialMediaPlatform>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    // =========================================================================
+    // Security: non-owner → 403 ForbidResult (Platforms sub-actions)
+    // The constructor default mock returns BuildEngagement(id) with OID "test-oid-12345".
+    // Creating the SUT with ownerOid "non-owner-oid-99999" ensures the ownership check fails.
+    // =========================================================================
+
+    [Fact]
+    public async Task GetPlatformsForEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Default mock returns engagement owned by "test-oid-12345"; user carries "non-owner-oid-99999".
+        var sut = CreateSut(Scopes.Engagements.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetPlatformsForEngagementAsync(1);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _dataStoreMock.Verify(
+            d => d.GetByEngagementIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPlatformForEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Default mock returns engagement owned by "test-oid-12345"; user carries "non-owner-oid-99999".
+        var sut = CreateSut(Scopes.Engagements.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetPlatformForEngagementAsync(1, 2);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _dataStoreMock.Verify(
+            d => d.GetAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AddPlatformToEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Default mock returns engagement owned by "test-oid-12345"; user carries "non-owner-oid-99999".
+        var request = new EngagementSocialMediaPlatformRequest
+        {
+            SocialMediaPlatformId = 2,
+            Handle = "@handle"
+        };
+        var sut = CreateSut(Scopes.Engagements.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.AddPlatformToEngagementAsync(1, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _dataStoreMock.Verify(
+            d => d.AddAsync(It.IsAny<EngagementSocialMediaPlatform>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RemovePlatformFromEngagementAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Default mock returns engagement owned by "test-oid-12345"; user carries "non-owner-oid-99999".
+        var sut = CreateSut(Scopes.Engagements.Delete, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.RemovePlatformFromEngagementAsync(1, 2);
+
+        // Assert
+        result.Should().BeOfType<ForbidResult>();
+        _dataStoreMock.Verify(
+            d => d.DeleteAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs
@@ -1,0 +1,183 @@
+using System.Security.Claims;
+using AutoMapper;
+using FluentAssertions;
+using JosephGuadagno.Broadcasting.Api.Controllers;
+using JosephGuadagno.Broadcasting.Api.Dtos;
+using JosephGuadagno.Broadcasting.Api.Tests.Helpers;
+using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace JosephGuadagno.Broadcasting.Api.Tests.Controllers;
+
+public class MessageTemplatesControllerTests
+{
+    private readonly Mock<IMessageTemplateDataStore> _messageTemplateDataStoreMock;
+    private readonly Mock<ISocialMediaPlatformManager> _socialMediaPlatformManagerMock;
+    private readonly Mock<ILogger<MessageTemplatesController>> _loggerMock;
+
+    // Use the assembly-wide shared mapper to avoid AutoMapper profile-registry races
+    // when xUnit runs test classes in parallel.  See ApiTestMapper for details.
+    private static readonly IMapper _mapper = ApiTestMapper.Instance;
+
+    public MessageTemplatesControllerTests()
+    {
+        _messageTemplateDataStoreMock = new Mock<IMessageTemplateDataStore>();
+        _socialMediaPlatformManagerMock = new Mock<ISocialMediaPlatformManager>();
+        _loggerMock = new Mock<ILogger<MessageTemplatesController>>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private MessageTemplatesController CreateSut(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
+    {
+        var controller = new MessageTemplatesController(
+            _messageTemplateDataStoreMock.Object,
+            _socialMediaPlatformManagerMock.Object,
+            _loggerMock.Object,
+            _mapper)
+        {
+            ControllerContext = CreateControllerContext(scopeClaimValue, ownerOid, isSiteAdmin),
+            ProblemDetailsFactory = new TestProblemDetailsFactory()
+        };
+        return controller;
+    }
+
+    /// <summary>
+    /// Builds an HttpContext whose <see cref="ClaimsPrincipal"/> carries the given OAuth
+    /// scope so that <c>HttpContext.VerifyUserHasAnyAcceptedScope</c> succeeds.
+    /// Both the short "scp" claim and the full URI claim type are set for maximum
+    /// compatibility with different versions of Microsoft.Identity.Web.
+    /// </summary>
+    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
+    {
+        var claims = new List<Claim>
+        {
+            new Claim("scp", scopeClaimValue),
+            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
+            new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
+        };
+        if (isSiteAdmin)
+            claims.Add(new Claim(ClaimTypes.Role, Domain.Constants.RoleNames.SiteAdministrator));
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuthentication"));
+        var httpContext = new DefaultHttpContext { User = user };
+        return new ControllerContext { HttpContext = httpContext };
+    }
+
+    private static SocialMediaPlatform BuildPlatform(int id = 1, string name = "TestPlatform") => new()
+    {
+        Id = id,
+        Name = name,
+        IsActive = true
+    };
+
+    private static MessageTemplate BuildTemplate(string oid = "test-oid-12345") => new()
+    {
+        SocialMediaPlatformId = 1,
+        MessageType = "RandomPost",
+        Template = "Check out {{ title }}!",
+        CreatedByEntraOid = oid
+    };
+
+    // -------------------------------------------------------------------------
+    // Security: GetAsync — non-owner returns 403
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Template is owned by "owner-oid-12345"; the calling user has a different OID.
+        var platform = BuildPlatform();
+        var template = BuildTemplate(oid: "owner-oid-12345");
+
+        _socialMediaPlatformManagerMock
+            .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platform);
+        _messageTemplateDataStoreMock
+            .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        var sut = CreateSut(Domain.Scopes.MessageTemplates.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetAsync("TestPlatform", "RandomPost");
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _messageTemplateDataStoreMock.Verify(
+            m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: UpdateAsync — non-owner returns 403
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        var platform = BuildPlatform();
+        var template = BuildTemplate(oid: "owner-oid-12345");
+        var request = new MessageTemplateRequest { Template = "Updated {{ title }}!" };
+
+        _socialMediaPlatformManagerMock
+            .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platform);
+        _messageTemplateDataStoreMock
+            .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        var sut = CreateSut(Domain.Scopes.MessageTemplates.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.UpdateAsync("TestPlatform", "RandomPost", request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _messageTemplateDataStoreMock.Verify(
+            m => m.UpdateAsync(It.IsAny<MessageTemplate>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: GetAllAsync — SiteAdmin calls unfiltered overload
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAllAsync_WhenSiteAdmin_CallsUnfilteredGetAll()
+    {
+        // Arrange
+        var templates = new List<MessageTemplate> { BuildTemplate() };
+        // Set up the unfiltered overload (no ownerOid — first param is int page).
+        _messageTemplateDataStoreMock
+            .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<MessageTemplate> { Items = templates, TotalCount = templates.Count });
+
+        var sut = CreateSut(Domain.Scopes.MessageTemplates.All, isSiteAdmin: true);
+
+        // Act
+        var result = await sut.GetAllAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.TotalCount.Should().Be(1);
+
+        // Unfiltered overload must be invoked exactly once …
+        _messageTemplateDataStoreMock.Verify(
+            m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        // … and the owner-filtered overload must never be called.
+        _messageTemplateDataStoreMock.Verify(
+            m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -18,19 +18,15 @@ public class SchedulesControllerTests
 {
     private readonly Mock<IScheduledItemManager> _scheduledItemManagerMock;
     private readonly Mock<ILogger<SchedulesController>> _loggerMock;
-    private readonly IMapper _mapper;
+
+    // Use the assembly-wide shared mapper to avoid AutoMapper profile-registry races
+    // when xUnit runs test classes in parallel.  See ApiTestMapper for details.
+    private static readonly IMapper _mapper = ApiTestMapper.Instance;
 
     public SchedulesControllerTests()
     {
         _scheduledItemManagerMock = new Mock<IScheduledItemManager>();
         _loggerMock = new Mock<ILogger<SchedulesController>>();
-        
-        // Configure AutoMapper with the API profile
-        var mapperConfig = new MapperConfiguration(cfg =>
-        {
-            cfg.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>();
-        }, new LoggerFactory());
-        _mapper = mapperConfig.CreateMapper();
     }
 
     // -------------------------------------------------------------------------
@@ -66,14 +62,16 @@ public class SchedulesControllerTests
         return new ControllerContext { HttpContext = httpContext };
     }
 
-    private static ScheduledItem BuildScheduledItem(int id = 1) => new()
+    private static ScheduledItem BuildScheduledItem(int id = 1, string oid = "test-oid-12345") => new()
     {
         Id = id,
         ItemType = Domain.Enums.ScheduledItemType.SyndicationFeedSources,
         ItemPrimaryKey = id * 10,
         Message = $"Check out item {id}!",
         SendOnDateTime = DateTimeOffset.UtcNow.AddDays(id),
-        MessageSent = false
+        MessageSent = false,
+        // Must match the ownerOid set in CreateControllerContext so ownership checks pass.
+        CreatedByEntraOid = oid
     };
 
     private static ScheduledItemRequest BuildScheduledItemRequest(int id = 1) => new()
@@ -97,7 +95,7 @@ public class SchedulesControllerTests
             BuildScheduledItem(1),
             BuildScheduledItem(2)
         };
-        _scheduledItemManagerMock.Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+        _scheduledItemManagerMock.Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
             .ReturnsAsync(new PagedResult<ScheduledItem> { Items = items, TotalCount = items.Count });
 
         var sut = CreateSut(Domain.Scopes.Schedules.All);
@@ -110,14 +108,14 @@ public class SchedulesControllerTests
         result.Value!.Items.Should().HaveCount(2);
         result.Value!.Items.Should().BeEquivalentTo(items, opts => opts.ExcludingMissingMembers());
         result.Value!.TotalCount.Should().Be(2);
-        _scheduledItemManagerMock.Verify(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+        _scheduledItemManagerMock.Verify(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
     }
 
     [Fact]
     public async Task GetScheduledItemsAsync_WhenNoItemsExist_ReturnsEmptyList()
     {
         // Arrange
-        _scheduledItemManagerMock.Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+        _scheduledItemManagerMock.Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
             .ReturnsAsync(new PagedResult<ScheduledItem> { Items = new List<ScheduledItem>(), TotalCount = 0 });
 
         var sut = CreateSut(Domain.Scopes.Schedules.All);
@@ -129,7 +127,7 @@ public class SchedulesControllerTests
         result.Value.Should().NotBeNull();
         result.Value!.Items.Should().BeEmpty();
         result.Value!.TotalCount.Should().Be(0);
-        _scheduledItemManagerMock.Verify(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+        _scheduledItemManagerMock.Verify(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
     }
 
     // -------------------------------------------------------------------------
@@ -267,6 +265,8 @@ public class SchedulesControllerTests
     {
         // Arrange
         var request = BuildScheduledItemRequest(5);
+        // GetAsync is called first to load the existing item for the ownership check.
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(BuildScheduledItem(5));
         var savedItem = BuildScheduledItem(5);
         savedItem.Message = "Updated message";
         _scheduledItemManagerMock.Setup(m => m.SaveAsync(It.IsAny<ScheduledItem>())).ReturnsAsync(OperationResult<ScheduledItem>.Success(savedItem));
@@ -288,6 +288,8 @@ public class SchedulesControllerTests
     {
         // Arrange
         var request = BuildScheduledItemRequest(5);
+        // GetAsync is called first to load the existing item for the ownership check.
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(BuildScheduledItem(5));
         _scheduledItemManagerMock.Setup(m => m.SaveAsync(It.IsAny<ScheduledItem>())).ReturnsAsync(OperationResult<ScheduledItem>.Failure("Save failed"));
 
         var sut = CreateSut(Domain.Scopes.Schedules.All);
@@ -308,6 +310,8 @@ public class SchedulesControllerTests
     public async Task DeleteScheduledItemAsync_WhenItemExists_ReturnsNoContent()
     {
         // Arrange
+        // GetAsync is called first to load the existing item for the ownership check.
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(BuildScheduledItem(1));
         _scheduledItemManagerMock.Setup(m => m.DeleteAsync(1)).ReturnsAsync(OperationResult<bool>.Success(true));
 
         var sut = CreateSut(Domain.Scopes.Schedules.All);
@@ -324,7 +328,9 @@ public class SchedulesControllerTests
     public async Task DeleteScheduledItemAsync_WhenItemNotFound_ReturnsNotFound()
     {
         // Arrange
-        _scheduledItemManagerMock.Setup(m => m.DeleteAsync(99)).ReturnsAsync(OperationResult<bool>.Failure("Not found"));
+        // The controller now fetches the item first (ownership check).  When GetAsync
+        // returns null it short-circuits with NotFound — DeleteAsync is never invoked.
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(99)).Returns(Task.FromResult<ScheduledItem?>(null));
 
         var sut = CreateSut(Domain.Scopes.Schedules.All);
 
@@ -333,7 +339,8 @@ public class SchedulesControllerTests
 
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();
-        _scheduledItemManagerMock.Verify(m => m.DeleteAsync(99), Times.Once);
+        _scheduledItemManagerMock.Verify(m => m.GetAsync(99), Times.Once);
+        _scheduledItemManagerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never);
     }
 
     // -------------------------------------------------------------------------

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -33,11 +33,11 @@ public class SchedulesControllerTests
     // Helpers
     // -------------------------------------------------------------------------
 
-    private SchedulesController CreateSut(string scopeClaimValue)
+    private SchedulesController CreateSut(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
     {
         var controller = new SchedulesController(_scheduledItemManagerMock.Object, _loggerMock.Object, _mapper)
         {
-            ControllerContext = CreateControllerContext(scopeClaimValue),
+            ControllerContext = CreateControllerContext(scopeClaimValue, ownerOid, isSiteAdmin),
             ProblemDetailsFactory = new TestProblemDetailsFactory()
         };
         return controller;
@@ -49,15 +49,18 @@ public class SchedulesControllerTests
     /// Both the short "scp" claim and the full URI claim type are set for maximum
     /// compatibility with different versions of Microsoft.Identity.Web.
     /// </summary>
-    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345")
+    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
     {
-        var user = new ClaimsPrincipal(new ClaimsIdentity(
-        [
+        var claims = new List<Claim>
+        {
             new Claim("scp", scopeClaimValue),
             new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
             new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
-        ], "TestAuthentication"));
+        };
+        if (isSiteAdmin)
+            claims.Add(new Claim(ClaimTypes.Role, Domain.Constants.RoleNames.SiteAdministrator));
 
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuthentication"));
         var httpContext = new DefaultHttpContext { User = user };
         return new ControllerContext { HttpContext = httpContext };
     }
@@ -341,6 +344,96 @@ public class SchedulesControllerTests
         result.Result.Should().BeOfType<NotFoundResult>();
         _scheduledItemManagerMock.Verify(m => m.GetAsync(99), Times.Once);
         _scheduledItemManagerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: non-owner → 403 ForbidResult
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetScheduledItemAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        // Item is owned by "owner-oid-12345"; the calling user has a different OID.
+        var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(item);
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.GetScheduledItemAsync(5);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _scheduledItemManagerMock.Verify(m => m.GetAsync(5), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateScheduledItemAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+        var request = BuildScheduledItemRequest(5);
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(item);
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.UpdateScheduledItemAsync(5, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _scheduledItemManagerMock.Verify(m => m.SaveAsync(It.IsAny<ScheduledItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteScheduledItemAsync_WhenNonOwner_ReturnsForbid()
+    {
+        // Arrange
+        var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+        _scheduledItemManagerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(item);
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "non-owner-oid-99999");
+
+        // Act
+        var result = await sut.DeleteScheduledItemAsync(5);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+        _scheduledItemManagerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: SiteAdmin list → unfiltered GetAll
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WhenSiteAdmin_CallsUnfilteredGetAll()
+    {
+        // Arrange
+        var items = new List<ScheduledItem> { BuildScheduledItem(1) };
+        // Set up the unfiltered overload (no ownerOid, first param is int page).
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = items, TotalCount = items.Count });
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All, isSiteAdmin: true);
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.TotalCount.Should().Be(1);
+
+        // Unfiltered overload must be invoked exactly once …
+        _scheduledItemManagerMock.Verify(
+            m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()),
+            Times.Once);
+        // … and the owner-filtered overload must never be called.
+        _scheduledItemManagerMock.Verify(
+            m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+            Times.Never);
     }
 
     // -------------------------------------------------------------------------

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -53,12 +53,13 @@ public class SchedulesControllerTests
     /// Both the short "scp" claim and the full URI claim type are set for maximum
     /// compatibility with different versions of Microsoft.Identity.Web.
     /// </summary>
-    private static ControllerContext CreateControllerContext(string scopeClaimValue)
+    private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345")
     {
         var user = new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim("scp", scopeClaimValue),
-            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue)
+            new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
+            new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
         ], "TestAuthentication"));
 
         var httpContext = new DefaultHttpContext { User = user };

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SocialMediaPlatformsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SocialMediaPlatformsControllerTests.cs
@@ -17,18 +17,15 @@ public class SocialMediaPlatformsControllerTests
 {
     private readonly Mock<ISocialMediaPlatformManager> _managerMock;
     private readonly Mock<ILogger<SocialMediaPlatformsController>> _loggerMock;
-    private readonly IMapper _mapper;
+
+    // Use the assembly-wide shared mapper to avoid AutoMapper profile-registry races
+    // when xUnit runs test classes in parallel.  See ApiTestMapper for details.
+    private static readonly IMapper _mapper = ApiTestMapper.Instance;
 
     public SocialMediaPlatformsControllerTests()
     {
         _managerMock = new Mock<ISocialMediaPlatformManager>();
         _loggerMock = new Mock<ILogger<SocialMediaPlatformsController>>();
-
-        var mapperConfig = new MapperConfiguration(cfg =>
-        {
-            cfg.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>();
-        }, new LoggerFactory());
-        _mapper = mapperConfig.CreateMapper();
     }
 
     // -------------------------------------------------------------------------

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Helpers/ApiTestMapper.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Helpers/ApiTestMapper.cs
@@ -1,0 +1,35 @@
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Api.Tests.Helpers;
+
+/// <summary>
+/// Provides a single, lazily-initialized <see cref="IMapper"/> instance for the entire
+/// test assembly.
+///
+/// <para>
+/// Each test class previously created its own <c>MapperConfiguration</c> in a
+/// <c>static readonly</c> field.  Because xUnit runs test classes in parallel,
+/// four static field initializers could call
+/// <c>new MapperConfiguration(cfg => cfg.AddProfile&lt;ApiBroadcastingProfile&gt;())</c>
+/// simultaneously.  AutoMapper 16 maintains an internal, per-profile-type static
+/// registry; concurrent initialization of the same profile from separate
+/// <see cref="MapperConfiguration"/> instances races against that registry and
+/// produces intermittent test failures.
+/// </para>
+/// <para>
+/// Sharing one instance removes the race entirely: the CLR guarantees that a
+/// <c>static readonly</c> field is initialized exactly once, and AutoMapper mappers
+/// are fully immutable and thread-safe after creation.
+/// </para>
+/// </summary>
+public static class ApiTestMapper
+{
+    /// <summary>
+    /// The shared mapper instance configured with <c>ApiBroadcastingProfile</c>.
+    /// </summary>
+    public static readonly IMapper Instance = new MapperConfiguration(
+        cfg => cfg.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>(),
+        new LoggerFactory())
+        .CreateMapper();
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/EngagementsController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using AutoMapper;
 using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
@@ -44,6 +45,17 @@ public class EngagementsController: ControllerBase
         _mapper = mapper;
     }
 
+    private string GetOwnerOid()
+    {
+        return User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)
+            ?? throw new InvalidOperationException("Entra Object ID claim not found");
+    }
+
+    private bool IsSiteAdministrator()
+    {
+        return User.IsInRole(RoleNames.SiteAdministrator);
+    }
+
     /// <summary>
     /// Gets all the engagements
     /// </summary>
@@ -65,7 +77,17 @@ public class EngagementsController: ControllerBase
         
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.List, Domain.Scopes.Engagements.All);
 
-        var result = await _engagementManager.GetAllAsync(page, pageSize, sortBy, sortDescending, filter);
+        PagedResult<Engagement> result;
+        if (IsSiteAdministrator())
+        {
+            result = await _engagementManager.GetAllAsync(page, pageSize, sortBy, sortDescending, filter);
+        }
+        else
+        {
+            var ownerOid = GetOwnerOid();
+            result = await _engagementManager.GetAllAsync(ownerOid, page, pageSize, sortBy, sortDescending, filter);
+        }
+
         var items = _mapper.Map<List<EngagementResponse>>(result.Items);
         
         return new PagedResponse<EngagementResponse>
@@ -99,6 +121,12 @@ public class EngagementsController: ControllerBase
         var engagement = await _engagementManager.GetAsync(engagementId);
         if (engagement is null)
             return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         return Ok(_mapper.Map<EngagementResponse>(engagement));
     }
 
@@ -125,6 +153,7 @@ public class EngagementsController: ControllerBase
         }
 
         var engagement = _mapper.Map<Engagement>(request);
+        engagement.CreatedByEntraOid = GetOwnerOid();
         var result = await _engagementManager.SaveAsync(engagement);
         if (result.IsSuccess && result.Value != null)
         {
@@ -159,8 +188,18 @@ public class EngagementsController: ControllerBase
             return BadRequest(ModelState);    
         }
 
+        var existing = await _engagementManager.GetAsync(engagementId);
+        if (existing is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && existing.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         var engagement = _mapper.Map<Engagement>(request);
         engagement.Id = engagementId;
+        engagement.CreatedByEntraOid = existing.CreatedByEntraOid;
         var result = await _engagementManager.SaveAsync(engagement);
         if (result.IsSuccess && result.Value != null)
         {
@@ -188,6 +227,18 @@ public class EngagementsController: ControllerBase
     public async Task<ActionResult<bool>> DeleteEngagementAsync(int engagementId)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.Delete, Domain.Scopes.Engagements.All);
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+        {
+            _logger.LogWarning("Engagement {EngagementId} not found for deletion", engagementId);
+            return new NotFoundResult();
+        }
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
         
         var wasDeleted = await _engagementManager.DeleteAsync(engagementId);
         if (wasDeleted.IsSuccess)
@@ -195,7 +246,7 @@ public class EngagementsController: ControllerBase
             _logger.LogInformation("Engagement {EngagementId} deleted successfully", engagementId);
             return new NoContentResult();
         }
-        _logger.LogWarning("Engagement {EngagementId} not found for deletion", engagementId);
+        _logger.LogWarning("Engagement {EngagementId} deletion failed", engagementId);
         return new NotFoundResult();
     }
     
@@ -218,6 +269,16 @@ public class EngagementsController: ControllerBase
         if (pageSize > Pagination.MaxPageSize) pageSize = Pagination.MaxPageSize;
         
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.List, Domain.Scopes.Talks.All);
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         var result = await _engagementManager.GetTalksForEngagementAsync(engagementId, page, pageSize);
         var items = _mapper.Map<List<TalkResponse>>(result.Items);
         
@@ -251,6 +312,15 @@ public class EngagementsController: ControllerBase
         {
             _logger.LogWarning("CreateTalkAsync called with invalid model state");
             return BadRequest(ModelState);
+        }
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
         }
 
         var talk = _mapper.Map<Talk>(request);
@@ -290,6 +360,15 @@ public class EngagementsController: ControllerBase
             return BadRequest(ModelState);
         }
 
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         var talk = _mapper.Map<Talk>(request);
         talk.EngagementId = engagementId;
         talk.Id = talkId;
@@ -322,6 +401,15 @@ public class EngagementsController: ControllerBase
     public async Task<ActionResult<TalkResponse>> GetTalkAsync(int engagementId, int talkId)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.View, Domain.Scopes.Talks.All);
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
         
         var talk = await _engagementManager.GetTalkAsync(talkId);
         if (talk is null)
@@ -347,6 +435,15 @@ public class EngagementsController: ControllerBase
     public async Task<ActionResult<bool>> DeleteTalkAsync(int engagementId, int talkId)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Talks.Delete, Domain.Scopes.Talks.All);
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
         
         var wasDeleted =  await _engagementManager.RemoveTalkFromEngagementAsync(talkId);
         
@@ -377,6 +474,15 @@ public class EngagementsController: ControllerBase
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.View, Domain.Scopes.Engagements.All);
 
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         var platforms = await _engagementSocialMediaPlatformDataStore.GetByEngagementIdAsync(engagementId);
         return Ok(_mapper.Map<List<EngagementSocialMediaPlatformResponse>>(platforms));
     }
@@ -404,6 +510,15 @@ public class EngagementsController: ControllerBase
     public async Task<ActionResult<EngagementSocialMediaPlatformResponse>> GetPlatformForEngagementAsync(int engagementId, int platformId)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.View, Domain.Scopes.Engagements.All);
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
 
         var platform = await _engagementSocialMediaPlatformDataStore.GetAsync(engagementId, platformId);
         if (platform is null)
@@ -439,6 +554,15 @@ public class EngagementsController: ControllerBase
         {
             _logger.LogWarning("AddPlatformToEngagementAsync called with invalid model state for engagement {EngagementId}", engagementId);
             return BadRequest(ModelState);
+        }
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
         }
 
         var esmp = _mapper.Map<EngagementSocialMediaPlatform>(request);
@@ -493,6 +617,15 @@ public class EngagementsController: ControllerBase
     public async Task<IActionResult> RemovePlatformFromEngagementAsync(int engagementId, int platformId)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Engagements.Delete, Domain.Scopes.Engagements.All);
+
+        var engagement = await _engagementManager.GetAsync(engagementId);
+        if (engagement is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
 
         var deleted = await _engagementSocialMediaPlatformDataStore.DeleteAsync(engagementId, platformId);
         if (!deleted)

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using AutoMapper;
 using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
@@ -44,6 +45,17 @@ public class MessageTemplatesController : ControllerBase
     private static string SanitizeForLog(string? value) =>
         value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
+    private string GetOwnerOid()
+    {
+        return User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)
+            ?? throw new InvalidOperationException("Entra Object ID claim not found");
+    }
+
+    private bool IsSiteAdministrator()
+    {
+        return User.IsInRole(RoleNames.SiteAdministrator);
+    }
+
     /// <summary>
     /// Gets all message templates
     /// </summary>
@@ -62,7 +74,18 @@ public class MessageTemplatesController : ControllerBase
         if (pageSize > Pagination.MaxPageSize) pageSize = Pagination.MaxPageSize;
         
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.MessageTemplates.List, Domain.Scopes.MessageTemplates.All);
-        var result = await _messageTemplateDataStore.GetAllAsync(page, pageSize);
+
+        PagedResult<MessageTemplate> result;
+        if (IsSiteAdministrator())
+        {
+            result = await _messageTemplateDataStore.GetAllAsync(page, pageSize);
+        }
+        else
+        {
+            var ownerOid = GetOwnerOid();
+            result = await _messageTemplateDataStore.GetAllAsync(ownerOid, page, pageSize);
+        }
+
         var items = _mapper.Map<List<MessageTemplateResponse>>(result.Items);
         
         return new PagedResponse<MessageTemplateResponse>
@@ -104,6 +127,12 @@ public class MessageTemplatesController : ControllerBase
             _logger.LogWarning("MessageTemplate not found for PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
             return NotFound();
         }
+
+        if (!IsSiteAdministrator() && template.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         return _mapper.Map<MessageTemplateResponse>(template);
     }
 
@@ -141,13 +170,26 @@ public class MessageTemplatesController : ControllerBase
             return NotFound();
         }
 
+        var existing = await _messageTemplateDataStore.GetAsync(socialMediaPlatform.Id, messageType);
+        if (existing is null)
+        {
+            _logger.LogWarning("MessageTemplate not found for update: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
+            return NotFound();
+        }
+
+        if (!IsSiteAdministrator() && existing.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         var messageTemplate = _mapper.Map<MessageTemplate>(request);
         messageTemplate.SocialMediaPlatformId = socialMediaPlatform.Id;
         messageTemplate.MessageType = messageType;
+        messageTemplate.CreatedByEntraOid = existing.CreatedByEntraOid;
         var updated = await _messageTemplateDataStore.UpdateAsync(messageTemplate);
         if (updated is null)
         {
-            _logger.LogWarning("MessageTemplate not found for update: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
+            _logger.LogWarning("MessageTemplate update failed: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
             return NotFound();
         }
 

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using AutoMapper;
 using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
@@ -35,6 +36,17 @@ public class SchedulesController: ControllerBase
         _logger = logger;
         _mapper = mapper;
     }
+
+    private string GetOwnerOid()
+    {
+        return User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)
+            ?? throw new InvalidOperationException("Entra Object ID claim not found");
+    }
+
+    private bool IsSiteAdministrator()
+    {
+        return User.IsInRole(RoleNames.SiteAdministrator);
+    }
     
     /// <summary>
     /// Returns all the scheduled items
@@ -54,7 +66,18 @@ public class SchedulesController: ControllerBase
         if (pageSize > Pagination.MaxPageSize) pageSize = Pagination.MaxPageSize;
         
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Schedules.List, Domain.Scopes.Schedules.All);
-        var result = await _scheduledItemManager.GetAllAsync(page, pageSize);
+
+        PagedResult<ScheduledItem> result;
+        if (IsSiteAdministrator())
+        {
+            result = await _scheduledItemManager.GetAllAsync(page, pageSize);
+        }
+        else
+        {
+            var ownerOid = GetOwnerOid();
+            result = await _scheduledItemManager.GetAllAsync(ownerOid, page, pageSize);
+        }
+
         var items = _mapper.Map<List<ScheduledItemResponse>>(result.Items);
         
         return new PagedResponse<ScheduledItemResponse>
@@ -88,6 +111,12 @@ public class SchedulesController: ControllerBase
         var item = await _scheduledItemManager.GetAsync(scheduledItemId);
         if (item is null)
             return NotFound();
+
+        if (!IsSiteAdministrator() && item.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         return Ok(_mapper.Map<ScheduledItemResponse>(item));
     }
 
@@ -114,6 +143,7 @@ public class SchedulesController: ControllerBase
         }
 
         var scheduledItem = _mapper.Map<ScheduledItem>(request);
+        scheduledItem.CreatedByEntraOid = GetOwnerOid();
         var result = await _scheduledItemManager.SaveAsync(scheduledItem);
         if (result.IsSuccess && result.Value != null)
         {
@@ -148,8 +178,18 @@ public class SchedulesController: ControllerBase
             return BadRequest(ModelState);
         }
 
+        var existing = await _scheduledItemManager.GetAsync(scheduledItemId);
+        if (existing is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && existing.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
         var scheduledItem = _mapper.Map<ScheduledItem>(request);
         scheduledItem.Id = scheduledItemId;
+        scheduledItem.CreatedByEntraOid = existing.CreatedByEntraOid;
         var result = await _scheduledItemManager.SaveAsync(scheduledItem);
         if (result.IsSuccess && result.Value != null)
         {
@@ -177,6 +217,18 @@ public class SchedulesController: ControllerBase
     public async Task<ActionResult<bool>> DeleteScheduledItemAsync(int scheduledItemId)
     {
         HttpContext.VerifyUserHasAnyAcceptedScope(Domain.Scopes.Schedules.Delete, Domain.Scopes.Schedules.All);
+
+        var scheduledItem = await _scheduledItemManager.GetAsync(scheduledItemId);
+        if (scheduledItem is null)
+        {
+            _logger.LogWarning("ScheduledItem {ScheduledItemId} not found for deletion", scheduledItemId);
+            return new NotFoundResult();
+        }
+
+        if (!IsSiteAdministrator() && scheduledItem.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
         
         var wasDeleted = await _scheduledItemManager.DeleteAsync(scheduledItemId);
         if (wasDeleted.IsSuccess)
@@ -184,7 +236,7 @@ public class SchedulesController: ControllerBase
             _logger.LogInformation("ScheduledItem {ScheduledItemId} deleted successfully", scheduledItemId);
             return new NoContentResult();
         }
-        _logger.LogWarning("ScheduledItem {ScheduledItemId} not found for deletion", scheduledItemId);
+        _logger.LogWarning("ScheduledItem {ScheduledItemId} deletion failed", scheduledItemId);
         return new NotFoundResult();
     }
     


### PR DESCRIPTION
Closes #729

Enforces per-user owner isolation in API controllers by extracting the authenticated user's Entra OID from JWT claims and passing it to managers. Site Administrators bypass owner filtering. SocialMediaPlatformsController unchanged.

## Changes

- Added GetOwnerOid() and IsSiteAdministrator() helpers to EngagementsController, SchedulesController, MessageTemplatesController
- GET list endpoints: Site Admins call unfiltered methods, regular users call owner-filtered methods
- GET by ID, PUT, DELETE: Verify ownership and return 403 Forbid if non-admin attempts cross-owner access
- POST: Set CreatedByEntraOid from authenticated user's OID claim
- Updated API controller test helpers to include Entra OID claim in JWT context
- Updated test mocks to match new owner-filtered method signatures

## Testing

- All 846 tests passing (excluding network-dependent SyndicationFeedReader tests)
- Build succeeded with zero errors

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>