### PR TITLE
docs(squad): add security test checklist and mock overload resolution docs (#743, #748)

### DIFF
--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -21,6 +21,28 @@
 - Write decisions to inbox when making team-relevant choices
 - Focused, practical, gets things done
 
+## Security Test Requirements
+
+Before writing any test for a controller that calls `Forbid()` or enforces ownership via `CreatedByEntraOid`:
+
+1. Read `.squad/skills/security-test-checklist/SKILL.md` — this is the authoritative guide
+2. Follow the permanent team rule in `.squad/decisions.md` (section: "Permanent Rule: Security Test Checklist for Forbid() Enforcement Features"):
+   - Grep ALL `Forbid()` call sites before writing a single test
+   - Build the coverage matrix (file, line number, test name per call site)
+   - Apply the OID mismatch pattern: entity OID ≠ caller OID, verify `ForbidResult`, verify side-effects `Times.Never`
+   - Include the completed coverage matrix in the PR description
+
+**A PR that adds ownership-gated logic without a coverage matrix in the description will be rejected.**
+
+## Mock Setup Rules
+
+When a manager method signature changes (new parameter added):
+
+1. Read `.squad/skills/mock-overload-resolution/SKILL.md` — covers before/after patterns and fix process
+2. ALWAYS update all `.Setup()` calls to match the new overload before running any test
+3. Use `It.IsAny<T>()` for new parameters unless the test specifically verifies them
+4. Run the specific test class (`dotnet test --filter "FullyQualifiedName~XTests"`) after updating setups — before pushing
+
 ## Boundaries
 
 **I handle:** xUnit, Moq, FluentAssertions

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -15506,3 +15506,175 @@ File: .github/workflows/main_jjgnet-broadcast.yml
 Re-enable: After #732 merges and Functions validated working.
 
 Related: Epic #609, #728 (OID threading), #732 (final integration).
+
+
+--- From: neo-743-security-test-checklist.md ---
+---
+date: 2026-04-18
+author: Neo
+issue: 743
+status: permanent-rule
+retro: PR #739 required 3 review rounds because Tank had no documented process for enumerating Forbid() call sites before writing tests. Round 1 had zero non-owner rejection tests on a security feature.
+---
+
+# Permanent Rule: Security Test Checklist for Forbid() Enforcement Features
+
+## Rule
+
+**Every PR that introduces or modifies ownership-gated controller actions MUST follow the Forbid() Security Test Checklist before it can be opened for review.**
+
+This rule is permanent. It applies to all team members. Reviewers must reject PRs that do not include a coverage matrix in the PR description.
+
+---
+
+## Checklist (Required — Not Optional)
+
+### Step 1 — Grep ALL `Forbid()` Call Sites Before Writing a Single Test
+
+Before writing any test, run the following to enumerate every `Forbid()` site in the target controller:
+
+```powershell
+# All controllers:
+Select-String -Path ".\src\**\*Controller.cs" -Pattern "Forbid\(\)" -Recurse
+
+# Specific controller (preferred — scope to the PR's controller):
+Select-String -Path ".\src\JosephGuadagno.Broadcasting.Api\Controllers\SchedulesController.cs" -Pattern "Forbid\(\)"
+```
+
+**Rule:** Do not guess the count. Run the grep. One non-owner 403 test is required per `Forbid()` call site. If grep finds 5 sites, there must be 5 non-owner tests.
+
+---
+
+### Step 2 — Build the Coverage Matrix
+
+Create this table before writing any code. Fill in each row from the grep output:
+
+| Action Method | HTTP Verb | File | Line | Non-Owner Test Name | Status |
+|---|---|---|---|---|---|
+| `GetItemAsync` | GET | `SchedulesController.cs` | 47 | `GetItemAsync_WhenNonOwner_ReturnsForbid` | not written |
+| `UpdateItemAsync` | PUT | `SchedulesController.cs` | 89 | `UpdateItemAsync_WhenNonOwner_ReturnsForbid` | not written |
+| `DeleteItemAsync` | DELETE | `SchedulesController.cs` | 112 | `DeleteItemAsync_WhenNonOwner_ReturnsForbid` | not written |
+
+Mark cells as done only after the test is written and green. **A PR may not be opened while any cell is not done.**
+
+---
+
+### Step 3 — Apply the OID Mismatch Test Pattern
+
+The canonical pattern for **API controllers** — entity OID must differ from caller OID:
+
+```csharp
+[Fact]
+public async Task UpdateItemAsync_WhenNonOwner_ReturnsForbid()
+{
+    // Arrange
+    // Entity owned by "owner-oid-12345"; caller OID is different -> ownership check must reject.
+    var item = BuildItem(5, oid: "owner-oid-12345");
+    _managerMock.Setup(m => m.GetAsync(5)).ReturnsAsync(item);
+
+    var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "non-owner-oid-99999");
+
+    // Act
+    var result = await sut.UpdateItemAsync(5, request);
+
+    // Assert
+    result.Result.Should().BeOfType<ForbidResult>();
+    // Side-effect must not fire - authorization short-circuits before any mutation.
+    _managerMock.Verify(m => m.SaveAsync(It.IsAny<Item>()), Times.Never);
+}
+```
+
+**Required invariants:**
+- Entity OID ("owner-oid-12345") != caller OID ("non-owner-oid-99999") -- they must be different strings
+- `Times.Never` on every side-effect mock (delete, save, update) that must not fire during a 403
+- No magic strings -- use `Domain.Scopes.*` and `Domain.Constants.*` constants throughout
+
+---
+
+### Step 4 — Include the Coverage Matrix in the PR Description
+
+The PR description must contain the completed coverage matrix (all cells done) before the PR is opened. Reviewers are required to check the matrix against the grep output from Step 1.
+
+**Reviewer gate:** If the PR description is missing the matrix, or if the matrix has cells that do not map to actual tests in the diff, the PR must be rejected immediately (no partial credit).
+
+---
+
+## Full Checklist Reference
+
+The full 7-step checklist -- including the Web MVC redirect variant, admin bypass verification, helper structure, and anti-patterns -- is in:
+
+```
+.squad/skills/security-test-checklist/SKILL.md
+```
+
+Tank must read this SKILL.md before writing any ownership-enforcement tests. The SKILL.md is the authoritative implementation guide; this decisions.md entry is the permanent team rule that makes following it mandatory.
+
+---
+
+## Why This Rule Exists
+
+PR #739 (Epic #729 -- ownership enforcement) required three review rounds:
+- Round 1: Zero non-owner 403 tests on a PR that added 17 Forbid() call sites
+- Round 2: 9 of 17 sites covered; 8 still missing
+- Round 3: All 17 covered -> approved and merged
+
+The delay was caused by Tank not enumerating call sites before writing tests, leading to systematic gaps. This checklist prevents recurrence by making the coverage matrix a hard gate, not a courtesy.
+
+---
+
+## Ownership
+
+- Rule author: Neo (Lead)
+- Primary user: Tank (Tester)
+- Enforced by: PR reviewer (any agent or Joseph)
+- Skill reference: `.squad/skills/security-test-checklist/SKILL.md`
+
+
+--- From: neo-748-mock-overload-resolution.md ---
+---
+date: 2026-04-18
+author: Neo
+issue: 748
+status: documented
+---
+
+# Mock Overload Resolution Pattern for Manager Signature Changes
+
+## Problem
+
+When a controller call changes from `GetAllAsync(page, size)` to `GetAllAsync(ownerOid, page, size, ...)` (as happened in Epic #609), tests using the old mock setup fail with `MockException` or silently match the wrong overload. This is a **silent failure mode**: the test compiles, may even pass, but is not testing what you think it's testing.
+
+## Rule
+
+**ALWAYS update mock setups when the controller call signature changes.** Moq setups are resolved at runtime, not compile time. A setup for the wrong overload compiles without warning.
+
+## Quick Reference
+
+### Before (Broken)
+```csharp
+// Targets old 2-parameter overload; controller now calls 3-parameter overload
+_managerMock
+    .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+    .ReturnsAsync(result);
+```
+
+### After (Fixed)
+```csharp
+// Matches the 3-parameter owner-filtered overload the controller actually calls
+_managerMock
+    .Setup(m => m.GetAllAsync(
+        It.IsAny<string>(),  // ownerOid -- new parameter
+        It.IsAny<int>(),     // page
+        It.IsAny<int>()))    // pageSize
+    .ReturnsAsync(result);
+```
+
+Use `It.IsAny<T>()` for new parameters unless the test specifically needs to verify their value.
+
+## Full Pattern Reference
+
+See `.squad/skills/mock-overload-resolution/SKILL.md` for:
+- Full before/after code examples with Epic #609 context
+- Step-by-step fix process (grep, update, run specific test class, run suite)
+- Admin bypass dual-overload pattern
+- Anti-patterns and when to use explicit parameter values vs. It.IsAny<T>()

--- a/.squad/skills/mock-overload-resolution/SKILL.md
+++ b/.squad/skills/mock-overload-resolution/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: "mock-overload-resolution"
+description: "How to update Moq mock setups when a manager method gains new parameters — prevents silent overload mismatch bugs that cause MockException or wrong test results"
+domain: "testing"
+confidence: "high"
+source: "earned (Epic #609 — GetAllAsync signature change from (page, size) to (ownerOid, page, size) caused broken test setups across multiple controller test files)"
+---
+
+## Context
+
+When a manager interface method gains new parameters (e.g., `ownerOid` added as part of Epic #609's per-user ownership enforcement), **every existing Moq `.Setup()` call that targets the old signature becomes a dead setup**. Moq will either:
+
+1. **Silently match nothing** — the method is called but no setup matches, so Moq returns the default value (`null` for reference types, `0` for value types, `false` for `bool`). The test passes for the wrong reason, or fails with a `NullReferenceException` that is hard to diagnose.
+2. **Throw `MockException`** — when `.Verifiable()` is in play and the expected call never fired, the verify step throws.
+
+This is a **silent failure mode**: the test compiles, may even pass, but is not testing what you think it's testing.
+
+**Project:** JJGNET Broadcasting  
+**Framework:** xUnit + Moq 4.20.72 + FluentAssertions  
+**Trigger:** Any manager method signature change (new parameter added, parameter type changed, parameter removed)
+
+---
+
+## The Problem
+
+### Scenario: Epic #609 — `GetAllAsync` gains `ownerOid` parameter
+
+Before Epic #609, the manager interface was:
+
+```csharp
+// IScheduledItemManager — BEFORE
+Task<PagedResult<ScheduledItem>> GetAllAsync(int page, int pageSize);
+```
+
+After Epic #609, a new overload was added for owner-filtered access:
+
+```csharp
+// IScheduledItemManager — AFTER (two overloads)
+Task<PagedResult<ScheduledItem>> GetAllAsync(int page, int pageSize);                        // admin/unfiltered
+Task<PagedResult<ScheduledItem>> GetAllAsync(string ownerOid, int page, int pageSize, ...);  // owner-filtered
+```
+
+The controller now calls the owner-filtered overload for non-admin users:
+
+```csharp
+// SchedulesController (after Epic #609)
+var result = await _scheduledItemManager.GetAllAsync(currentUserOid, page, pageSize);
+```
+
+---
+
+## Before (Broken)
+
+The old mock setup targets the **unfiltered** overload (2 parameters). The controller now calls the **owner-filtered** overload (3+ parameters). Moq finds no matching setup.
+
+```csharp
+// ❌ BROKEN — targets old 2-parameter overload; controller now calls 3-parameter overload
+_scheduledItemManagerMock
+    .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+    .ReturnsAsync(new PagedResult<ScheduledItem> { Items = items, TotalCount = 1 });
+
+var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "test-oid-12345");
+
+var result = await sut.GetScheduledItemsAsync();
+
+// result.Value is null — the controller called the 3-parameter overload, no setup matched.
+// The test may fail with NullReferenceException or, worse, produce a false positive.
+result.Value.Should().NotBeNull(); // ← throws NullReferenceException
+```
+
+**Symptom:** `NullReferenceException`, `MockException`, or (worst case) a test that "passes" because the null result flows through a code path that returns an empty 200 OK.
+
+---
+
+## After (Fixed)
+
+Match the overload that the controller **actually calls**. Use `It.IsAny<T>()` for the new parameter unless the test specifically needs to assert its value.
+
+```csharp
+// ✅ FIXED — targets the 3-parameter owner-filtered overload that the controller now calls
+_scheduledItemManagerMock
+    .Setup(m => m.GetAllAsync(
+        It.IsAny<string>(),   // ownerOid — new parameter; use IsAny<> unless test verifies it
+        It.IsAny<int>(),      // page
+        It.IsAny<int>()))     // pageSize
+    .ReturnsAsync(new PagedResult<ScheduledItem> { Items = items, TotalCount = 1 });
+
+var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "test-oid-12345");
+
+var result = await sut.GetScheduledItemsAsync();
+
+// Now resolves correctly — setup matches the actual call.
+result.Value.Should().NotBeNull();
+result.Value!.Items.Should().HaveCount(1);
+```
+
+---
+
+## When to Verify the Specific New Parameter
+
+Use `It.IsAny<string>()` for the new parameter in **most** tests. Use an explicit value only when the test is **specifically verifying** that the controller passes the correct OID:
+
+```csharp
+// ✅ Verifying that the controller passes the caller's OID to the manager
+_scheduledItemManagerMock
+    .Setup(m => m.GetAllAsync(
+        "test-oid-12345",     // exact OID — this test verifies the controller uses the caller's OID
+        It.IsAny<int>(),
+        It.IsAny<int>()))
+    .ReturnsAsync(new PagedResult<ScheduledItem> { Items = items, TotalCount = 1 });
+
+// Then verify after Act:
+_scheduledItemManagerMock.Verify(
+    m => m.GetAllAsync("test-oid-12345", It.IsAny<int>(), It.IsAny<int>()),
+    Times.Once);
+```
+
+**Default rule:** Use `It.IsAny<T>()` for new parameters unless there is an explicit test objective around that parameter's value.
+
+---
+
+## Step-by-Step Fix Process
+
+When a manager method signature changes:
+
+1. **Find all affected `.Setup()` calls:**
+   ```powershell
+   Select-String -Path ".\src\**\*Tests.cs" -Pattern "\.Setup\(m => m\.GetAllAsync" -Recurse
+   ```
+
+2. **For each match, check the parameter count against the new interface.**
+   - If the count is wrong, it's a dead setup — update it.
+
+3. **Add `It.IsAny<T>()` for each new parameter** (unless the test needs to assert the specific value).
+
+4. **Run the specific test class immediately** to verify the fix before moving on:
+   ```powershell
+   dotnet test .\src\ --filter "FullyQualifiedName~SchedulesControllerTests" --no-build --verbosity normal
+   ```
+
+5. **Run the full test suite** before pushing:
+   ```powershell
+   dotnet test .\src\ --no-build --verbosity normal --filter "FullyQualifiedName!~SyndicationFeedReader"
+   ```
+
+---
+
+## Admin Bypass Overload (Special Case)
+
+When a controller has an `IsSiteAdministrator()` branch that calls the **unfiltered** overload, both setups must exist simultaneously in the same test class:
+
+```csharp
+// Setup for non-admin tests (owner-filtered overload):
+_scheduledItemManagerMock
+    .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+    .ReturnsAsync(pagedResult);
+
+// Setup for admin tests (unfiltered overload):
+_scheduledItemManagerMock
+    .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+    .ReturnsAsync(pagedResult);
+```
+
+Then in admin-bypass tests, verify that the **unfiltered** overload fires and the **owner-filtered** one does not:
+
+```csharp
+_scheduledItemManagerMock.Verify(
+    m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()),
+    Times.Once);
+_scheduledItemManagerMock.Verify(
+    m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+    Times.Never);
+```
+
+This is the same pattern used in the security-test-checklist SKILL for admin bypass verification — the two skills are complementary.
+
+---
+
+## Anti-Patterns
+
+### ❌ Leaving old 2-parameter setup after controller switches to 3-parameter call
+
+```csharp
+// WRONG — setup for old overload; controller calls new overload → null result
+_managerMock.Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(result);
+```
+
+### ❌ Using a fixed OID in setup for a general happy-path test
+
+```csharp
+// WRONG — if the test OID ever changes, this setup silently stops matching
+_managerMock.Setup(m => m.GetAllAsync("hardcoded-oid", It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(result);
+```
+
+### ❌ Not running the test class after updating a setup
+
+```
+// WRONG workflow: update setup → push → find out CI failed
+// RIGHT workflow: update setup → dotnet test --filter "FullyQualifiedName~XTests" → green → push
+```
+
+### ❌ Assuming the compiler catches overload mismatches
+
+Moq setups are resolved at **runtime**, not compile time. A setup for the wrong overload compiles without warning. **Always run the test** after a setup change.
+
+---
+
+## Related
+
+- **security-test-checklist SKILL.md** — the admin bypass pattern in Step 5 depends on having correct setups for both overloads
+- **Anti-pattern in security-test-checklist:** "Mock overload mismatch after controller signature change" (brief mention — this SKILL is the full treatment)
+- **Epic #609** — the trigger: per-user content required `GetAllAsync(ownerOid, page, size)` alongside the existing `GetAllAsync(page, size)` on all four manager interfaces
+
+## References
+
+- **Epic:** #609 — Multi-tenancy: per-user content, publishers, and social tokens
+- **Interfaces affected:** `IScheduledItemManager`, `IEngagementManager`, `ITalkManager`, `IMessageTemplateManager`
+- **Test files affected:** All `*ControllerTests.cs` files in `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/`


### PR DESCRIPTION
## Summary

Closes #743, #748

### Issue #743 — Security Test Checklist for Forbid() Enforcement

**Problem:** PR #739 required 3 review rounds because Tank had no documented process for enumerating all \Forbid()\ call sites before writing tests. Round 1 had zero non-owner rejection tests on a security feature.

**Changes:**
- Added permanent team rule to \.squad/decisions.md\ — the **Forbid() Security Test Checklist** is now a hard gate for all PRs that add or modify ownership-gated controller actions
- Rule requires: grep all \Forbid()\ call sites, build a coverage matrix (file/line/test name), apply OID mismatch pattern, include completed matrix in PR description
- Reviewers must reject PRs missing the coverage matrix

### Issue #748 — Mock Overload Resolution Pattern

**Problem:** When controller calls changed from \GetAllAsync(page, size)\ to \GetAllAsync(ownerOid, page, size, ...)\ in Epic #609, tests using old mock setups failed with \MockException\ or silently matched the wrong overload.

**Changes:**
- Created new skill: \.squad/skills/mock-overload-resolution/SKILL.md\
- Documents full before/after Moq setup patterns with Epic #609 as the concrete example
- Covers step-by-step fix process, \It.IsAny<T>()\ rule, admin bypass dual-overload pattern
- Brief summary also added to \.squad/decisions.md\ for discoverability

### Tank's Charter Updated
- \.squad/agents/tank/charter.md\ updated to reference both skill files as mandatory pre-work
- Security test requirements section added
- Mock setup rules section added

## Coverage Matrix

| Deliverable | File | Status |
|---|---|---|
| Permanent team rule | \.squad/decisions.md\ | done |
| Security checklist skill (existing) | \.squad/skills/security-test-checklist/SKILL.md\ | pre-existing |
| Mock overload resolution skill | \.squad/skills/mock-overload-resolution/SKILL.md\ | new |
| Tank charter update | \.squad/agents/tank/charter.md\ | updated |