### PR TITLE
test(#732): add owner isolation coverage

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs
@@ -221,6 +221,35 @@ public class EngagementsControllerTests
     }
 
     [Fact]
+    public async Task CreateEngagementAsync_WhenCalled_StampsCreatedByEntraOidFromClaims()
+    {
+        // Arrange
+        var request = new EngagementRequest
+        {
+            Name = "New Conference",
+            Url = "https://new-conf.example.com",
+            StartDateTime = DateTimeOffset.UtcNow,
+            EndDateTime = DateTimeOffset.UtcNow.AddDays(2),
+            TimeZoneId = "UTC"
+        };
+        Engagement? capturedEngagement = null;
+        _engagementManagerMock
+            .Setup(m => m.SaveAsync(It.IsAny<Engagement>()))
+            .Callback<Engagement, CancellationToken>((engagement, _) => capturedEngagement = engagement)
+            .ReturnsAsync(OperationResult<Engagement>.Success(new Engagement { Id = 42, CreatedByEntraOid = "owner-1" }));
+
+        var sut = CreateSut(Domain.Scopes.Engagements.All, ownerOid: "owner-1");
+
+        // Act
+        var result = await sut.CreateEngagementAsync(request);
+
+        // Assert
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        capturedEngagement.Should().NotBeNull();
+        capturedEngagement!.CreatedByEntraOid.Should().Be("owner-1");
+    }
+
+    [Fact]
     public async Task CreateEngagementAsync_WhenSaveFails_ReturnsInternalServerError()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -199,6 +199,28 @@ public class SchedulesControllerTests
     }
 
     [Fact]
+    public async Task CreateScheduledItemAsync_WhenCalled_StampsCreatedByEntraOidFromClaims()
+    {
+        // Arrange
+        var request = BuildScheduledItemRequest(4);
+        ScheduledItem? capturedItem = null;
+        _scheduledItemManagerMock
+            .Setup(m => m.SaveAsync(It.IsAny<ScheduledItem>()))
+            .Callback<ScheduledItem, CancellationToken>((item, _) => capturedItem = item)
+            .ReturnsAsync(OperationResult<ScheduledItem>.Success(BuildScheduledItem(4, oid: "owner-1")));
+
+        var sut = CreateSut(Domain.Scopes.Schedules.All, ownerOid: "owner-1");
+
+        // Act
+        var result = await sut.CreateScheduledItemAsync(request);
+
+        // Assert
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        capturedItem.Should().NotBeNull();
+        capturedItem!.CreatedByEntraOid.Should().Be("owner-1");
+    }
+
+    [Fact]
     public async Task CreateScheduledItemAsync_WhenSaveFails_ReturnsInternalServerError()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/EngagementDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/EngagementDataStoreTests.cs
@@ -36,7 +36,7 @@ public class EngagementDataStoreTests : IDisposable
         _context.Dispose();
     }
 
-    private Engagement CreateEngagement(int id = 0, string name = "Test Conference") => new Engagement
+    private Engagement CreateEngagement(int id = 0, string name = "Test Conference", string? ownerOid = null) => new Engagement
     {
         Id = id,
         Name = name,
@@ -44,6 +44,7 @@ public class EngagementDataStoreTests : IDisposable
         StartDateTime = new DateTimeOffset(2025, 6, 1, 9, 0, 0, TimeSpan.Zero),
         EndDateTime = new DateTimeOffset(2025, 6, 3, 17, 0, 0, TimeSpan.Zero),
         TimeZoneId = "UTC",
+        CreatedByEntraOid = ownerOid,
         CreatedOn = DateTimeOffset.UtcNow,
         LastUpdatedOn = DateTimeOffset.UtcNow
     };
@@ -108,6 +109,58 @@ public class EngagementDataStoreTests : IDisposable
         // Assert
         Assert.NotNull(result);
         Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ReturnsOnlyMatchingEngagements()
