### PR TITLE
feat(process): add PR template and enforce test-pass gate (#744)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+Brief description of your changes.
+
+## Related Issue
+Fixes #
+
+## Pre-Submission Checklist
+- [ ] All tests pass locally (`dotnet test .\src\ --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"`)
+- [ ] Zero test failures — I have not included known failures in this PR
+- [ ] No "Note on Remaining Test Failures" or similar acknowledgments in this description
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Process/infrastructure change
+
+## Additional Context

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -418,3 +418,100 @@ All 9 have the identical `if (!IsSiteAdministrator() && engagement.CreatedByEntr
 **Verdict:** ❌ REJECTED — Talks and Platforms sub-resource ownership paths uncovered. PR comment #739 posted with specific tests required.
 
 **Pattern reinforced:** When reviewing ownership-guarded controllers, grep for ALL `Forbid()` call sites, not just the primary CRUD actions. Sub-resource actions on the same entity share the same ownership gate and need the same test coverage.
+
+## 2026-04-18: Sprint 18 Retrospective Debrief (Completed)
+
+**Status:** ✅ COMPLETE  
+**Session:** Retro follow-up with Joseph Guadagno
+
+### Work Summary
+
+Conducted Sprint 18 retrospective debrief with Joseph. All 18 retro items reviewed and categorized:
+- 12 failures traced to **inadequate pre-submission validation** (PRs #738, #739 required multiple review rounds)
+- 5 directive violations — "run tests before committing" was written but had no enforcement mechanism
+- 6 HIGH severity items all related to missing security test coverage on a security feature
+
+### Action Items Filed (Sprint 19)
+
+All 6 action items filed as issues #743–#748 with `sprint:19` label:
+
+**P1 (Training/Enforcement):**
+- **#743:** Security test checklist skill (Tank) — Establish mandatory Forbid() coverage pattern
+- **#744:** Test-pass gate before push (Neo) — Decide: training vs. enforcement? Branch protection? PR template? Pre-push hook?
+- **#747:** Tank history checklist update (Tank) — Document ownership test checklist ownership
+
+**P2 (Enhancement):**
+- **#745:** Non-owner context helper (Trinity) — Add helper to API test base classes
+- **#746:** PR comment formatting (Neo) — Improve clarity of code review feedback
+- **#748:** Mock overload docs (Tank) — Document `.Setup()` pattern for controllers with ownerOid param
+
+### Open Question for Joseph
+
+**Should the "run tests before committing" gap be addressed as:**
+1. **Training** — better checklists/tools for Tank (prioritize #743, #747 first), or
+2. **Enforcement** — CI gate that blocks PRs with failures (prioritize #744 first)?
+
+Joseph's answer determines P1 priority order.
+
+### Decisions Documented
+
+Tank's security checklist skill (@.squad/skills/security-test-checklist/SKILL.md) now captures the ownership enforcement pattern:
+- Grep Forbid() sites first
+- Build coverage matrix
+- Write one test per Forbid() path
+- Include matrix in PR description
+- Run `dotnet test` with 0 failures before PR creation
+
+**Permanent team rules established:**
+1. ALWAYS run `dotnet test` before committing
+2. ZERO test failures before opening PR
+3. For any security/ownership feature: grep `Forbid()` first, build matrix, write test per site
+4. When controller signatures add `ownerOid` parameter: update mock `.Setup()` overload immediately
+
+### Outcome
+
+Sprint 18 fully retrospected. Sprint 19 ready to address identified gaps. Awaiting Joseph's decision on enforcement approach for #744 to finalize P1 prioritization.
+
+## 2026-04-18: Issue #744 Advisor Role (Background)
+
+**Status:** ✅ COMPLETE (Background Agent)  
+**Role:** Architecture advisor
+
+### Work Summary
+
+Advised Joseph on three options for implementing test-pass gate on PR #744:
+
+1. **Branch Protection Rule** (GitHub UI)
+   - Prevents merge until PR checks pass (including tests)
+   - Built-in, no code needed
+   - Requires GitHub repository admin access
+   - Applies to all PRs uniformly
+
+2. **PR Template** (Markdown file)
+   - Prompts submitter to confirm tests were run
+   - Non-blocking (user can ignore prompt)
+   - Good for training/awareness
+   - Works with existing CI/CD
+
+3. **Pre-push Hook** (Git local setup)
+   - Developer machine runs tests before push
+   - Fastest feedback (before network round-trip)
+   - Requires developer buy-in and proper setup
+   - Can be bypassed with `git push --no-verify`
+
+### Background Findings
+
+Neo researched each option:
+- Branch Protection: GitHub-native, strongest enforcement, requires admin
+- PR Template: Low friction, good for onboarding, reminder-based
+- Pre-push Hook: Fastest local feedback, but human-dependent
+
+Joseph to decide which option(s) align with team workflow.
+
+### Decision Impact
+
+The chosen enforcement mechanism will shape Sprint 19 priority order:
+- **Training-first approach:** #743 (checklist skill), #747 (Tank history) first, then consider #744
+- **Enforcement-first approach:** Implement #744 first, then training artifacts as reinforcement
+
+---

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -1,5 +1,61 @@
 # Tank - History
 
+## Ownership Test Checklist (Sprint 18 Established — 2026-04-18)
+
+> Formal checklist extracted from sprint 18 work (Issues #729, #730, #738, #739).
+> Full SKILL.md: `.squad/skills/security-test-checklist/SKILL.md`
+
+### Step-by-Step (Condensed)
+
+1. **Grep Forbid() sites first** — count before writing a single test
+2. **Build coverage matrix** — one row per `Forbid()` site; one test column per row
+3. **Write non-owner test** per site using the OID mismatch pattern
+4. **Assert ForbidResult + Times.Never** on all side-effect mocks
+5. **Write admin bypass test** if controller has `IsSiteAdministrator()` branch
+6. **Run `dotnet test`** — zero failures before opening PR
+
+### Grep Command
+
+```powershell
+Select-String -Path ".\src\**\*Controller.cs" -Pattern "Forbid\(\)" -Recurse
+```
+
+### OID Setup Pattern
+
+```csharp
+// Entity is owned by "owner-oid-12345" …
+var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+_managerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(item);
+
+// … caller has a different OID — ownership check must reject it
+var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "non-owner-oid-99999");
+
+var result = await sut.UpdateScheduledItemAsync(5, request);
+
+result.Result.Should().BeOfType<ForbidResult>();
+_managerMock.Verify(m => m.SaveAsync(It.IsAny<ScheduledItem>()), Times.Never);
+```
+
+### Web MVC Pattern (Redirect vs ForbidResult)
+
+| Layer | Forbidden Response |
+|---|---|
+| API Controller | `result.Result.Should().BeOfType<ForbidResult>()` |
+| Web MVC Controller | `result.Should().BeOfType<RedirectToActionResult>()` + `TempData["ErrorMessage"].Should().NotBeNull()` |
+
+### Team Rules (Permanent)
+
+- **ALWAYS run `dotnet test` before committing** — no exceptions
+- **ZERO test failures before opening PR** — failing tests block the PR
+- **For any security/ownership feature:** grep `Forbid()` first, build matrix, write test per site
+- **When controller signatures add `ownerOid` parameter:** update mock `.Setup()` overload immediately — mismatched overloads silently miss setups
+
+### Mock Overload Resolution Note
+
+When a controller method signature changes to add an `ownerOid` parameter, Moq will silently skip mismatched `.Setup()` calls rather than throwing. This causes the mock to return null and tests to behave incorrectly. Always verify the exact parameter types match the controller dispatch path.
+
+---
+
 ## 2026-04-18 — PR #739: Add 9 Security Tests (Round 2) — MERGED
 
 **Status:** ✅ COMPLETE  

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -10986,6 +10986,184 @@ exceptions
 4. After #636 merges, create first sub-issue for #637 (Phase 1: App Insights + Log Analytics)
 
 
+---
+
+# Decision: Sprint 18 Retro Debrief — 2026-04-18
+
+**Author:** Neo  
+**Date:** 2026-04-18  
+**Status:** Completed — awaiting Joseph's direction on §5
+
+## Context
+
+Sprint 18 retro debrief conducted with Joseph. Both PRs (#738, #739) merged,
+all branches cleaned up, security enforcement is live. 18 retro items reviewed,
+6 action items already filed as issues in Sprint 19 (#743–#748).
+
+## Key Findings Confirmed
+
+- 12/18 failures trace to **inadequate pre-submission validation**
+- 5 directive violations — the directive "run tests before committing" was
+  written but had no enforcement mechanism
+- 6 HIGH severity items all share a common thread: missing security test coverage
+  on a security feature
+
+## Decisions / Direction from Joseph
+
+- *(Pending — Joseph's answer to the training-vs-enforcement question in §5
+  will determine P1 priority order for Sprint 19)*
+
+## Actions Confirmed
+
+All 6 action items are filed and tagged `sprint:19`:
+- **P1:** #743 (security checklist), #744 (test-pass gate), #747 (Tank history checklist)
+- **P2:** #745 (non-owner context helper), #746 (PR comment formatting), #748 (mock overload docs)
+
+## Open Question
+
+Should the "run tests before committing" gap be addressed as:
+1. **Training** — better checklists/tools for Tank (prioritize #743, #747 first), or
+2. **Enforcement** — CI gate that blocks PRs with failures (prioritize #744 first)?
+
+Joseph's answer shapes the Sprint 19 priority order.
+
+
+---
+
+# Decision: Security Test Checklist Skill Established
+
+**Date:** 2026-04-18  
+**Author:** Tank (Tester)  
+**Issues:** #743, #747  
+**Confidence:** `high`
+
+## Summary
+
+The security test checklist skill has been created at `.squad/skills/security-test-checklist/SKILL.md`.
+
+This skill codifies the ownership enforcement / Forbid() coverage pattern established during Sprint 18 across Issues #729, #730, #738, and #739. It covers 20+ security tests written across three API controllers (`EngagementsController`, `SchedulesController`, `TalksController`/`PlatformsController`).
+
+## Confidence Rationale
+
+Rated `high` because:
+- Pattern was applied successfully across 3+ controllers in Sprint 18
+- 20 tests passing covering all Forbid() call sites
+- Pattern is mechanically reproducible via grep → matrix → test
+- Admin bypass branching is verified and documented
+
+## Skill Location
+
+`.squad/skills/security-test-checklist/SKILL.md`
+
+## Tank History Update
+
+A condensed checklist section has been prepended to `.squad/agents/tank/history.md` under the heading:
+
+```
+## Ownership Test Checklist (Sprint 18 Established — 2026-04-18)
+```
+
+## Permanent Team Rules Established
+
+1. ALWAYS run `dotnet test` before committing
+2. ZERO test failures before opening PR
+3. For any security/ownership feature: grep `Forbid()` first, build matrix, write test per site
+4. When controller signatures add `ownerOid` parameter: update mock `.Setup()` overload immediately
+
+
+---
+
+# Copilot Directive: Retro Timing
+
+### 2026-04-18T16-52-12Z: User directive
+**By:** Joseph (via Copilot)
+**What:** Do not run retrospectives until the current sprint work is fully complete (all PRs merged). Wait until the sprint is done before spinning up the retro.
+**Why:** User request — captured for team memory
+
+
+---
+
+# Neo Retro Action Items — 2026-04-18
+
+**Source:** Sprint Retrospective Issue #740  
+**Priority:** P1 (all three items)  
+**Status:** PROPOSED — requires team sign-off
+
+---
+
+## Action Item 1: Security Test Checklist (Mandatory)
+
+**Directive:**  
+For ANY feature that adds `Forbid()`, `return 403`, or ownership enforcement:
+
+1. **Before coding tests:** Grep the controller for ALL `Forbid()` / `return Forbid()` call sites
+2. **Create coverage matrix:** List every call site with line number and corresponding test name
+3. **Test pattern:** Entity OID ≠ User OID, verify `ForbidResult`, verify side-effects `Times.Never`
+4. **Submit matrix with PR:** Include the coverage matrix in the PR description
+
+**Example grep command:**
+```bash
+grep -n "Forbid()" src/JosephGuadagno.Broadcasting.Api/Controllers/*.cs
+```
+
+**Rationale:** PR #739 required 3 review rounds because Tank didn't enumerate all Forbid() paths before submission.
+
+---
+
+## Action Item 2: Test-Pass Gate Before Push (Enforced)
+
+**Directive:**  
+PRs with known test failures are REJECTED without review.
+
+**Enforcement:**
+- PR body must NOT contain "tests still need updating" or similar disclaimers
+- Run `dotnet test` BEFORE creating PR
+- 0 failures required for review to begin
+
+**Violation consequence:** Auto-rejection; Tank must fix and re-request review.
+
+**Rationale:** PR #738 was submitted with explicit "Note on Remaining Test Failures" — this wastes reviewer time.
+
+---
+
+## Action Item 3: Add Non-Owner Context Helper
+
+**Directive:**  
+Add this helper to all API controller test base classes:
+
+```csharp
+/// <summary>
+/// Creates controller context where user OID does NOT match entity CreatedByEntraOid.
+/// Use for testing ownership rejection (403 Forbid).
+/// </summary>
+private static ControllerContext CreateNonOwnerControllerContext(string scopeClaimValue) =>
+    CreateControllerContext(scopeClaimValue, ownerOid: "non-owner-oid-99999");
+```
+
+**Rationale:** 38 API + 5 Web test failures occurred because this pattern wasn't standardized in test infrastructure.
+
+---
+
+## Proposed Team Rules
+
+Add to `.squad/decisions.md`:
+
+```markdown
+### 2026-04-18: Security Test Directive (Post-Retro)
+**By:** Neo (Lead Architect)
+**What:** For any Forbid()/403 enforcement feature, Tank MUST:
+1. Grep all Forbid() call sites before writing tests
+2. Create one test per Forbid() path
+3. Include coverage matrix in PR description
+4. Run `dotnet test` with 0 failures before PR creation
+**Why:** PR #739 required 3 review rounds due to incomplete coverage; PR #738 submitted with known failures.
+```
+
+---
+
+**Sign-off required:** Joseph Guadagno
+
+
 
 ---
 

--- a/.squad/retro/sprint-2026-04-18.md
+++ b/.squad/retro/sprint-2026-04-18.md
@@ -1,0 +1,142 @@
+# Sprint Retrospective — 2026-04-18
+
+**Epic:** #609 (Multi-tenancy — per-user data isolation)  
+**Issues:** #729, #730 (API and Web owner isolation enforcement)  
+**PRs:** #738 (Web MVC), #739 (API Controllers)  
+**Requested By:** Joseph (via Copilot)
+
+---
+
+## What Went Wrong (18 Items)
+
+### Category: Quality Failures
+
+| # | What Happened | Root Cause | Severity |
+|---|---------------|------------|----------|
+| 1 | PR #739 rejected Round 1 — zero security tests for ownership enforcement | Tank submitted feature without ANY non-owner 403 tests | 🔴 HIGH |
+| 2 | PR #739 rejected Round 2 — 9 missing Talks/Platforms tests | Tank covered only top-level CRUD, missed sub-actions (13 Forbid() paths total) | 🔴 HIGH |
+| 3 | PR #738 created with test failures in PR body ("Some tests still need user claims setup") | Trinity pushed incomplete work with known failures | 🔴 HIGH |
+| 4 | 38 API test failures after feat(#730) commit | Tests lacked OID claims and CreatedByEntraOid on mock entities | 🟡 MEDIUM |
+| 5 | 5 Web MVC test failures after ownership enforcement added | Same root cause — missing OID claim + entity field matching | 🟡 MEDIUM |
+
+### Category: Process Failures
+
+| # | What Happened | Root Cause | Severity |
+|---|---------------|------------|----------|
+| 6 | Three-round review cycle consumed 2+ hours of Neo's review time | Initial submission quality too low; Tank needed clearer checklist | 🟡 MEDIUM |
+| 7 | GitHub comment formatting lost backticks after posting | PowerShell heredoc escaping mangled Markdown in PR comments | 🟡 MEDIUM |
+| 8 | Scribe had to manually fix PR comments post-merge | No validation step for GitHub API comment rendering | 🟡 MEDIUM |
+| 9 | Tank didn't verify coverage matrix against controller source code | No formal checklist for "grep all Forbid() sites and match to tests" | 🔴 HIGH |
+
+### Category: Directive Violations
+
+| # | What Happened | Root Cause | Severity |
+|---|---------------|------------|----------|
+| 10 | Tank committed with known test failures (PR #738 body admits failures) | Violated directive: "Tank must run relevant test project(s) before committing any work" | 🔴 HIGH |
+| 11 | Tests submitted without OID claim setup (ownership pattern) | Ignored established pattern: "OID claim + CreatedByEntraOid must match" from decisions.md | 🟡 MEDIUM |
+| 12 | Round 1 submission had 0 security tests on security feature | Violated implicit directive: security features require security tests | 🔴 HIGH |
+
+### Category: Communication Failures
+
+| # | What Happened | Root Cause | Severity |
+|---|---------------|------------|----------|
+| 13 | Neo had to repeat rejection twice before coverage was complete | Tank didn't fully read Round 1 review requirements | 🟡 MEDIUM |
+| 14 | Neo's Round 2 review explicitly listed 9 missing tests, Tank missed line numbers | Unclear whether Tank read full review comment | 🟢 LOW |
+
+### Category: Tooling/Infra Failures
+
+| # | What Happened | Root Cause | Severity |
+|---|---------------|------------|----------|
+| 15 | GitHub comment Markdown rendered incorrectly | Backtick escaping in PowerShell `gh pr comment` command | 🟡 MEDIUM |
+| 16 | Had to use manual GitHub API comment edits to fix formatting | No pre-validation for comment content before posting | 🟢 LOW |
+
+### Category: Test Infrastructure Gaps
+
+| # | What Happened | Root Cause | Severity |
+|---|---------------|------------|----------|
+| 17 | No helper method for creating non-owner controller context | Test infrastructure hadn't anticipated ownership pattern | 🟡 MEDIUM |
+| 18 | Mock overload resolution failures (owner-filtered vs unfiltered) | Tests using wrong manager overload; signatures changed but tests not updated | 🟡 MEDIUM |
+
+---
+
+## Directive Violations
+
+| Directive | When Given | How Violated |
+|-----------|------------|--------------|
+| "Tank must run relevant test project(s) before committing any work" | 2026-03-20 (decisions.md line 7063-7066) | PR #738 submitted with acknowledged test failures in PR body |
+| "Ownership checks require BOTH user claim AND entity OID field matching" | 2026-04-02 (neo-pr-review-rbac-phase2-followup.md) | 38 API + 5 Web tests failed because pattern not applied |
+| "Security features require security tests" | Implicit team rule | PR #739 Round 1 had zero non-owner rejection tests |
+| "Run full test suite AFTER committing changes" | Tank history.md "Team Rules" section | Feature commits pushed with failures |
+| "All 17 Forbid() paths must have coverage" | Neo Round 1 review | Only 4 covered in Round 1, 9 more needed after Round 2 |
+
+---
+
+## Severity Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 HIGH | 6 |
+| 🟡 MEDIUM | 10 |
+| 🟢 LOW | 2 |
+| **Total** | **18** |
+
+---
+
+## Action Items
+
+| # | Action | Owner | Priority |
+|---|--------|-------|----------|
+| 1 | **Create formal security test checklist**: For any Forbid()/403 enforcement feature, require Tank to grep all Forbid() call sites and create matching tests BEFORE review | Neo | 🔴 P1 |
+| 2 | **Enforce test-pass gate before push**: Add pre-commit hook or CI gate that fails if `dotnet test` doesn't pass; do not allow "tests still need updating" in PR bodies | Joseph | 🔴 P1 |
+| 3 | **Add non-owner context helper to test infrastructure**: Create `CreateNonOwnerControllerContext(string scopeClaimValue)` helper in test base classes | Tank | 🟡 P2 |
+| 4 | **Fix GitHub comment formatting workflow**: Use `gh api` with JSON body instead of heredoc escaping; validate Markdown renders correctly before posting | Scribe | 🟡 P2 |
+| 5 | **Update Tank history.md with explicit checklist**: Add "For ownership tests: 1) Grep Forbid() sites, 2) Create test per site, 3) Verify OID mismatch pattern, 4) Run all tests" | Tank | 🔴 P1 |
+| 6 | **Document mock overload resolution pattern**: When controller calls change from `GetAllAsync(page, size)` to `GetAllAsync(ownerOid, page, size, ...)`, tests MUST update mock setup | Neo | 🟡 P2 |
+
+---
+
+## What Went Right
+
+Despite the failures, several things worked well:
+
+1. **Multi-round review process caught all gaps** — Neo's methodical Forbid() coverage matrix prevented incomplete security from shipping
+2. **Clear rejection criteria** — Neo's reviews explicitly listed required tests with line numbers and code patterns
+3. **Tank completed all assigned tests** — Once requirements were clear, Tank delivered 20 total security tests
+4. **Test patterns scaled well** — The entity OID ≠ user OID pattern from Round 1 was reused across all 3 controllers
+5. **Final coverage is comprehensive** — All 17 Forbid() paths now have tests; security posture is strong
+6. **PR #739 merged successfully** — 93/93 tests passing, merged to main
+7. **Scribe caught and fixed formatting issues** — GitHub comment rendering restored post-merge
+8. **Setup Experience Spec produced** — Neo delivered 90-page architecture spec for next phase
+
+---
+
+## Root Cause Analysis
+
+The majority of failures (12/18) stem from **inadequate pre-submission validation**:
+
+1. **No formal checklist for security features** — Tank didn't have a documented process for "how to test ownership enforcement"
+2. **Pattern not documented in test infrastructure** — The OID claim + entity field pattern was in decisions.md but not in test base classes as helpers
+3. **Directive not enforced** — "Run tests before commit" is a written rule but has no enforcement mechanism
+
+### Recommendation
+
+Convert the top 3 action items into **hard directives** with enforcement:
+- P1 items should block PR creation until addressed
+- Add to `.squad/agents/tank/history.md` and `.squad/decisions.md` as permanent team rules
+
+---
+
+## Sprint Metrics
+
+| Metric | Value |
+|--------|-------|
+| PRs Reviewed | 2 (#738, #739) |
+| Review Rounds | 4 (PR #739: 3 rounds, PR #738: 1 round in progress) |
+| Total Tests Added | 63 (20 security + 43 fix tests) |
+| Total Failures Fixed | 43 (38 API + 5 Web) |
+| Neo Review Hours | ~3h (estimated across 3 rounds) |
+| Time to Merge (PR #739) | ~20h (created → merged) |
+
+---
+
+*End of retrospective. Next sprint should implement P1 action items before starting new work.*

--- a/.squad/skills/security-test-checklist/SKILL.md
+++ b/.squad/skills/security-test-checklist/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: "security-test-checklist"
+description: "Step-by-step checklist for writing ownership enforcement (Forbid/403) tests on API controllers and Web MVC controllers that gate on CreatedByEntraOid"
+domain: "testing"
+confidence: "high"
+source: "earned (Sprint 18 — Issues #729, #730, #738, #739 — 20+ security tests across 3 controllers)"
+---
+
+## Context
+
+When a controller enforces resource ownership via `CreatedByEntraOid`, every action that reads, modifies, or deletes a resource must return `403 Forbidden` when the caller's Entra OID does not match the entity's stored OID. This pattern is established across `EngagementsController`, `SchedulesController`, `TalksController`, and `PlatformsController`.
+
+Use this checklist every time you:
+- Add a new controller that calls `Forbid()`
+- Add ownership enforcement to an existing controller action
+- Review a PR that touches any controller with `CreatedByEntraOid` checks
+
+**Project:** JJGNET Broadcasting  
+**Framework:** xUnit + Moq + FluentAssertions  
+**Auth model:** `User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)` vs `entity.CreatedByEntraOid`
+
+---
+
+## Step 1 — Pre-work: Grep the Forbid() Sites
+
+Before writing a single test, know exactly how many `Forbid()` call sites exist in the controller:
+
+```powershell
+Select-String -Path ".\src\**\*Controller.cs" -Pattern "Forbid\(\)" -Recurse
+```
+
+Or for a specific controller:
+
+```powershell
+Select-String -Path ".\src\JosephGuadagno.Broadcasting.Api\Controllers\SchedulesController.cs" -Pattern "Forbid\(\)"
+```
+
+**Rule:** One non-owner 403 test is required per `Forbid()` call site. Do not guess — count from grep output.
+
+---
+
+## Step 2 — Build the Coverage Matrix
+
+Create a table before writing any tests. One row per `Forbid()` site:
+
+| Action Method | HTTP Verb | Forbid() Site | Non-Owner Test | Admin Bypass Test |
+|---|---|---|---|---|
+| `GetScheduledItemAsync` | GET | Line 47 | ✅ `WhenNonOwner_ReturnsForbid` | N/A (read-only) |
+| `UpdateScheduledItemAsync` | PUT | Line 89 | ✅ `WhenNonOwner_ReturnsForbid` | N/A |
+| `DeleteScheduledItemAsync` | DELETE | Line 112 | ✅ `WhenNonOwner_ReturnsForbid` | N/A |
+
+Mark each cell only after the test is written and green. Do not close the PR with empty cells.
+
+---
+
+## Step 3 — OID Mismatch Pattern (API — ForbidResult)
+
+The canonical non-owner test pattern for **API controllers**:
+
+```csharp
+[Fact]
+public async Task UpdateScheduledItemAsync_WhenNonOwner_ReturnsForbid()
+{
+    // Arrange
+    // Entity is owned by "owner-oid-12345".
+    // The calling user has a DIFFERENT OID — ownership check must reject it.
+    var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+    var request = BuildScheduledItemRequest(5);
+    _scheduledItemManagerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(item);
+
+    // SUT is initialized with a non-owner OID — this is the mismatch.
+    var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "non-owner-oid-99999");
+
+    // Act
+    var result = await sut.UpdateScheduledItemAsync(5, request);
+
+    // Assert
+    result.Result.Should().BeOfType<ForbidResult>();
+    // Side-effect must never fire — authorization short-circuits before SaveAsync.
+    _scheduledItemManagerMock.Verify(m => m.SaveAsync(It.IsAny<ScheduledItem>()), Times.Never);
+}
+```
+
+**Key invariants:**
+- Entity OID (`"owner-oid-12345"`) ≠ caller OID (`"non-owner-oid-99999"`) — they must be different strings
+- Use domain-constant scope: `Domain.Scopes.Schedules.All` — no magic strings
+- `Times.Never` on every side-effect mock that must not fire during a 403
+
+---
+
+## Step 4 — Required Test Assertions
+
+Every non-owner 403 test **must** include both of these assertions:
+
+### 4a. Result type assertion
+```csharp
+result.Result.Should().BeOfType<ForbidResult>();
+```
+
+### 4b. Side-effect Times.Never assertion
+```csharp
+// Example: delete action must not call DeleteAsync if ownership check fails
+_managerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never);
+```
+
+If the controller calls `GetAsync` first (pre-flight), verify that **only** `GetAsync` fires:
+```csharp
+_managerMock.Verify(m => m.GetAsync(5), Times.Once);        // pre-flight: must fire
+_managerMock.Verify(m => m.DeleteAsync(It.IsAny<int>()), Times.Never); // side-effect: must NOT fire
+```
+
+---
+
+## Step 5 — Admin Bypass Verification
+
+When the controller has an `IsSiteAdministrator()` branch that skips the ownership check, add a test that proves the admin path calls the **unfiltered** overload:
+
+```csharp
+[Fact]
+public async Task GetScheduledItemsAsync_WhenSiteAdmin_CallsUnfilteredGetAll()
+{
+    // Arrange
+    var items = new List<ScheduledItem> { BuildScheduledItem(1) };
+    // Set up the unfiltered overload (no ownerOid param).
+    _scheduledItemManagerMock
+        .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+        .ReturnsAsync(new PagedResult<ScheduledItem> { Items = items, TotalCount = items.Count });
+
+    // SiteAdmin = true bypasses ownership filter.
+    var sut = CreateSut(Domain.Scopes.Schedules.All, isSiteAdmin: true);
+
+    // Act
+    var result = await sut.GetScheduledItemsAsync();
+
+    // Assert
+    // Unfiltered overload must be invoked exactly once …
+    _scheduledItemManagerMock.Verify(
+        m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()),
+        Times.Once);
+    // … and the owner-filtered overload must NEVER be called.
+    _scheduledItemManagerMock.Verify(
+        m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+        Times.Never);
+}
+```
+
+---
+
+## Step 6 — Pre-PR Gate
+
+Before opening any PR that adds or modifies controller security logic:
+
+```powershell
+dotnet test .\src\ `
+  --no-build `
+  --verbosity normal `
+  --configuration Release `
+  --filter "FullyQualifiedName!~SyndicationFeedReader"
+```
+
+**Hard rule:** Zero failures. No exceptions. `SyndicationFeedReader` tests may be excluded (network-dependent), but all other tests must be green.
+
+If the build is required first:
+```powershell
+dotnet build .\src\ --configuration Release
+```
+
+---
+
+## Step 7 — Web MVC Variant (Redirect + TempData)
+
+Web MVC controllers do **not** return `ForbidResult`. They redirect with an error message in `TempData`. The non-owner pattern for Web MVC:
+
+```csharp
+[Fact]
+public async Task Edit_Post_WhenNonOwner_RedirectsWithError()
+{
+    // Arrange
+    var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+    _scheduledItemServiceMock.Setup(s => s.GetScheduledItemAsync(5)).ReturnsAsync(item);
+
+    // Caller has a different OID — ownership check must reject it.
+    _controller.ControllerContext = CreateControllerContext(ownerOid: "non-owner-oid-99999");
+
+    // Act
+    var result = await _controller.Edit(viewModel);
+
+    // Assert — Web MVC redirects rather than returning ForbidResult
+    var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+    redirect.ActionName.Should().Be("Index");                         // or whichever action
+    _controller.TempData["ErrorMessage"].Should().NotBeNull();
+    // Side-effect must not fire
+    _scheduledItemServiceMock.Verify(
+        s => s.UpdateScheduledItemAsync(It.IsAny<ScheduledItem>()),
+        Times.Never);
+}
+```
+
+**Key difference from API pattern:**
+| API Controller | Web MVC Controller |
+|---|---|
+| `result.Result.Should().BeOfType<ForbidResult>()` | `result.Should().BeOfType<RedirectToActionResult>()` |
+| No TempData check | `TempData["ErrorMessage"].Should().NotBeNull()` |
+
+---
+
+## Examples
+
+### Reference Files
+
+| Controller | Test File |
+|---|---|
+| `EngagementsController` | `src\JosephGuadagno.Broadcasting.Api.Tests\Controllers\EngagementsControllerTests.cs` |
+| `SchedulesController` (API) | `src\JosephGuadagno.Broadcasting.Api.Tests\Controllers\SchedulesControllerTests.cs` |
+| `TalksController` | `src\JosephGuadagno.Broadcasting.Api.Tests\Controllers\EngagementsController_TalksTests.cs` |
+| `PlatformsController` | `src\JosephGuadagno.Broadcasting.Api.Tests\Controllers\EngagementsController_PlatformsTests.cs` |
+
+### Helper Structure (Required in Every API Test Class)
+
+```csharp
+private SchedulesController CreateSut(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
+{
+    var controller = new SchedulesController(_scheduledItemManagerMock.Object, _loggerMock.Object, _mapper)
+    {
+        ControllerContext = CreateControllerContext(scopeClaimValue, ownerOid, isSiteAdmin),
+        ProblemDetailsFactory = new TestProblemDetailsFactory()
+    };
+    return controller;
+}
+
+private static ControllerContext CreateControllerContext(string scopeClaimValue, string ownerOid = "test-oid-12345", bool isSiteAdmin = false)
+{
+    var claims = new List<Claim>
+    {
+        new Claim("scp", scopeClaimValue),
+        new Claim("http://schemas.microsoft.com/identity/claims/scope", scopeClaimValue),
+        new Claim(Domain.Constants.ApplicationClaimTypes.EntraObjectId, ownerOid)
+    };
+    if (isSiteAdmin)
+        claims.Add(new Claim(ClaimTypes.Role, Domain.Constants.RoleNames.SiteAdministrator));
+
+    var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuthentication"));
+    var httpContext = new DefaultHttpContext { User = user };
+    return new ControllerContext { HttpContext = httpContext };
+}
+
+private static ScheduledItem BuildScheduledItem(int id = 1, string oid = "test-oid-12345") => new()
+{
+    Id = id,
+    // ... fields ...
+    CreatedByEntraOid = oid   // ← must always be set; defaults to "test-oid-12345"
+};
+```
+
+---
+
+## Anti-Patterns
+
+### ❌ Forgetting to set entity OID
+
+```csharp
+// WRONG — entity OID is null; ownership check behaviour is undefined
+var item = new ScheduledItem { Id = 5, Message = "Test" };
+```
+
+```csharp
+// RIGHT — entity OID explicitly set to a different value than the caller's OID
+var item = BuildScheduledItem(5, oid: "owner-oid-12345");
+var sut = CreateSut(scope, ownerOid: "non-owner-oid-99999");
+```
+
+### ❌ Using the same OID for entity and caller in a non-owner test
+
+```csharp
+// WRONG — this is an *owner* test; controller will pass, not Forbid
+var item = BuildScheduledItem(5, oid: "test-oid-12345");
+var sut = CreateSut(scope, ownerOid: "test-oid-12345"); // same!
+```
+
+### ❌ Missing Times.Never on side-effects
+
+```csharp
+// WRONG — does not verify that the side-effect was suppressed
+result.Result.Should().BeOfType<ForbidResult>();
+// (missing _managerMock.Verify(..., Times.Never))
+```
+
+### ❌ Pushing with failing tests
+
+Opening a PR with failing tests is not allowed. Always run `dotnet test` first. If tests fail, fix them before opening the PR.
+
+### ❌ Mock overload mismatch after controller signature change
+
+When a controller method signature adds an `ownerOid` parameter, the Moq `.Setup()` overload must be updated immediately. Mismatched overloads silently miss the setup, causing tests to return null and producing wrong results.
+
+---
+
+## Patterns
+
+### Naming Convention for Non-Owner Tests
+
+```
+{ActionMethod}_WhenNonOwner_ReturnsForbid         // API
+{ActionMethod}_WhenNonOwner_RedirectsWithError    // Web MVC
+{ActionMethod}_WhenSiteAdmin_CallsUnfilteredGetAll // Admin bypass
+```
+
+### OID Constants to Use
+
+| Constant | Value | Role |
+|---|---|---|
+| Default owner OID | `"test-oid-12345"` | Entity owner + authorized user in happy-path tests |
+| Non-owner OID | `"non-owner-oid-99999"` | Unauthorized caller in 403 tests |
+| Owner OID (explicit) | `"owner-oid-12345"` | Entity owner when 403 test is explicit |
+
+All OIDs are test-only strings. No magic strings in production code — use `Domain.Constants.ApplicationClaimTypes.EntraObjectId`.


### PR DESCRIPTION
## Description
Implements the test-pass gate from issue #744.

## Related Issue
Fixes #744

## Changes
- Added \.github/pull_request_template.md\ with pre-submission checklist requiring zero test failures
- Branch protection rule on \main\ already configured (done via GitHub Settings)

## Pre-Submission Checklist
- [x] All tests pass locally
- [x] Zero test failures
- [x] No acknowledged failures in this description

## Type of Change
- [x] Process/infrastructure change