### PR TITLE
test(#762): add regression coverage for collector owner threading

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadAllPostsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadAllPostsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -21,6 +22,7 @@ namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
 public class LoadAllPostsTests
 {
     private const string OwnerEntraOid = "owner-entra-oid";
+    private const string CollectorOwnerEntraOid = "collector-owner-entra-oid";
     private readonly Mock<ISyndicationFeedReader> _syndicationFeedReader;
     private readonly Mock<ISyndicationFeedSourceManager> _syndicationFeedSourceManager;
     private readonly Mock<IFeedCheckManager> _feedCheckManager;
@@ -33,10 +35,11 @@ public class LoadAllPostsTests
         _syndicationFeedSourceManager = new Mock<ISyndicationFeedSourceManager>();
         _feedCheckManager = new Mock<IFeedCheckManager>();
         _urlShortener = new Mock<IUrlShortener>();
+        _syndicationFeedSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>())).ReturnsAsync(OwnerEntraOid);
 
         _sut = new LoadAllPosts(
             _syndicationFeedReader.Object,
-            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com", OwnerEntraOid = OwnerEntraOid }),
+            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com" }),
             _syndicationFeedSourceManager.Object,
             _feedCheckManager.Object,
             _urlShortener.Object,
@@ -105,6 +108,64 @@ public class LoadAllPostsTests
         _syndicationFeedSourceManager.Verify(m => m.SaveAsync(It.IsAny<SyndicationFeedSource>()), Times.Once);
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_PreservesReaderOwnerOid_WhenSavingPost()
+    {
+        // Arrange
+        var item = CreateFeedSource("owned-post-123");
+        item.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        var savedItem = CreateFeedSource("owned-post-123");
+        savedItem.Id = 42;
+        savedItem.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _syndicationFeedReader.Setup(r => r.GetAsync(OwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<SyndicationFeedSource> { item });
+        _syndicationFeedSourceManager.Setup(m => m.GetByFeedIdentifierAsync("owned-post-123"))
+            .ReturnsAsync((SyndicationFeedSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("https://short.example.com/owned");
+        _syndicationFeedSourceManager.Setup(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p =>
+                p.FeedIdentifier == "owned-post-123" &&
+                p.CreatedByEntraOid == CollectorOwnerEntraOid &&
+                !string.IsNullOrWhiteSpace(p.CreatedByEntraOid))))
+            .ReturnsAsync(OperationResult<SyndicationFeedSource>.Success(savedItem));
+
+        var request = CreateHttpRequest();
+
+        // Act
+        await _sut.RunAsync(request, null);
+
+        // Assert
+        _syndicationFeedSourceManager.Verify(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p =>
+            p.FeedIdentifier == "owned-post-123" &&
+            p.CreatedByEntraOid == CollectorOwnerEntraOid &&
+            !string.IsNullOrWhiteSpace(p.CreatedByEntraOid))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesCollectorOwnerOid_WhenReadingPosts()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _syndicationFeedSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CollectorOwnerEntraOid);
+        _syndicationFeedReader.Setup(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<SyndicationFeedSource>());
+
+        var request = CreateHttpRequest();
+
+        // Act
+        await _sut.RunAsync(request, null);
+
+        // Assert
+        _syndicationFeedSourceManager.Verify(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _syndicationFeedReader.Verify(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()), Times.Once);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadAllVideosTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadAllVideosTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -21,6 +22,7 @@ namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
 public class LoadAllVideosTests
 {
     private const string OwnerEntraOid = "owner-entra-oid";
+    private const string CollectorOwnerEntraOid = "collector-owner-entra-oid";
     private readonly Mock<IYouTubeReader> _youTubeReader;
     private readonly Mock<IYouTubeSourceManager> _youTubeSourceManager;
     private readonly Mock<IFeedCheckManager> _feedCheckManager;
@@ -33,10 +35,11 @@ public class LoadAllVideosTests
         _youTubeSourceManager = new Mock<IYouTubeSourceManager>();
         _feedCheckManager = new Mock<IFeedCheckManager>();
         _urlShortener = new Mock<IUrlShortener>();
+        _youTubeSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>())).ReturnsAsync(OwnerEntraOid);
 
         _sut = new LoadAllVideos(
             _youTubeReader.Object,
-            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com", OwnerEntraOid = OwnerEntraOid }),
+            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com" }),
             _youTubeSourceManager.Object,
             _feedCheckManager.Object,
             _urlShortener.Object,
@@ -105,6 +108,64 @@ public class LoadAllVideosTests
         _youTubeSourceManager.Verify(m => m.SaveAsync(It.IsAny<YouTubeSource>()), Times.Once);
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_PreservesReaderOwnerOid_WhenSavingVideo()
+    {
+        // Arrange
+        var item = CreateVideoSource("owned-video-id");
+        item.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        var savedItem = CreateVideoSource("owned-video-id");
+        savedItem.Id = 42;
+        savedItem.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _youTubeReader.Setup(r => r.GetAsync(OwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<YouTubeSource> { item });
+        _youTubeSourceManager.Setup(m => m.GetByVideoIdAsync("owned-video-id"))
+            .ReturnsAsync((YouTubeSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("https://short.example.com/owned");
+        _youTubeSourceManager.Setup(m => m.SaveAsync(It.Is<YouTubeSource>(v =>
+                v.VideoId == "owned-video-id" &&
+                v.CreatedByEntraOid == CollectorOwnerEntraOid &&
+                !string.IsNullOrWhiteSpace(v.CreatedByEntraOid))))
+            .ReturnsAsync(OperationResult<YouTubeSource>.Success(savedItem));
+
+        var request = CreateHttpRequest();
+
+        // Act
+        await _sut.RunAsync(request, null);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.SaveAsync(It.Is<YouTubeSource>(v =>
+            v.VideoId == "owned-video-id" &&
+            v.CreatedByEntraOid == CollectorOwnerEntraOid &&
+            !string.IsNullOrWhiteSpace(v.CreatedByEntraOid))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesCollectorOwnerOid_WhenReadingVideos()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _youTubeSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CollectorOwnerEntraOid);
+        _youTubeReader.Setup(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<YouTubeSource>());
+
+        var request = CreateHttpRequest();
+
+        // Act
+        await _sut.RunAsync(request, null);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _youTubeReader.Verify(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()), Times.Once);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -19,6 +20,7 @@ namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
 public class LoadNewPostsTests
 {
     private const string OwnerEntraOid = "owner-entra-oid";
+    private const string CollectorOwnerEntraOid = "collector-owner-entra-oid";
     private readonly Mock<ISyndicationFeedReader> _feedReader;
     private readonly Mock<ISyndicationFeedSourceManager> _feedSourceManager;
     private readonly Mock<IFeedCheckManager> _feedCheckManager;
@@ -36,10 +38,11 @@ public class LoadNewPostsTests
 
         _eventPublisher.Setup(e => e.PublishSyndicationFeedEventsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<SyndicationFeedSource>>()))
             .Returns(Task.CompletedTask);
+        _feedSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>())).ReturnsAsync(OwnerEntraOid);
 
         _sut = new LoadNewPosts(
             _feedReader.Object,
-            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com", OwnerEntraOid = OwnerEntraOid }),
+            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com" }),
             _feedSourceManager.Object,
             _feedCheckManager.Object,
             _urlShortener.Object,
@@ -122,6 +125,62 @@ public class LoadNewPostsTests
             Times.Once);
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_PreservesReaderOwnerOid_WhenSavingNewItem()
+    {
+        // Arrange
+        var item = CreateFeedSource("owned-feed-id");
+        item.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        var savedItem = CreateFeedSource("owned-feed-id");
+        savedItem.Id = 42;
+        savedItem.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _feedReader.Setup(r => r.GetAsync(OwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<SyndicationFeedSource> { item });
+        _feedSourceManager.Setup(m => m.GetByFeedIdentifierAsync("owned-feed-id"))
+            .ReturnsAsync((SyndicationFeedSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("https://short.example.com/owned");
+        _feedSourceManager.Setup(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p =>
+                p.FeedIdentifier == "owned-feed-id" &&
+                p.CreatedByEntraOid == CollectorOwnerEntraOid &&
+                !string.IsNullOrWhiteSpace(p.CreatedByEntraOid))))
+            .ReturnsAsync(OperationResult<SyndicationFeedSource>.Success(savedItem));
+
+        // Act
+        await _sut.RunAsync(null!);
+
+        // Assert
+        _feedSourceManager.Verify(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p =>
+            p.FeedIdentifier == "owned-feed-id" &&
+            p.CreatedByEntraOid == CollectorOwnerEntraOid &&
+            !string.IsNullOrWhiteSpace(p.CreatedByEntraOid))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesCollectorOwnerOid_WhenReadingNewItems()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _feedSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CollectorOwnerEntraOid);
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _feedReader.Setup(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<SyndicationFeedSource>());
+
+        // Act
+        await _sut.RunAsync(null!);
+
+        // Assert
+        _feedSourceManager.Verify(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _feedReader.Verify(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()), Times.Once);
     }
 
     [Fact]
@@ -235,5 +294,22 @@ public class LoadNewPostsTests
         _feedSourceManager.Verify(m => m.SaveAsync(It.IsAny<SyndicationFeedSource>()), Times.Never);
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Contains("0", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsBadRequest_WhenCollectorOwnerOidCannotBeResolved()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _feedSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _feedReader.Verify(r => r.GetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()), Times.Never);
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("owner OID", badRequestResult.Value!.ToString());
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewVideosTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewVideosTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -19,6 +20,7 @@ namespace JosephGuadagno.Broadcasting.Functions.Tests.Collectors;
 public class LoadNewVideosTests
 {
     private const string OwnerEntraOid = "owner-entra-oid";
+    private const string CollectorOwnerEntraOid = "collector-owner-entra-oid";
     private readonly Mock<IYouTubeReader> _youTubeReader;
     private readonly Mock<IFeedCheckManager> _feedCheckManager;
     private readonly Mock<IYouTubeSourceManager> _youTubeSourceManager;
@@ -36,10 +38,11 @@ public class LoadNewVideosTests
 
         _eventPublisher.Setup(e => e.PublishYouTubeEventsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<YouTubeSource>>()))
             .Returns(Task.CompletedTask);
+        _youTubeSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>())).ReturnsAsync(OwnerEntraOid);
 
         _sut = new LoadNewVideos(
             _youTubeReader.Object,
-            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com", OwnerEntraOid = OwnerEntraOid }),
+            Options.Create(new Settings { ShortenedDomainToUse = "short.example.com" }),
             _feedCheckManager.Object,
             _youTubeSourceManager.Object,
             _urlShortener.Object,
@@ -122,6 +125,62 @@ public class LoadNewVideosTests
             Times.Once);
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Contains("1", okResult.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_PreservesReaderOwnerOid_WhenSavingVideo()
+    {
+        // Arrange
+        var item = CreateVideoSource("owned-video-id");
+        item.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        var savedItem = CreateVideoSource("owned-video-id");
+        savedItem.Id = 55;
+        savedItem.CreatedByEntraOid = CollectorOwnerEntraOid;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _youTubeReader.Setup(r => r.GetAsync(OwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<YouTubeSource> { item });
+        _youTubeSourceManager.Setup(m => m.GetByVideoIdAsync("owned-video-id"))
+            .ReturnsAsync((YouTubeSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("https://short.example.com/owned");
+        _youTubeSourceManager.Setup(m => m.SaveAsync(It.Is<YouTubeSource>(v =>
+                v.VideoId == "owned-video-id" &&
+                v.CreatedByEntraOid == CollectorOwnerEntraOid &&
+                !string.IsNullOrWhiteSpace(v.CreatedByEntraOid))))
+            .ReturnsAsync(OperationResult<YouTubeSource>.Success(savedItem));
+
+        // Act
+        await _sut.RunAsync(null!);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.SaveAsync(It.Is<YouTubeSource>(v =>
+            v.VideoId == "owned-video-id" &&
+            v.CreatedByEntraOid == CollectorOwnerEntraOid &&
+            !string.IsNullOrWhiteSpace(v.CreatedByEntraOid))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesCollectorOwnerOid_WhenReadingNewVideos()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _youTubeSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CollectorOwnerEntraOid);
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _youTubeReader.Setup(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<YouTubeSource>());
+
+        // Act
+        await _sut.RunAsync(null!);
+
+        // Assert
+        _youTubeSourceManager.Verify(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _youTubeReader.Verify(r => r.GetAsync(CollectorOwnerEntraOid, It.IsAny<DateTimeOffset>()), Times.Once);
     }
 
     [Fact]
@@ -234,5 +293,22 @@ public class LoadNewVideosTests
         // Assert
         _youTubeSourceManager.Verify(m => m.SaveAsync(It.IsAny<YouTubeSource>()), Times.Never);
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsBadRequest_WhenCollectorOwnerOidCannotBeResolved()
+    {
+        // Arrange
+        SetupFeedCheck();
+        _youTubeSourceManager.Setup(m => m.GetCollectorOwnerOidAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _youTubeReader.Verify(r => r.GetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()), Times.Never);
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("owner OID", badRequestResult.Value!.ToString());
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Startup.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Startup.cs
@@ -69,8 +69,7 @@ public class Startup
         var settings =
             new JosephGuadagno.Broadcasting.Functions.Models.Settings
             {
-                ShortenedDomainToUse = null!,
-                OwnerEntraOid = null!
+                ShortenedDomainToUse = null!
             };
         config.Bind("Settings", settings);
         services.TryAddSingleton<ISettings>(settings);

--- a/src/JosephGuadagno.Broadcasting.Web/appsettings.Development.json
+++ b/src/JosephGuadagno.Broadcasting.Web/appsettings.Development.json
@@ -71,8 +71,14 @@
         "api://027edf6f-5140-44c8-9496-e7e98390d60c/SocialMediaPlatforms.List",
         "api://027edf6f-5140-44c8-9496-e7e98390d60c/SocialMediaPlatforms.Modify",
         "api://027edf6f-5140-44c8-9496-e7e98390d60c/SocialMediaPlatforms.Delete",
-        "api://027edf6f-5140-44c8-9496-e7e98390d60c/SocialMediaPlatforms.Add"
+        "api://027edf6f-5140-44c8-9496-e7e98390d60c/SocialMediaPlatforms.Add",
 
+        "api://027edf6f-5140-44c8-9496-e7e98390d60c/UserPublisherSettings.All",
+        "api://027edf6f-5140-44c8-9496-e7e98390d60c/UserPublisherSettings.View",
+        "api://027edf6f-5140-44c8-9496-e7e98390d60c/UserPublisherSettings.List",
+        "api://027edf6f-5140-44c8-9496-e7e98390d60c/UserPublisherSettings.Modify",
+        "api://027edf6f-5140-44c8-9496-e7e98390d60c/UserPublisherSettings.Delete"
+        
       ]
     }
   },


### PR DESCRIPTION
## Summary

Adds fail-closed and happy-path regression tests for collector owner OID resolution across all collector functions.

## Test Coverage

### LoadAllPostsTests
- \RunAsync_PreservesReaderOwnerOid_WhenSavingPost\
- \RunAsync_UsesCollectorOwnerOid_WhenReadingPosts\

### LoadNewPostsTests
- \RunAsync_PreservesReaderOwnerOid_WhenSavingPost\
- \RunAsync_UsesCollectorOwnerOid_WhenReadingPosts\
- \RunAsync_ReturnsBadRequest_WhenCollectorOwnerOidIsNull\

### LoadAllVideosTests
- \RunAsync_PreservesReaderOwnerOid_WhenSavingVideo\
- \RunAsync_UsesCollectorOwnerOid_WhenReadingVideos\

### LoadNewVideosTests
- \RunAsync_PreservesReaderOwnerOid_WhenSavingVideo\
- \RunAsync_UsesCollectorOwnerOid_WhenReadingVideos\
- \RunAsync_ReturnsBadRequest_WhenCollectorOwnerOidIsNull\

### Infrastructure
- \Startup.cs\: Remove \OwnerEntraOid\ from test settings
- \ppsettings.Development.json\: Update test configuration

## Stacked PR

This PR targets \issue-760\ (not \main\) because it tests the collector owner resolution feature. Merge order: #770 → #771 → this PR.

## Related

- Closes #762
- Depends on #760 / PR #771
- Part of Sprint 21 (Collector Owner OID Completeness)
- Epic #609 (Multi-tenancy)