### PR TITLE
docs(squad): update Scribe charter with gh-api pattern and Tank history with ownership checklist (#746, #747)

### DIFF
--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -45,6 +45,30 @@ Before starting work, read `.squad/decisions.md` for team decisions that affect 
 After making a decision others should know, write it to `.squad/decisions/inbox/scribe-{brief-slug}.md`.
 If I need another team member's input, say so — the coordinator will bring them in.
 
+## Posting GitHub PR/Issue Comments
+
+**ALWAYS use `gh api` with a JSON body via temp file** — never use `gh pr comment --body` with inline strings on Windows PowerShell.
+
+**WHY:** PowerShell heredocs are not supported (`<<<` is invalid syntax). Inline `--body` strings mangle Markdown backticks (`` `GET` `` renders as `\GET\` in the posted comment).
+
+**Correct pattern:**
+```powershell
+# CORRECT: gh api with JSON body via temp file — preserves Markdown formatting
+$body = @{ body = "Your comment with ``backticks`` and **markdown**" } | ConvertTo-Json
+$tmp = [System.IO.Path]::GetTempFileName()
+$body | Set-Content $tmp
+gh api repos/OWNER/REPO/issues/ISSUE_NUMBER/comments --input $tmp
+Remove-Item $tmp
+```
+
+**Wrong pattern (do NOT use):**
+```powershell
+# WRONG: mangles backticks on Windows PowerShell — produces \GET\ instead of `GET`
+gh pr comment 123 --body "Use `GET` endpoint"
+```
+
+This applies to all `gh pr comment`, `gh issue comment`, and `gh api` calls that include Markdown.
+
 ## Voice
 
 Silent observer. Keeps the record straight so the team never loses context.

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -769,3 +769,21 @@ This provides regression coverage as close to the actual bug as the existing tes
 23. **Test constructors must match updated production code signatures.** After commit 6ad9396 (issue #713), all DataStore classes added `ILogger<T>` parameters. Test setup must include `var logger = new Mock<ILogger<XDataStore>>()` and pass `logger.Object` to constructors. EngagementManager similarly requires `ILogger<EngagementManager>` in its constructor.
 
 24. **Extension methods for fluent test object modification are helpful.** When setting up test data with varying properties (e.g., different `StartDateTime` values for sort tests), a `With()` extension method allows chaining: `CreateEngagement(name: "Conf A").With(e => e.StartDateTime = ...)`. Declared as `file static class` to keep it scoped to the test file.
+
+## Ownership Test Checklist
+
+Before writing any test for a security/ownership feature:
+
+1. Grep ALL `Forbid()` call sites in the target controller(s)
+2. List every call site with: file path, line number, intended test name
+3. For EACH call site, write a test that:
+   a. Sets `entity.CreatedByEntraOid = "owner-oid-12345"`
+   b. Sets user claim OID = `"non-owner-oid-99999"` (different from entity)
+   c. Verifies result is `ForbidResult`
+   d. Verifies service method was NOT called (`Times.Never`)
+4. Run `dotnet test` — must be 0 failures BEFORE creating PR
+5. Include the coverage matrix in the PR description
+
+### Standard OIDs
+- **Owner OID:** `"owner-oid-12345"` — used in entity mocks
+- **Non-owner OID:** `"non-owner-oid-99999"` — used in user claim for rejection tests


### PR DESCRIPTION
## Summary

Closes #746 and #747.

### Issue #746 — fix(tooling): gh api JSON body pattern for PR comments

**Problem:** PowerShell inline --body strings mangle Markdown backticks (` GET ` → `\GET\`). Scribe had to manually fix post-merge.

**Changes:**
- Added ## Posting GitHub PR/Issue Comments section to .squad/agents/scribe/charter.md with the correct gh api --input <tmpfile> pattern
- Created .squad/decisions/inbox/scribe-gh-api-json-body.md with the team decision (inbox is gitignored — merge separately)

### Issue #747 — process(retro): Tank ownership test checklist

**Problem:** Tank's history.md lacked a step-by-step checklist for ownership/security test patterns, causing repeated mistakes across PRs #738 and #739.

**Changes:**
- Appended ## Ownership Test Checklist section to .squad/agents/tank/history.md with the full 5-step checklist and standard OIDs

---

### Files changed
- .squad/agents/scribe/charter.md — gh-api comment posting pattern
- .squad/agents/tank/history.md — ownership test checklist appended