+    {
+        // Arrange
+        _context.Engagements.AddRange(
+            CreateEngagement(name: "Owner A", ownerOid: "owner-1"),
+            CreateEngagement(name: "Owner B", ownerOid: "owner-1"),
+            CreateEngagement(name: "Other Owner", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.All(result, item => Assert.Equal("owner-1", item.CreatedByEntraOid));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_WhenNoMatchesExist_ReturnsEmptyList()
+    {
+        // Arrange
+        _context.Engagements.Add(CreateEngagement(name: "Other Owner", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOidAndPaging_ReturnsOnlyMatchingPage()
+    {
+        // Arrange
+        _context.Engagements.AddRange(
+            CreateEngagement(name: "Owner A", ownerOid: "owner-1"),
+            CreateEngagement(name: "Owner B", ownerOid: "owner-1"),
+            CreateEngagement(name: "Owner C", ownerOid: "owner-1"),
+            CreateEngagement(name: "Other Owner", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1", 1, 2);
+
+        // Assert
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(2, result.Items.Count);
+        Assert.All(result.Items, item => Assert.Equal("owner-1", item.CreatedByEntraOid));
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/MessageTemplateDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/MessageTemplateDataStoreTests.cs
@@ -54,12 +54,14 @@ public class MessageTemplateDataStoreTests : IDisposable
         int platformId,
         string messageType,
         string template = "{{ title }} - {{ url }}",
-        string? description = null) => new()
+        string? description = null,
+        string? ownerOid = null) => new()
     {
         SocialMediaPlatformId = platformId,
         MessageType = messageType,
         Template = template,
-        Description = description
+        Description = description,
+        CreatedByEntraOid = ownerOid
     };
 
     [Fact]
@@ -183,5 +185,64 @@ public class MessageTemplateDataStoreTests : IDisposable
 
         // Assert
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ReturnsOnlyMatchingTemplates()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        var facebookId = await GetOrCreatePlatformIdAsync("Facebook");
+
+        _context.MessageTemplates.AddRange(
+            CreateMessageTemplate(twitterId, "RandomPost", ownerOid: "owner-1"),
+            CreateMessageTemplate(facebookId, "NewPost", ownerOid: "owner-1"),
+            CreateMessageTemplate(twitterId, "Reminder", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.All(result, template => Assert.Equal("owner-1", template.CreatedByEntraOid));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_WhenNoMatchesExist_ReturnsEmptyList()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        _context.MessageTemplates.Add(CreateMessageTemplate(twitterId, "RandomPost", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOidAndPaging_ReturnsOnlyMatchingPage()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        var facebookId = await GetOrCreatePlatformIdAsync("Facebook");
+
+        _context.MessageTemplates.AddRange(
+            CreateMessageTemplate(twitterId, "RandomPost", ownerOid: "owner-1"),
+            CreateMessageTemplate(facebookId, "NewPost", ownerOid: "owner-1"),
+            CreateMessageTemplate(twitterId, "Reminder", ownerOid: "owner-1"),
+            CreateMessageTemplate(facebookId, "Weekly", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1", 1, 2);
+
+        // Assert
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(2, result.Items.Count);
+        Assert.All(result.Items, template => Assert.Equal("owner-1", template.CreatedByEntraOid));
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/ScheduledItemDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/ScheduledItemDataStoreTests.cs
@@ -37,13 +37,15 @@ public class ScheduledItemDataStoreTests : IDisposable
     private ScheduledItem CreateScheduledItem(
         string message = "Test Message",
         DateTimeOffset? sendOn = null,
-        bool messageSent = false) => new ScheduledItem
+        bool messageSent = false,
+        string? ownerOid = null) => new ScheduledItem
     {
         ItemTableName = "Engagements",
         ItemPrimaryKey = 1,
         Message = message,
         SendOnDateTime = sendOn ?? DateTimeOffset.UtcNow.AddHours(1),
-        MessageSent = messageSent
+        MessageSent = messageSent,
+        CreatedByEntraOid = ownerOid
     };
 
     [Fact]
@@ -90,6 +92,58 @@ public class ScheduledItemDataStoreTests : IDisposable
         // Assert
         Assert.NotNull(result);
         Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ReturnsOnlyMatchingScheduledItems()
+    {
+        // Arrange
+        _context.ScheduledItems.AddRange(
+            CreateScheduledItem("Owner 1 Item 1", ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 1 Item 2", ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 2 Item", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.All(result, item => Assert.Equal("owner-1", item.CreatedByEntraOid));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_WhenNoMatchesExist_ReturnsEmptyList()
+    {
+        // Arrange
+        _context.ScheduledItems.Add(CreateScheduledItem("Other Owner Item", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOidAndPaging_ReturnsOnlyMatchingPage()
+    {
+        // Arrange
+        _context.ScheduledItems.AddRange(
+            CreateScheduledItem("Owner 1 Item 1", ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 1 Item 2", ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 1 Item 3", ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 2 Item", ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllAsync("owner-1", 1, 2);
+
+        // Assert
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(2, result.Items.Count);
+        Assert.All(result.Items, item => Assert.Equal("owner-1", item.CreatedByEntraOid));
     }
 
     [Fact]
@@ -232,6 +286,25 @@ public class ScheduledItemDataStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetUnsentScheduledItemsAsync_WithOwnerOid_ReturnsOnlyMatchingOwnerItems()
+    {
+        // Arrange
+        _context.ScheduledItems.AddRange(
+            CreateScheduledItem("Owner 1 Unsent", messageSent: false, ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 1 Sent", messageSent: true, ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 2 Unsent", messageSent: false, ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetUnsentScheduledItemsAsync("owner-1");
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("owner-1", result[0].CreatedByEntraOid);
+        Assert.False(result[0].MessageSent);
+    }
+
+    [Fact]
     public async Task GetScheduledItemsByCalendarMonthAsync_ReturnsItemsInSpecifiedMonth()
     {
         // Arrange
@@ -249,6 +322,25 @@ public class ScheduledItemDataStoreTests : IDisposable
         Assert.NotNull(result);
         Assert.Equal(2, result.Count);
         Assert.All(result, r => Assert.Contains("June", r.Message));
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsByCalendarMonthAsync_WithOwnerOid_ReturnsOnlyMatchingOwnerItems()
+    {
+        // Arrange
+        _context.ScheduledItems.AddRange(
+            CreateScheduledItem("Owner 1 June", new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero), ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 1 July", new DateTimeOffset(2025, 7, 15, 10, 0, 0, TimeSpan.Zero), ownerOid: "owner-1"),
+            CreateScheduledItem("Owner 2 June", new DateTimeOffset(2025, 6, 20, 10, 0, 0, TimeSpan.Zero), ownerOid: "owner-2"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetScheduledItemsByCalendarMonthAsync("owner-1", 2025, 6);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("owner-1", result[0].CreatedByEntraOid);
+        Assert.Equal("Owner 1 June", result[0].Message);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/EngagementManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/EngagementManagerTests.cs
@@ -109,6 +109,61 @@ public class EngagementManagerTests
     }
 
     [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var engagements = new List<Engagement> { new Engagement { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetAllAsync("owner-1", default)).ReturnsAsync(engagements);
+
+        // Act
+        var result = await _engagementManager.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(engagements, result);
+        _repository.Verify(r => r.GetAllAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOidAndPaging_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var pagedResult = new PagedResult<Engagement>
+        {
+            Items = new List<Engagement> { new Engagement { Id = 1, CreatedByEntraOid = "owner-1" } },
+            TotalCount = 1
+        };
+        _repository.Setup(r => r.GetAllAsync("owner-1", 2, 10, "name", false, "conf", default))
+            .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _engagementManager.GetAllAsync("owner-1", 2, 10, "name", false, "conf");
+
+        // Assert
+        Assert.Equal(pagedResult, result);
+        _repository.Verify(r => r.GetAllAsync("owner-1", 2, 10, "name", false, "conf", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithPaging_ShouldCallUnfilteredRepository()
+    {
+        // Arrange
+        var pagedResult = new PagedResult<Engagement>
+        {
+            Items = new List<Engagement> { new Engagement { Id = 1 } },
+            TotalCount = 1
+        };
+        _repository.Setup(r => r.GetAllAsync(1, 25, "startdate", true, "conf", default))
+            .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _engagementManager.GetAllAsync(1, 25, "startdate", true, "conf");
+
+        // Assert
+        Assert.Equal(pagedResult, result);
+        _repository.Verify(r => r.GetAllAsync(1, 25, "startdate", true, "conf", default), Times.Once);
+    }
+
+    [Fact]
     public async Task DeleteAsync_Entity_ShouldCallRepository()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
@@ -63,6 +63,40 @@ public class ScheduledItemManagerTests
     }
 
     [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var scheduledItems = new List<ScheduledItem> { new ScheduledItem { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetAllAsync("owner-1", default)).ReturnsAsync(scheduledItems);
+
+        // Act
+        var result = await _scheduledItemManager.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(scheduledItems, result);
+        _repository.Verify(r => r.GetAllAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOidAndPaging_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var pagedResult = new PagedResult<ScheduledItem>
+        {
+            Items = new List<ScheduledItem> { new ScheduledItem { Id = 1, CreatedByEntraOid = "owner-1" } },
+            TotalCount = 1
+        };
+        _repository.Setup(r => r.GetAllAsync("owner-1", 2, 5, default)).ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _scheduledItemManager.GetAllAsync("owner-1", 2, 5);
+
+        // Assert
+        Assert.Equal(pagedResult, result);
+        _repository.Verify(r => r.GetAllAsync("owner-1", 2, 5, default), Times.Once);
+    }
+
+    [Fact]
     public async Task DeleteAsync_Entity_ShouldCallRepository()
     {
         // Arrange
@@ -122,6 +156,21 @@ public class ScheduledItemManagerTests
     }
 
     [Fact]
+    public async Task GetUnsentScheduledItemsAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var scheduledItems = new List<ScheduledItem> { new ScheduledItem { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetUnsentScheduledItemsAsync("owner-1", default)).ReturnsAsync(scheduledItems);
+
+        // Act
+        var result = await _scheduledItemManager.GetUnsentScheduledItemsAsync("owner-1");
+
+        // Assert
+        Assert.Equal(scheduledItems, result);
+        _repository.Verify(r => r.GetUnsentScheduledItemsAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
     public async Task GetScheduledItemsByCalendarMonthAsync_ShouldCallRepository()
     {
         // Arrange
@@ -134,6 +183,21 @@ public class ScheduledItemManagerTests
         // Assert
         Assert.Equal(scheduledItems, result);
         _repository.Verify(r => r.GetScheduledItemsByCalendarMonthAsync(2022, 1), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsByCalendarMonthAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var scheduledItems = new List<ScheduledItem> { new ScheduledItem { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetScheduledItemsByCalendarMonthAsync("owner-1", 2022, 1, default)).ReturnsAsync(scheduledItems);
+
+        // Act
+        var result = await _scheduledItemManager.GetScheduledItemsByCalendarMonthAsync("owner-1", 2022, 1);
+
+        // Assert
+        Assert.Equal(scheduledItems, result);
+        _repository.Verify(r => r.GetScheduledItemsByCalendarMonthAsync("owner-1", 2022, 1, default), Times.Once);
     }
 
     [Fact]
@@ -163,5 +227,20 @@ public class ScheduledItemManagerTests
         // Assert
         Assert.True(result);
         _repository.Verify(r => r.SentScheduledItemAsync(1, sentOn), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrphanedScheduledItemsAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var scheduledItems = new List<ScheduledItem> { new ScheduledItem { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetOrphanedScheduledItemsAsync("owner-1", default)).ReturnsAsync(scheduledItems);
+
+        // Act
+        var result = await _scheduledItemManager.GetOrphanedScheduledItemsAsync("owner-1");
+
+        // Assert
+        Assert.Equal(scheduledItems, result);
+        _repository.Verify(r => r.GetOrphanedScheduledItemsAsync("owner-1", default), Times.Once);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
@@ -63,6 +63,21 @@ public class SyndicationFeedSourceManagerTests
     }
 
     [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var sources = new List<SyndicationFeedSource> { new SyndicationFeedSource { Id = 1, FeedIdentifier = "Test", CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetAllAsync("owner-1", default)).ReturnsAsync(sources);
+
+        // Act
+        var result = await _syndicationFeedSourceManager.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(sources, result);
+        _repository.Verify(r => r.GetAllAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
     public async Task DeleteAsync_Entity_ShouldCallRepository()
     {
         // Arrange
@@ -121,6 +136,23 @@ public class SyndicationFeedSourceManagerTests
         // Assert
         Assert.Equal(source, result);
         _repository.Verify(r => r.GetRandomSyndicationDataAsync(cutoffDate, excludedCategories, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRandomSyndicationDataAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var source = new SyndicationFeedSource { Id = 1, FeedIdentifier = "Test", CreatedByEntraOid = "owner-1" };
+        var cutoffDate = DateTimeOffset.UtcNow;
+        var excludedCategories = new List<string> { "Exclude" };
+        _repository.Setup(r => r.GetRandomSyndicationDataAsync("owner-1", cutoffDate, excludedCategories, default)).ReturnsAsync(source);
+
+        // Act
+        var result = await _syndicationFeedSourceManager.GetRandomSyndicationDataAsync("owner-1", cutoffDate, excludedCategories);
+
+        // Assert
+        Assert.Equal(source, result);
+        _repository.Verify(r => r.GetRandomSyndicationDataAsync("owner-1", cutoffDate, excludedCategories, default), Times.Once);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
@@ -63,6 +63,21 @@ public class YouTubeSourceManagerTests
     }
 
     [Fact]
+    public async Task GetAllAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()
+    {
+        // Arrange
+        var sources = new List<YouTubeSource> { new YouTubeSource { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetAllAsync("owner-1", default)).ReturnsAsync(sources);
+
+        // Act
+        var result = await _youTubeSourceManager.GetAllAsync("owner-1");
+
+        // Assert
+        Assert.Equal(sources, result);
+        _repository.Verify(r => r.GetAllAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
     public async Task DeleteAsync_Entity_ShouldCallRepository()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/EngagementsControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/EngagementsControllerTests.cs
@@ -541,6 +541,92 @@ public class EngagementsControllerTests
     }
 
     [Fact]
+    public async Task Details_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var engagement = new Engagement { Id = 1, CreatedByEntraOid = "different-user-oid" };
+
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _engagementService.Setup(s => s.GetEngagementAsync(1)).ReturnsAsync(engagement);
+
+        // Act
+        var result = await _controller.Details(1);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+        Assert.Equal("You do not have permission to view this engagement.", _controller.TempData["ErrorMessage"]);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var engagement = new Engagement { Id = 1, CreatedByEntraOid = "different-user-oid" };
+
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _engagementService.Setup(s => s.GetEngagementAsync(1)).ReturnsAsync(engagement);
+
+        // Act
+        var result = await _controller.Edit(1);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+        Assert.Equal("You do not have permission to edit this engagement.", _controller.TempData["ErrorMessage"]);
+        _engagementService.Verify(s => s.GetPlatformsForEngagementAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var engagement = new Engagement { Id = 1, CreatedByEntraOid = "different-user-oid" };
+
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _engagementService.Setup(s => s.GetEngagementAsync(1)).ReturnsAsync(engagement);
+
+        // Act
+        var result = await _controller.Delete(1);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+        Assert.Equal("You do not have permission to delete this engagement.", _controller.TempData["ErrorMessage"]);
+        _mapper.Verify(m => m.Map<EngagementViewModel>(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Add_Post_SetsCreatedByEntraOid()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/SchedulesControllerTests.cs
@@ -549,4 +549,119 @@ public class SchedulesControllerTests
         Assert.Equal(viewModels, viewResult.Model);
         _scheduledItemService.Verify(s => s.GetScheduledItemsToSendAsync(It.IsAny<int?>(), It.IsAny<int?>()), Times.Once);
     }
+
+    [Fact]
+    public async Task Details_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var scheduledItem = new ScheduledItem { Id = 1, CreatedByEntraOid = "different-user-oid" };
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _scheduledItemService.Setup(s => s.GetScheduledItemAsync(1)).ReturnsAsync(scheduledItem);
+
+        // Act
+        var result = await _controller.Details(1);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+        Assert.Equal("You do not have permission to view this scheduled item.", _controller.TempData["ErrorMessage"]);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var scheduledItem = new ScheduledItem { Id = 1, CreatedByEntraOid = "different-user-oid" };
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _scheduledItemService.Setup(s => s.GetScheduledItemAsync(1)).ReturnsAsync(scheduledItem);
+
+        // Act
+        var result = await _controller.Edit(1);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+        Assert.Equal("You do not have permission to edit this scheduled item.", _controller.TempData["ErrorMessage"]);
+        _mapper.Verify(m => m.Map<ScheduledItemViewModel>(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var scheduledItem = new ScheduledItem { Id = 1, CreatedByEntraOid = "different-user-oid" };
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _scheduledItemService.Setup(s => s.GetScheduledItemAsync(1)).ReturnsAsync(scheduledItem);
+
+        // Act
+        var result = await _controller.Delete(1);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+        Assert.Equal("You do not have permission to delete this scheduled item.", _controller.TempData["ErrorMessage"]);
+        _mapper.Verify(m => m.Map<ScheduledItemViewModel>(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Add_Post_SetsCreatedByEntraOid()
+    {
+        // Arrange
+        var userOid = "user-oid-67890";
+        var viewModel = new ScheduledItemViewModel { Id = 0 };
+        var savedItem = new ScheduledItem { Id = 55, CreatedByEntraOid = userOid };
+
+        var claims = new List<Claim> { new Claim(ApplicationClaimTypes.EntraObjectId, userOid) };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        ScheduledItem? capturedItem = null;
+        _mapper.Setup(m => m.Map<ScheduledItem>(It.IsAny<object>())).Returns(new ScheduledItem());
+        _scheduledItemService
+            .Setup(s => s.SaveScheduledItemAsync(It.IsAny<ScheduledItem>()))
+            .Callback<ScheduledItem>(item => capturedItem = item)
+            .ReturnsAsync(savedItem);
+
+        // Act
+        var result = await _controller.Add(viewModel);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Details", redirectResult.ActionName);
+        Assert.NotNull(capturedItem);
+        Assert.Equal(userOid, capturedItem!.CreatedByEntraOid);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/TalksControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/TalksControllerTests.cs
@@ -412,4 +412,123 @@ public class TalksControllerTests
         var redirectResult = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Add", redirectResult.ActionName);
     }
+
+    [Fact]
+    public async Task Details_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var talk = new Talk { Id = 10, EngagementId = 1, CreatedByEntraOid = "different-user-oid" };
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _engagementService.Setup(s => s.GetEngagementTalkAsync(1, 10)).ReturnsAsync(talk);
+
+        // Act
+        var result = await _controller.Details(1, 10);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Edit", redirectResult.ActionName);
+        Assert.Equal("Engagements", redirectResult.ControllerName);
+        Assert.Equal("You do not have permission to view this talk.", _controller.TempData["ErrorMessage"]);
+        _mapper.Verify(m => m.Map<TalkViewModel>(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var talk = new Talk { Id = 10, EngagementId = 1, CreatedByEntraOid = "different-user-oid" };
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _engagementService.Setup(s => s.GetEngagementTalkAsync(1, 10)).ReturnsAsync(talk);
+
+        // Act
+        var result = await _controller.Edit(1, 10);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Edit", redirectResult.ActionName);
+        Assert.Equal("Engagements", redirectResult.ControllerName);
+        Assert.Equal("You do not have permission to edit this talk.", _controller.TempData["ErrorMessage"]);
+        _mapper.Verify(m => m.Map<TalkViewModel>(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()
+    {
+        // Arrange
+        var talk = new Talk { Id = 10, EngagementId = 1, CreatedByEntraOid = "different-user-oid" };
+        var claims = new List<Claim>
+        {
+            new Claim(ApplicationClaimTypes.EntraObjectId, "user-oid-12345"),
+            new Claim(ClaimTypes.Role, RoleNames.Contributor)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        _engagementService.Setup(s => s.GetEngagementTalkAsync(1, 10)).ReturnsAsync(talk);
+
+        // Act
+        var result = await _controller.Delete(1, 10);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Edit", redirectResult.ActionName);
+        Assert.Equal("Engagements", redirectResult.ControllerName);
+        Assert.Equal("You do not have permission to delete this talk.", _controller.TempData["ErrorMessage"]);
+        _mapper.Verify(m => m.Map<TalkViewModel>(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Add_Post_SetsCreatedByEntraOid()
+    {
+        // Arrange
+        var userOid = "user-oid-67890";
+        var viewModel = new TalkViewModel { Id = 0, EngagementId = 1 };
+        var savedTalk = new Talk { Id = 10, EngagementId = 1, CreatedByEntraOid = userOid };
+
+        var claims = new List<Claim> { new Claim(ApplicationClaimTypes.EntraObjectId, userOid) };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        Talk? capturedTalk = null;
+        _mapper.Setup(m => m.Map<Talk>(It.IsAny<object>())).Returns(new Talk());
+        _engagementService
+            .Setup(s => s.SaveEngagementTalkAsync(It.IsAny<Talk>()))
+            .Callback<Talk>(talk => capturedTalk = talk)
+            .ReturnsAsync(savedTalk);
+
+        // Act
+        var result = await _controller.Add(viewModel);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Details", redirectResult.ActionName);
+        Assert.NotNull(capturedTalk);
+        Assert.Equal(userOid, capturedTalk!.CreatedByEntraOid);
+    }
 }


### PR DESCRIPTION
## Summary
- add owner-filtered Data.Sql coverage for engagements, message templates, and scheduled items
- add manager pass-through tests for owner-aware query overloads
- add API and Web claim-stamping / ownership enforcement coverage in existing controller test suites

Closes #732

## Testing
- dotnet restore .\src\
- dotnet build .\src\ --no-restore --configuration Release
- dotnet test .\src\ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"