### PR TITLE
docs(.squad): Recover team history and decisions from local backup

### DIFF
--- a/.squad/agents/link/history.md
+++ b/.squad/agents/link/history.md
@@ -4,6 +4,7 @@
 
 | Date | Task | Outcome |
 |------|------|---------|
+| 2026-04-19 | **PR #759 Merge: Sprint 20 Wrap Docs to main** — Convert 4 unpushed commits on local main into GitHub PR and merge after CI passes. Protect uncommitted `.squad` changes in working tree. | ✅ PR #759 created from temporary branch `link/sprint20-wrapup-pr`, pushed to remote. All CI checks passed (build-and-test 2m21s, CodeQL 6m18s, GitGuardian). Merged with normal merge commit (not squash) at `33154c5`. Local main fast-forwarded. Uncommitted `.squad` changes left untouched in working tree. |
 | 2026-04-19 | **Retro Guardrails: Reducing Token Waste & Directive Drift** — Analyze three sprints of repeated failures (PR #738, #739 multi-round reviews); propose operational guardrails to prevent duplicate work, enforce pre-submission validation, and reduce expensive GitHub API polling | ✅ Proposal written to `.squad/decisions/inbox/link-retro-guardrails.md`. Key findings: 6 waste patterns identified; ~6,000 tokens wasted per 3-cycle review due to missing pre-checks. Guardrails target: (1) pre-execution checklist gate, (2) orchestration log deduplication, (3) cheap checks before expensive work, (4) SOP for branch readiness. Implementation priority: P1 pre-hook + coordinator gate this week; P2 skill doc next sprint; P3 task tracking + webhook handling later. |
 | 2026-04-19 | **Sprint 20 Wrap — Branch Cleanup & Orchestration** — Delete local branches after PR #756 and #757 merged; update main from origin/main; prune remote-tracking branches; record orchestration log | ✅ Deleted `issue-731-user-publisher-settings`, `issue-732-owner-isolation-tests`, `issue-745`, `neo/pr-recovery-731-732`. Pruned remote tracking branches. Local main now at `0bcc1fe` (origin/main HEAD) with clean working tree. Orchestration log recorded at `.squad/orchestration-log/2026-04-19T14-47-26Z-link-sprint20-cleanup.md`. |
 | 2026-04-01 | **Serilog Configuration Deduplication (#314)** — Extract duplicate Serilog bootstrap from Api/Functions/Web into shared `LoggingExtensions.ConfigureSerilog()` method; Web gains OpenTelemetry sink | ✅ PR #594 opened, targets `issue-591-reduce-production-logging` branch (depends on PR #592). Web/Program.cs now has `WriteTo.OpenTelemetry()` enabled. |
@@ -14,6 +15,7 @@
 
 ## Learnings
 
+- **Dirty worktree branch creation**: When the working tree has uncommitted changes but you need to convert unpushed commits to a PR, use `git branch <name> <sha>` (without switching branches) to create a new branch from HEAD without staging dirty content. This preserves uncommitted changes while allowing you to push a clean feature branch from the desired commit.
 - **Branch-behind-main CI failures**: When a PR branch pre-dates a merge to main that renames symbols (controllers, methods), the CI merge commit will fail to compile. Fix is always `git merge origin/main --no-edit` on the feature branch — no rebase needed when the changes are non-overlapping.
 - **Stash pop conflicts in shared workflow files**: Workflow files (`.github/workflows/*.yml`) change frequently across branches. When popping a stash onto a branch that has received main updates, expect conflicts in workflow steps. Always favour the `origin/main` version of vuln-scan logic since those decisions are made intentionally and tracked in PRs.
 - **Stash hygiene**: After a conflicted stash pop, git leaves the stash entry in the list. Always `git stash drop stash@{N}` after manually committing the resolution.
@@ -55,3 +57,19 @@
 - Root cause of addition: PR #646 review used single-backtick fences; GitHub rendered broken inline code (words truncated, multi-line collapsed)
 - Charter updated with enforcement rule (## How I Work)
 - Read .squad/skills/github-comment-formatting/SKILL.md before posting any PR review or issue comment containing code
+
+
+## Sprint 20 Conclusion — Orchestration & Decisions Management (2026-04-19T15:40:15Z)
+
+**Decision Source:** Scribe processing (20260419T154015-link.md)
+
+**Wrap-up Tasks Completed:**
+- ✅ Merged PR #759 (4 unpushed commits from local main) after full CI pass
+- ✅ Wrote .squad/orchestration-log/20260419T154015-link.md
+- ✅ Wrote .squad/log/20260419T154015-pr-759-merge.md
+- ✅ Merged 9 decision inbox files into .squad/decisions.md
+- ✅ Deleted all .squad/decisions/inbox/*.md files
+- ✅ Updated team member history files with Sprint 20 context
+- ✅ Verified decisions.md size (738,980 bytes) — no immediate archival needed
+
+**Retro Guardrails Proposal:** Recorded in decisions.md as part of Sprint 20 retrospective. Document outlines 6 waste patterns from sprint 18–20 reviews and proposes operational gates (pre-execution checklist, orchestration log dedup, cheap pre-checks) to reduce token cost per cycle from ~6,000 to near-baseline.

--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -26,120 +26,39 @@
 - RBAC #602: Roles, ApplicationUsers, UserRoles, UserApprovalLog tables + 3 role seeds
 - RBAC #607: CreatedByEntraOid nullable columns on 4 tables + domain/EF models
 - PR #662 (#323): SourceTags junction discriminator + unique index UX_SourceTags_SourceId_SourceType_Tag
-- Epic #667 Phase 1: SocialMediaPlatforms table, EngagementSocialMediaPlatforms junction, string->int FK migrations, 5 seeds
-- Issue #715: Removed AnyAsync pre-check from EngagementSocialMediaPlatformDataStore.AddAsync; capped EF retry to 3x/5s
+- Epic #667 Phase 1: SocialMediaPlatforms table, EngagementSocialMediaPlatforms junction, string→int FK migrations, 5 seeds
+- Issue #715: Removed AnyAsync pre-check from AddAsync; capped EF retry to 3×/5s; fixed DisableRetry flag on AddSqlServerDbContext
+- Issue #713: Exception logging audit (added LogError to 7 catch blocks)
+- Issue #727: Owner-filtered data store overloads (SyndicationFeedSource, YouTubeSource, Engagement, ScheduledItem, MessageTemplate)
+- PR #734: TODO comments for CreatedByEntraOid placeholders in SyndicationFeedReader, YouTubeReader
+- Role restructuring: Renamed Administrator → Site Administrator; introduced new narrower Administrator role
+
+**Key learnings:**
+- Nullable-to-NOT-NULL column promotion: two-step approach (add nullable + backfill, then tighten)
+- AnyAsync anti-pattern: Never guard AddAsync with pre-existence check — use PK + DbUpdateException handler
+- EF retry override: Set DisableRetry = true in configureSettings to prevent Aspire's default policy from silently overriding explicit cap
+- Owner-filtered overloads: Use derived interfaces (not base), apply owner filter before counting/paging, use It.IsAny<CancellationToken>() in Moq
+- Custom role seeds: Two-step idempotent block for renames: UPDATE if target doesn't exist, INSERT if still missing
+- Exception logging: Every catch block returning OperationResult MUST log the exception before returning
 
 **Team standing rules:** Only Joseph merges PRs; All mapping via AutoMapper; Paging at data layer only
-### 2026-04-08 — Epic #667 Phase 1: Database Layer Complete
-- **Migration:** `scripts/database/migrations/2026-04-08-social-media-platforms.sql`
-  - Created SocialMediaPlatforms table (Id, Name UNIQUE, Url, Icon, IsActive)
-  - Created EngagementSocialMediaPlatforms junction table (composite PK on EngagementId + SocialMediaPlatformId)
-  - Migrated ScheduledItems.Platform (nvarchar) → SocialMediaPlatformId (int FK) with best-effort string mapping
-  - Migrated MessageTemplates.Platform (composite PK component) → SocialMediaPlatformId (int FK, new PK)
-  - Dropped old columns: Engagements (BlueSkyHandle, ConferenceHashtag, ConferenceTwitterHandle), Talks (BlueSkyHandle)
-  - Seeded 5 platforms: Twitter, BlueSky, LinkedIn, Facebook, Mastodon
-- **Base scripts updated:** `table-create.sql` and `data-seed.sql` reflect post-migration schema
-- **EF Core:**
-  - Created entity models: `SocialMediaPlatform.cs`, `EngagementSocialMediaPlatform.cs`
-  - Updated existing entities: Engagement, Talk, ScheduledItem, MessageTemplate (removed old social fields, added FK refs)
-  - Updated `BroadcastingContext.cs` with new DbSets, composite PK config, FK relationships, unique indexes
-- **Domain:**
-  - Created domain models: `SocialMediaPlatform.cs`, `EngagementSocialMediaPlatform.cs`
-  - Updated existing: Engagement, Talk, ScheduledItem, MessageTemplate (replaced string Platform with int SocialMediaPlatformId)
-- **Repository:**
-  - Created `ISocialMediaPlatformDataStore` interface (GetAsync, GetAllAsync, AddAsync, UpdateAsync, DeleteAsync)
-  - Implemented `SocialMediaPlatformDataStore` with soft delete logic (IsActive flag)
-  - Updated `IMessageTemplateDataStore` and `MessageTemplateDataStore` to use int SocialMediaPlatformId instead of string Platform
-- **AutoMapper:** Added mappings for SocialMediaPlatform ↔ EngagementSocialMediaPlatform (bidirectional ReverseMap)
-- **DI Registration:** Added `ISocialMediaPlatformDataStore` → `SocialMediaPlatformDataStore` to Api Program.cs
-- **Decision doc:** `.squad/decisions/inbox/morpheus-667-db-decisions.md` (migration strategy, PK migration approach, risks)
-- **Status:** ✅ Database layer complete. Breaking changes to MessageTemplate interface require updates in Functions and Web (out of scope for Morpheus — Trinity and Cypher to handle).
-- **Branch:** `issue-667-social-media-platforms`
 
-### 2026-04-08 — Epic #667: PR #683 Opened (Draft)
-- **PR:** https://github.com/jguadagno/jjgnet-broadcast/pull/683
-- **Status:** Draft PR (build broken with 14 expected compile errors from breaking changes)
-- **Breaking change:** `IMessageTemplateDataStore.GetAsync(string platform, ...)` → `GetAsync(int socialMediaPlatformId, ...)`
-- **Impact:** Functions (Twitter, Facebook, LinkedIn), Api, and Web require updates in Sprint 2 (Trinity) and Sprint 3 (Switch/Sparks)
-- **Closes:** #668, #669, #670, #671, #672, #673 (Sprint 1 child issues)
-- **Label:** squad:morpheus
-- **Pattern:** For large cross-cutting changes, use draft PRs to show DB foundation while acknowledging downstream compilation errors. Clearly document expected failures and remediation owners.
+---
 
-### 2026-04-08 — Epic #667: PR #683 Review Fix (bi-bluesky icon)
-- **Review comment:** Reviewer flagged line 78 of migration script — `bi-cloud` should be `bi-bluesky` for BlueSky platform
-- **Files fixed:**
-  - `scripts/database/migrations/2026-04-08-social-media-platforms.sql` (line 78)
-  - `scripts/database/data-seed.sql` (line 78)
-- **Pattern:** Bootstrap icon class names for social platforms must match official icon library names. BlueSky uses `bi-bluesky`, not `bi-cloud`.
-- **Process:** Fixed in both migration script AND base seed data script (consistency rule).
-- **Commit:** `c864f74` — `fix(#667): Use correct Bootstrap icon bi-bluesky for BlueSky platform seed data`
-- **PR reply:** Posted via `gh api repos/.../pulls/683/comments/{comment_id}/replies` to confirm fix and close review thread
+## Recent Sessions
 
-## Learnings
+### 2026-04-20 — PR #771 Seed Bootstrap Patch
 
-### 2026-04-20 — Issue #760: Bootstrap owner OID seed for fail-closed collectors
+- **Work:** Fix fresh-environment database bootstrap for collector owner resolution
+  - Patched scripts\database\data-seed.sql with placeholder Entra OID variable
+  - Applied variable across seeded owner-aware records: Sources, Engagements, ScheduledItems, Talks, MessageTemplates
+  - Reused same variable consistently to enable single TODO search-and-replace during fresh environment setup
+  
+- **Outcome:** Fresh-database seeding now includes CreatedByEntraOid on all owner-aware records; new fail-closed owner resolution can resolve collectors at startup
+- **Commit:** 978fc73
+- **Validation:** Docs lint clean; pre-existing Functions.Tests compile errors on issue-760 remain unrelated to seed changes
+- **Status:** ✅ COMPLETE
 
-- **Problem:** PR #771 made collector owner resolution fail closed by reading the newest non-blank `CreatedByEntraOid` from persisted source rows, but a clean database had no bootstrap owner path because `data-seed.sql` did not populate seeded ownership columns.
-- **Fix:** Added a single `@SeededOwnerEntraOid` variable near the top of `scripts/database/data-seed.sql` with a TODO to replace the placeholder GUID, then threaded that variable through all seeded owner-aware records in the bootstrap script (Engagements, Talks, ScheduledItems, SyndicationFeedSources, YouTubeSources, and MessageTemplates).
-- **Pattern:** When a feature begins resolving ownership from seeded content, the base seed script must expose one explicit, reusable owner OID variable instead of scattering literals or leaving owner columns null/blank. This keeps AppHost fresh-database bootstrap deterministic and gives operators one place to swap in a real Entra object ID.
+---
 
-### 2026-04-17 — Issue #726: CreatedByEntraOid Promoted to NOT NULL
-
-- **Pattern:** Nullable-to-NOT NULL promotion follows a deliberate two-step approach for the project: (1) add column as NULL with a backfill migration (PR #733), confirm all rows updated, then (2) tighten to NOT NULL in a separate migration after confirmation. This avoids data-loss risk on active environments.
-- **Automated collectors:** `SyndicationFeedReader` and `YouTubeReader` use `string.Empty` as a `CreatedByEntraOid` placeholder because they run with no authenticated user context. Future work could inject a system/service-principal OID here.
-
-### 2025-01-30 — Issue #728: TODO Comments for CreatedByEntraOid Placeholders (PR #734)
-
-- **Context:** Sprint 17 issue #728 requires replacing `CreatedByEntraOid = string.Empty` scaffolding in readers with real ownership threading from collector config.
-- **Files flagged:**
-  - `src/JosephGuadagno.Broadcasting.SyndicationFeedReader/SyndicationFeedReader.cs` — two object initializers (lines 71, 127)
-  - `src/JosephGuadagno.Broadcasting.YouTubeReader/YouTubeReader.cs` — one object initializer (line 105)
-- **Comment template:** `// TODO: #728 — Replace with ownerOid resolved from collector config. CreatedByEntraOid must never be string.Empty or null. See decisions.md.`
-- **Pattern:** When adding technical debt markers to scaffolding, place the TODO comment on the line immediately before the problematic assignment. Include the issue number, a concise remediation instruction, and a reference to architectural context (decisions.md) for team visibility.
-- **Branch:** `squad/725-createdbyentraoid-not-null` (PR #734)
-- **Commit:** `9ab51a9` — `chore: add TODO comments to CreatedByEntraOid string.Empty placeholders`
-
-
-
-- **Change:** Renamed existing `Administrator` role to `Site Administrator` (broader platform admin) and introduced a new, narrower `Administrator` role (personal content management).
-- **Files changed:**
-  - `scripts/database/data-seed.sql` — replaced single Administrator seed with idempotent rename + re-seed block; kept Contributor and Viewer unchanged.
-  - `scripts/database/migrations/2026-04-17-role-restructure.sql` — standalone, safe-to-replay migration for existing production environments.
-- **Pattern:** When renaming a seed row, use a two-step idempotent block: (1) UPDATE existing row if rename target does not yet exist, (2) INSERT if it still does not exist after the UPDATE guard. This covers both fresh environments and existing ones in a single replay-safe script.
-
-### 2026-04-15 — Post-PR-718 Remaining 20 s Delay Investigation
-
-- **Context:** After #714 (FromBody) and #715 (AnyAsync removal + EF retry cap) merged in PR #718, a ~20 s delay persisted on `AddPlatformToEngagementAsync`.
-- **Root cause:** `DisableRetry = false` in `configureSettings` caused Aspire's `AddSqlServerDbContext` to install its default retry policy (6 retries, 30 s max) **before** `configureDbContextOptions` runs.  Despite the developer's subsequent `EnableRetryOnFailure(3, 5 s)` call theoretically overriding it, the observed latency (~20 s ≈ 3 retries at Aspire's default delay schedule) confirmed the 3/5 s cap was not taking effect.
-- **Fix:** Changed `DisableRetry = false` → `DisableRetry = true` in `configureSettings`.  Aspire now skips its retry setup entirely.  The developer's explicit `EnableRetryOnFailure(3, 5 s)` in `configureDbContextOptions` is the single source of truth, capping max retry delay at ~9.2 s.
-- **Pattern:** When customising EF Core retry via `configureDbContextOptions` in Aspire's `AddSqlServerDbContext`, **always** set `DisableRetry = true` to prevent Aspire's default retry from silently overriding or co-existing with your explicit cap.
-- **Verified:** API project builds with 0 errors.  Decision doc: `.squad/decisions/inbox/morpheus-delay-root-cause.md`.
-
-### 2025-01-27 — Issue #715: AnyAsync pre-check anti-pattern
-- **Problem:** `AnyAsync()` before `SaveChangesAsync()` in `AddAsync` triggered the EF Core SQL Server retry policy on transient faults, causing ~28s delays (6 retries × exponential backoff).
-- **Fix:** Removed the `AnyAsync` pre-check entirely. Duplicate detection now relies solely on the composite PK `(EngagementId, SocialMediaPlatformId)` and the existing `catch (DbUpdateException ex) when (IsDuplicateAssociationException(ex))` block.
-- **EF Retry cap:** `EnrichSqlServerDbContext` (Aspire 13.x) does NOT accept `configureDbContextOptions`. Use `AddSqlServerDbContext` with both `configureSettings` and `configureDbContextOptions` in a single call to set `EnableRetryOnFailure(maxRetryCount: 3, maxRetryDelay: 5s)`.
-- **Pattern:** Never guard `AddAsync` with an `AnyAsync` pre-existence check — it is both a TOCTOU race and a retry-policy amplifier on transient faults. Let the DB PK constraint + `DbUpdateException` handler be the single source of truth.
-
-### 2025-01-28 — Issue #713 Revision: Exception Logging Audit Completion
-- **Context:** Neo (Lead) rejected Trinity's initial exception audit work due to missing LogError calls and cross-contamination from issue #704/#705 pagination changes.
-- **Problems fixed:**
-  1. Added `ILogger<EngagementDataStore>` to primary constructor and inserted `_logger.LogError(ex, ...)` into all 5 catch blocks (SaveAsync, DeleteAsync×2, SaveTalkAsync, RemoveTalkFromEngagementAsync×2).
-  2. Added `ILogger<EngagementManager>` to constructor and inserted `_logger.LogError(ex, ...)` into 2 catch blocks (SaveAsync, SaveTalkAsync).
-  3. Reverted unrelated pagination changes: `EngagementsController.cs`, `IEngagementService.cs`, `EngagementService.cs`, `Index.cshtml`, `_PaginationPartial.cshtml`, `EngagementsControllerTests.cs` (restored from main).
-  4. Fixed broken tests: Added `Mock<ILogger<T>>` to constructors in all DataStore test classes (`EngagementDataStoreTests`, `FeedCheckDataStoreTests`, `ScheduledItemDataStoreTests`, `YouTubeSourceDataStoreTests`, `TokenRefreshDataStoreTests`, `SyndicationFeedSourceDataStoreTests`, `ScheduledItemOrphanTests`) + `EngagementManagerTests`.
-- **Build:** Clean success after all fixes (0 errors).
-- **Commit:** e306636 — `fix(data,managers): complete exception logging audit - add missing LogError calls (#713)` (10 files changed, -245 lines from reverted pagination tests).
-- **Pattern:** When fixing reviewer-rejected work on a feature branch, FIRST identify and revert any cross-contamination from unrelated branches (use `git diff main...branch --name-only` and `git checkout main -- path/to/file`), THEN add the fixes requested (logging calls), THEN fix all test constructors to match updated DI signatures. Never commit incomplete logging instrumentation — every catch block that returns an OperationResult MUST log the exception before returning.
-
-
-
-### 2026-04-17 — Sprint 16 #727: Owner-Filtered Data Store Overloads
-
-- **Pattern:** When adding owner-filtered query overloads (e.g., `GetAllAsync(string ownerEntraOid, ...)`) to data stores alongside existing unfiltered methods (`GetAllAsync(CancellationToken)`), maintain BOTH signatures for different use cases: owner-filtered for user-scoped queries, unfiltered for Site Admin and background job access.
-- **Interface design:** Place owner-filtered overloads directly in the derived interface (e.g., `ISyndicationFeedSourceDataStore`), not in the base `IDataStore<T>`. This keeps base interfaces clean and allows each data store to expose domain-specific filtering.
-- **Implementation:** Use `.Where(x => x.CreatedByEntraOid == ownerEntraOid)` in LINQ queries. For paged methods, apply the owner filter before counting and paging.
-- **Test fix:** When adding method overloads, Moq may struggle with overload resolution if tests use `GetAllAsync(default)`. Use `GetAllAsync(It.IsAny<CancellationToken>())` explicitly, or better, call with no parameters (`GetAllAsync()`) and let C# default parameter resolution handle it. After changing test mocks, REBUILD the test project to ensure Moq rebinds correctly.
-- **Scope:** Added owner-filtered overloads to 5 data stores: `SyndicationFeedSourceDataStore`, `YouTubeSourceDataStore`, `EngagementDataStore`, `ScheduledItemDataStore`, `MessageTemplateDataStore`.
-- **Branch:** `squad/727-filter-datasources-by-owner` → PR #735
-- **Commit:** `9558b20` — 275 insertions (12 files changed: 5 interfaces, 5 implementations, 2 test files)
+*Detailed work logs and learnings: See decisions.md for architectural decisions and issue-specific deep dives. Earlier work archived in git history.*

--- a/.squad/agents/neo/analysis-731-settings-design.md
+++ b/.squad/agents/neo/analysis-731-settings-design.md
@@ -1,0 +1,194 @@
+# Architectural Analysis: UserPublisherSettings — Why Key/Value Instead of Provider-Specific Objects
+
+**Issue:** #731 (Per-user publisher settings table and full-stack support)  
+**Date Analyzed:** 2026-04-19  
+**Reviewer:** Neo
+
+---
+
+## Executive Summary
+
+The implementation of `UserPublisherSettings` **does store a JSON blob** as originally designed in issue #731, but it's a **flat key/value dictionary** (not nested provider-specific objects) in both the database and runtime memory. This design choice was deliberate and provides critical stability and security benefits that direct object serialization would not.
+
+---
+
+## 1. What the Implementation Actually Stores and Returns
+
+### Database Layer
+- **Storage:** `Settings NVARCHAR(MAX)` column contains a **serialized JSON dictionary** of flat key/value pairs
+  - Example: `{"BlueskyUserName":"alice","BlueskyPassword":"***","PageId":"123","AppId":"456",...}`
+  - All keys are strings; all values are strings (or null)
+  - Case-insensitive lookup via `StringComparer.OrdinalIgnoreCase`
+
+### Runtime Representation
+1. **Persistent Layer** (`UserPublisherSettingDataStore`):
+   - Deserializes from JSON → `Dictionary<string, string?>`
+   - Builds platform-specific strongly-typed objects (`BlueskyPublisherSetting`, `TwitterPublisherSetting`, etc.) with masked values
+   - Example: `TwitterPublisherSetting { HasConsumerKey: true, HasAccessToken: false, ... }` — no actual secrets
+
+2. **Business Logic Layer** (`UserPublisherSettingManager`):
+   - Works with the flat `Dictionary<string, string?>` internally
+   - Converts inbound typed DTOs (e.g., `TwitterPublisherSettingUpdate`) → flat dictionary keys
+   - Applies **merge logic** for secrets: if a new value is provided, store it; if `null`, keep the existing value (safe partial updates)
+
+3. **API Contract** (`UserPublisherSettingResponse`):
+   - Returns **masked, typed, platform-specific responses** — never the raw key/value dict
+   - Secrets are represented as `bool` flags (`HasAccessToken`, `HasAppPassword`), never raw values
+
+### Key Insight
+The implementation **stores flat key/value** but **presents strongly typed objects** to consumers. This is a **bridge pattern**: flat storage + validation layer + typed API contract.
+
+---
+
+## 2. Why a Key/Value Bag Instead of Serializing Provider-Specific Objects
+
+### Original Proposal vs. Reality
+
+The issue #731 design note said:
+> **Settings** is a JSON blob — each platform has different settings... JSON is more flexible for different platform requirements and avoids schema changes when adding new platforms.
+
+This *could* mean nested objects per platform:
+```json
+{
+  "twitter": {"consumerKey": "...", "consumerSecret": "..."},
+  "bluesky": {"userName": "alice", "appPassword": "..."}
+}
+```
+
+**Why flat key/value was chosen instead:**
+
+#### **a) Write-Only Secret Masking**
+- Secrets (API keys, tokens) must **never** be returned in full after save — only as presence indicators
+- A flat `Dictionary<string, string?>` makes it trivial to:
+  1. Load all values from the database
+  2. Check presence: `HasValue("BlueskyPassword")` → return `HasAppPassword: true`
+  3. Never include the actual value in the response
+- Nested objects would require serializing provider-specific objects, then post-processing to mask—more error-prone
+
+#### **b) Partial Update Safety**
+- When a user updates only their Bluesky handle but not the password, the manager code:
+  ```csharp
+  "BlueskyPassword" = MergeSecret(settings?.AppPassword, existingSettings, "BlueskyPassword")
+  // If settings.AppPassword is null, keep the existing value
+  ```
+- This is **trivial with flat key/value**: just don't overwrite if the incoming value is null
+- With nested objects, you'd need nullable wrapper tracking or deep merge logic per provider
+
+#### **c) Platform Extensibility Without Recompilation**
+- Adding a new platform field at runtime (new credential type, new account field) requires **no schema migration**
+- Just add new keys to the dictionary
+- With strongly-typed nested objects, you'd need to redefine and recompile the entire domain model, manager logic, and API contracts
+
+#### **d) Validation Happens at the Contract Boundary, Not Serialization**
+- The manager's `BuildSettings(platform, request, existing)` methods **explicitly validate** what goes into each provider's key set
+- This prevents **accidental data leakage**: only expected keys are stored
+- Flat key/value + switch-case validation is easier to audit than generic object deserialization
+
+---
+
+## 3. Concrete Benefits/Tradeoffs Visible in This Codebase
+
+### Benefits
+
+| Benefit | Evidence in Code |
+|---------|------------------|
+| **API Contract Stability** | `UserPublisherSettingResponse` never exposes `Settings` dict; only typed properties with `HasX` flags. Clients can't accidentally see secrets. |
+| **Write-Only Secret Handling** | `HasAppPassword`, `HasAccessToken`, etc. are booleans; secrets are never in the response. Lines 81–82, 87–90 in DataStore. |
+| **Partial Update Safety** | `MergeSecret()` method (line 214–217, Manager) keeps existing values if incoming value is null. Safe for PATCH-like operations. |
+| **Cross-Platform Extensibility** | New platform credential types can be added without EF migrations. Just add new keys to the dictionary. |
+| **Validation is Explicit** | `BuildSettings()` switch-case (lines 119–134, Manager) ensures only expected keys per platform. Clear audit trail. |
+| **Case-Insensitive Lookup** | `StringComparer.OrdinalIgnoreCase` prevents case-sensitivity bugs if platforms report fields differently. |
+
+### Tradeoffs
+
+| Tradeoff | Impact | Mitigation |
+|----------|--------|-----------|
+| **Runtime Type Safety** | Key names are strings; typos in `"BlueskyUserName"` won't be caught at compile time. | Named constants or consts used consistently in manager. Code review. |
+| **Schema Discovery** | No compile-time schema definition per provider. | Domain classes (`BlueskyPublisherSetting`) document required fields for each platform. |
+| **Serialization Overhead** | Converting flat dict → typed object → API DTO happens every read. | Negligible for scale of this app; EF caching mitigates DB hits. |
+
+---
+
+## 4. Does It Satisfy the Original Intent of the JSON-Blob Design?
+
+**Yes, with a refinement.**
+
+The issue said:
+> Settings is a JSON blob — each platform has different settings... JSON is more flexible for different platform requirements and avoids schema changes when adding new platforms.
+
+**What was actually built:**
+- ✅ JSON blob in the database (`Settings NVARCHAR(MAX)`)
+- ✅ Flexible: new platform types and new credential fields can be added without schema changes
+- ✅ Avoids platform-specific columns (e.g., no `BlueskyUserName`, `TwitterToken` columns)
+- **Refined:** Instead of nested provider objects in the JSON, a **flat key/value dictionary** is used, with strongly-typed domain classes as an in-memory bridge
+
+**Why this refinement is better:**
+- The issue author likely imagined storing provider configs as isolated JSON objects or nested fields
+- The flat key/value approach **was the better choice** because:
+  1. All platforms share the same secret-masking, partial-update, and extensibility needs
+  2. Flattening allows validators and managers to be simple and predictable
+  3. The API response layer (strongly typed DTOs) still gives clients a clean, platform-specific interface
+
+---
+
+## 5. Meaningful Downsides and Future Costs
+
+### Potential Issues
+
+| Issue | Severity | Likelihood | Mitigation |
+|-------|----------|-----------|-----------|
+| **Accidental Key Collisions** | Medium | Low | Keys are prefixed per platform (`BlueskyUserName`, `TwitterToken`). Code review. |
+| **Performance at Scale** | Low | Low | Dictionary lookup is O(1). JSON serialization is standard. No query filters on Settings, so no DB performance hits. |
+| **Migration to Structured Storage** | Medium | Low | If you needed relational structure later (e.g., separate columns per platform), you'd need a migration script to denormalize the flat dict. Doable. |
+| **IDE Autocomplete Loss** | Low | Low | Use domain classes (`BlueskyPublisherSetting`) as the public API; developers rarely work directly with the flat dict. |
+
+### Future-Proofing
+
+The current design **supports evolution** toward more structure if needed:
+1. **Today:** Flat key/value dictionary with strongly-typed in-memory bridge classes
+2. **Future (if needed):** Add individual columns for high-frequency fields without breaking the API or existing data
+   - E.g., add `BlueskyHandle` column, migrate data, deprecate the dictionary key
+   - Gradual migration path
+
+---
+
+## 6. Why This Implementation Should Be Preserved
+
+### The Choice Is Architecturally Sound
+
+1. **Layering is clean:**
+   - Persistence: flat, flexible JSON dictionary
+   - Business logic: switch-case validators, partial-update merges
+   - API: strongly typed, masked responses
+   - Each layer has a clear responsibility
+
+2. **Security is built in:**
+   - Secrets are write-only by design
+   - No accidental exposure of raw values in API responses
+   - Masking happens at the manager/data-store boundary, not scattered in controllers
+
+3. **Extensibility is baked in:**
+   - Adding a new platform = add new keys, new domain class, new API response class, new manager switch-case
+   - No database schema migration
+   - No EF core model changes beyond the dictionary
+
+4. **Testability is high:**
+   - Flat dictionaries are easy to mock
+   - No complex object hierarchies to serialize/deserialize
+   - Tests can verify key presence, value merges, and masking in isolation
+
+---
+
+## Conclusion
+
+The implementation **satisfies the original intent** of issue #731 (JSON blob, platform flexibility, per-user config) while **making a smarter choice** about how to structure that JSON: flat key/value instead of nested provider objects.
+
+This tradeoff delivers critical benefits:
+- **Write-only secrets** are easier to enforce
+- **Partial updates** are safer
+- **Platform extensibility** doesn't require recompilation
+- **API contracts** are stable and strongly typed
+
+The flat key/value design is not a step backward from the "JSON blob" idea—it's a **disciplined implementation** of that idea, optimized for the real-world constraints of multi-user, multi-platform credential management.
+
+**Recommendation:** Keep the current approach. It is both more maintainable and more secure than direct object serialization.

--- a/.squad/agents/neo/history-archive.md
+++ b/.squad/agents/neo/history-archive.md
@@ -638,3 +638,526 @@ For breaking database migrations involving PK rebuilds or column drops:
 4. **Exception Logging** — All data stores inject ILogger and log before returning null
 
 **Next:** Joseph merges PR #683. Epic #667 Sprints 3-6 unblocked for Switch/Sparks (API/Web UI integration). Tank: Unit tests for SocialMediaPlatforms layer.
+## Core Context
+
+**Role:** Lead Reviewer & Architect | Architecture, code reviews, issue triage, sprint planning, CI/CD
+
+**Established patterns:**
+- DTO/API: request DTOs exclude route params, return Task<ActionResult<T>>, null guard before ToResponse
+- Pagination: guard divide-by-zero, clamp page>=1, pageSize 1-100; Testing: sealed types use typed null
+- EF Core value type defaults: Never .HasDefaultValueSql() on non-nullable value types
+- Log sanitization: Strip \r\n from user input before logging (CodeQL injection prevention)
+- JWT Bearer CSRF: [IgnoreAntiforgeryToken] at class level (NOT for cookie auth controllers)
+- DB filtering: All lookups via data store methods, never in-memory at manager layer
+- Breaking DB migrations (PK rebuilds): Code deploys first -> maintenance window -> migration script
+- Functions DI: Remove .ValidateOnStart() from Functions projects (causes startup activation failures)
+- Email queue: AddMessageWithBase64EncodingAsync (Base64 required for Azure Functions queue triggers)
+- Ownership checks (tests): Must include OID claim on ControllerContext AND matching CreatedByEntraOid on mock entities
+- Moq CancellationToken: Use non-generic Returns(Delegate) form with explicit matchers, not Returns<T1, T2>(lambda)
+
+**Epic #667 Architecture Decisions:**
+- SocialMediaPlatforms: Id, Name, Url, Icon, IsActive (soft delete)
+- EngagementSocialMediaPlatforms: EngagementId+SocialMediaPlatformId+Handle (composite PK)
+- ScheduledItems.Platform -> SocialMediaPlatformId int FK; MessageTemplates.Platform -> SocialMediaPlatformId (was composite PK)
+- Seed: Twitter(1), BlueSky(2), LinkedIn(3), Facebook(4), Mastodon(5); Talks inherit from parent Engagement
+- Sprint 1 DB+EF (Morpheus issues #668-#673), Sprint 2 API+Manager (Trinity #674-#677), Sprint 3 Web+Tests (Switch/Sparks/Tank/Neo #678-#682)
+
+**IaC (Bicep):** Circular dependency: never Module A->B where B->A; listKeys() exposes secrets (use managed identity); StorageV2; ConnectionString over InstrumentationKey; Pin all API versions to GA (no -preview); allowBlobPublicAccess:false; event-grid.bicep is in modules/data/ not monitoring/
+
+**Completed:** RBAC Phase 1&2 (PR #610,#611), Email (#623), Bicep IaC (PR #645 - CHANGES REQUESTED), Technical Debt PR #649, Junction table PR #662, Epic #667 PR #683 APPROVED
+
+**Team standing rules:** Only Joseph merges PRs; All mapping via AutoMapper; Paging at data layer only
+
+## 2026-04-10: Issue #695 - Replace DateTime.UtcNow with DateTimeOffset.UtcNow in Web Controllers
+
+**Challenge:** Four Web controllers used `DateTime.UtcNow` instead of the team-standard `DateTimeOffset.UtcNow`, violating the codebase convention that all datetime operations must use `DateTimeOffset` to avoid timezone ambiguity.
+
+**Solution:**
+1. Replaced all 8 occurrences of `DateTime.UtcNow` across 4 Web controllers:
+   - EngagementsController.cs line 206: 2 occurrences (StartDateTime, EndDateTime initialization)
+   - SchedulesController.cs line 188: 1 occurrence (SendOnDateTime initialization)
+   - TalksController.cs line 172: 2 occurrences (StartDateTime, EndDateTime initialization)
+   - LinkedInController.cs lines 146, 155, 156: 3 occurrences (token expiration calculations)
+2. For LinkedInController, added `.DateTime` property access when passing to KeyVault API (which expects `DateTime` parameter)
+
+**Pattern:** When interfacing with legacy APIs that require `DateTime`, use `DateTimeOffset` for all calculations and convert at the boundary via `.DateTime` property.
+
+**Result:** All Web controllers now use `DateTimeOffset.UtcNow` consistently. Build succeeds with 0 errors. PR #702 created.
+## Learnings — Epic #667 PR Review and Deployment Runbook (2026-04-08)
+
+**Task:** Review Morpheus's PR on branch `issue-667-social-media-platforms` and write production deployment runbook.
+
+**Context:**  
+- Morpheus completed database layer work for Epic #667 (Social Media Platforms)  
+- Branch exists locally (commit 3fc341e) but PR not yet created  
+- Work introduces breaking changes to `MessageTemplate` interface affecting Api, Web, Functions  
+
+**Review Findings:**
+
+**✅ PASSES:**
+1. **Database schema** — All tables match architecture decisions exactly (SocialMediaPlatforms, EngagementSocialMediaPlatforms, ScheduledItems/MessageTemplates FKs)
+2. **SQL migration script** — Excellent quality, proper 7-part structure, correct PK rebuild sequence for MessageTemplates
+3. **EF Core entities** — Match SQL schema perfectly, proper nullable annotations
+4. **Domain models** — Correct nullability, Required attributes, proper navigation properties
+5. **Repository pattern** — ISocialMediaPlatformDataStore interface complete, soft delete implemented correctly
+6. **AutoMapper profiles** — Bidirectional mappings for both new entities
+7. **DI registration** — Registered in Api Program.cs
+8. **Base scripts updated** — table-create.sql and data-seed.sql reflect post-migration schema
+
+**❌ BLOCKERS:**
+1. **Build fails** — 14 compile errors across Data.Sql.Tests, Api, Web, Functions projects
+2. **No PR exists** — Branch not pushed to GitHub
+3. **Breaking change** — `IMessageTemplateDataStore.GetAsync` signature changed from `GetAsync(string platform, ...)` to `GetAsync(int socialMediaPlatformId, ...)`, breaking 4 Azure Functions
+
+**Root cause of build errors:** Expected breaking change — downstream projects (Api, Web, Functions) still reference old `MessageTemplate.Platform` string field instead of new `SocialMediaPlatformId` int field. Requires Trinity and Cypher follow-up PRs.
+
+**Recommendation:** CONDITIONAL APPROVAL pending:
+1. Morpheus pushes branch and creates PR
+2. Trinity updates Api layer (MessageTemplates endpoints, SocialMediaPlatforms CRUD)
+3. Cypher updates all 4 Functions `ProcessScheduledItemFired` handlers
+4. Switch updates Web layer (MessageTemplateService, Engagement controllers)
+5. Build passes on main before DB migration runs
+
+**Deployment Runbook:**  
+Created comprehensive production deployment runbook posted to issue #667 ([comment link](https://github.com/jguadagno/jjgnet-broadcast/issues/667#issuecomment-4210318810)).
+
+**Key runbook decisions:**
+- **Downtime required:** 5-10 minute maintenance window during MessageTemplates PK rebuild (table lock)
+- **Service stop requirement:** All services (Functions, Api, Web) must stop during PART 5 of migration
+- **Deployment order:** Code MUST deploy first (all PRs merged), then DB migration during maintenance window
+- **Safe vs. breaking:** Parts 1-3 (new tables + seed) are additive and safe; Parts 4-7 (column drops + PK rebuild) are breaking
+- **Rollback plan:** Database restore from backup + redeploy previous code version
+- **Risk mitigation:** Pre-flight checklist enforces "all code deployed first" rule
+
+**Pattern established:**  
+For breaking database migrations involving PK rebuilds or column drops:
+1. **Code deploys first** — All layers (Data, Api, Web, Functions) must be updated and deployed
+2. **Maintenance window required** — PK rebuild operations require brief downtime with services stopped
+3. **Incremental migration option** — Additive changes (new tables, seed data) can run separately before code deployment
+4. **Runbook mandatory** — Complex migrations require step-by-step runbook with rollback plan
+
+**Files reviewed:**
+- Migration script: `scripts/database/migrations/2026-04-08-social-media-platforms.sql` (279 lines)
+- 24 C# files (753 insertions, 61 deletions)
+- Base scripts: table-create.sql, data-seed.sql
+
+**Outcome:**  
+- ✅ Deployment runbook posted to #667  
+- ✅ Review findings documented (neo-review-667.md)  
+- ⏳ Awaiting Morpheus to push branch and create PR  
+- ⏳ Awaiting Trinity/Cypher/Switch follow-up PRs to fix build errors  
+
+**Next steps:**
+1. Morpheus creates PR
+2. Trinity/Cypher/Switch create follow-up PRs
+3. Neo reviews final PR when build passes
+4. Joseph executes deployment runbook during maintenance window
+
+
+## Learnings — PR #683 Code Review (2026-04-11)
+
+**Context:** Formal code review of Epic #667 PR #683 (SocialMediaPlatforms table and database layer). Comprehensive multi-sprint PR spanning Morpheus (Sprint 1 DB), Trinity (Sprint 2 API/Managers), and Tank (test fixes).
+
+**Review scope:** 57 files, +2921/-244 lines. Migration script, domain models, data stores, manager, API controller, DTOs, AutoMapper profiles, DI registrations, scopes, Functions updates, test fixes.
+
+**Key findings:**
+1. ✅ **Architecture patterns respected:** Manager layer used correctly (Web/Functions never call data stores directly), soft delete via IsActive, DateTimeOffset consistency, DI registrations complete
+2. ✅ **Migration script safety:** Adds nullable columns → populates → makes NOT NULL. MessageTemplates composite PK change handled without data loss. Idempotent and safe.
+3. ✅ **Breaking change handling:** IMessageTemplateDataStore.GetAsync signature change (string→int) fixed in ALL callers (4 Functions, API, Web service)
+4. ⚠️ **Minor inefficiency:** SocialMediaPlatformManager.GetByNameAsync loads all platforms for in-memory filtering (acceptable for 5 platforms, but pattern doesn't scale)
+5. ⚠️ **Exception swallowing:** Data stores catch and return null/false without logging (suggested ILogger injection for troubleshooting)
+
+**Verdict:** ✅ APPROVED — No blockers, production-ready. Two suggestions for future optimization (non-blocking).
+
+**Pattern reinforced:**
+- Multi-agent PR reviews require checking ALL layer interactions: DB → Data.Sql → Domain → Managers → API/Functions/Web
+- Migration scripts must be verified for: idempotency, data loss risk, FK dependency order, nullable-first strategy
+- Breaking interface changes require grep-based verification of ALL callers across solution
+- Test compile errors from domain model changes are EXPECTED and must be fixed before merge (Tank's role)
+
+**Tools used:** gh pr diff, view, grep, git diff --stat. Full diff was 5147 lines; reviewed in sections (migration script, interfaces, implementations, controllers, tests).
+
+**Recommendation posted:** GitHub comment #4210546660 (cannot approve own PRs, posted as comment instead).
+
+## Learnings — PR #723 Code Review (2026-04-17)
+
+**Context:** Code review of PR #723 implementing issue #719 (role hierarchy restructure). Renames existing `Administrator` → `Site Administrator` (full app admin) and introduces new narrower `Administrator` role (personal content admin).
+
+**Review scope:** 14 files, +123/-29 lines. Domain constants, Program.cs policies, 3 controllers, 1 view, DB seed + migration script, 3 test files, 3 agent history files.
+
+**Initial review:** CHANGES REQUESTED — SocialMediaPlatforms/Index.cshtml had role checks not updated.
+
+**Follow-up (commit 2a6a15e):** Trinity fixed the view. Re-verified all 4 IsInRole locations:
+- Line 10: `Site Administrator || Administrator || Contributor` ✅
+- Line 68: `Site Administrator || Administrator || Contributor` ✅
+- Line 85: `Site Administrator` only (Delete button) ✅
+- Line 104: `Site Administrator || Administrator || Contributor` ✅
+
+**Final verification:**
+1. All view role checks align with controller authorization policies
+2. Add/Edit/ToggleActive = RequireContributor (Site Admin + Admin + Contributor) — views match
+3. Delete = RequireSiteAdministrator (Site Admin only) — view matches
+4. Other SocialMediaPlatforms views (Add.cshtml, Edit.cshtml, Delete.cshtml) have no inline role checks — correct because authorization is enforced at controller action level
+5. No other Razor views in the solution have orphaned role checks that need updating
+
+**Key findings (all verified):**
+1. **Domain constants** — `RoleNames.SiteAdministrator` added correctly
+2. **Authorization policies** — Cumulative chain correct
+3. **Controllers** — SiteAdminController, LinkedInController, SocialMediaPlatformsController all correct
+4. **Views** — _Layout.cshtml and SocialMediaPlatforms/Index.cshtml both correct
+5. **DB scripts** — Idempotent rename + seed pattern correct
+6. **Self-demotion guard** — Uses `RoleNames.SiteAdministrator`
+7. **Tests** — All policy assertions and fixtures updated
+
+**Final Verdict:** ✅ **APPROVED**
+
+### 2026-04-09: PR #683 Code Review Complete — Epic #667 Consolidation
+
+**Status:** ✅ CONSOLIDATED | Session log: .squad/log/2026-04-09T00-43-53Z-codeql-fixes.md
+
+**Work Summary:**
+- PR #683 (feat(#667): Add SocialMediaPlatforms table and database layer) — **APPROVED for merge**
+- Verified all architectural patterns, migration script safety, breaking change handling
+- Trinity executed CodeQL security hardening + performance suggestions from this review:
+  - Log sanitization (5 CodeQL alerts fixed)
+  - CSRF handling (1 CodeQL alert fixed)
+  - DB-level name lookup (performance)
+  - Exception logging (visibility)
+- 3 inbox decisions merged to decisions.md (consolidating all team work)
+- Appended team updates to Trinity, Neo, Tank history.md files
+
+**Review Verified:**
+- ✅ Build: 0 errors, 322 pre-existing warnings (safe)
+- ✅ Architecture: Manager pattern respected, soft delete via IsActive
+- ✅ Migration: Nullable-first, composite PK handled correctly, idempotent
+- ✅ Breaking changes: All callers updated (4 Functions, API, Web)
+- ✅ Test coverage: Tank fixed 40 compile errors
+- ✅ Code quality: XML docs, AutoMapper, scopes, EF Core config complete
+
+**Key Decisions Documented:**
+1. **Log Sanitization Pattern** — Sanitize all user input before logging (prevents injection)
+2. **JWT CSRF Handling** — `[IgnoreAntiforgeryToken]` for Bearer APIs (false positive suppression)
+3. **DB Filtering** — GetByNameAsync delegates to data layer (performance + scalability)
+4. **Exception Logging** — All data stores inject ILogger and log before returning null
+
+**Next:** Joseph merges PR #683. Epic #667 Sprints 3-6 unblocked for Switch/Sparks (API/Web UI integration). Tank: Unit tests for SocialMediaPlatforms layer.
+
+## 2026-04-10: Issue #690 - Remove Web → Data.Sql Direct Reference
+
+**Challenge:** Web project had illegal direct `<ProjectReference>` to Data.Sql, violating architectural rule that Web must NEVER call data stores directly.
+
+**Solution:**
+1. Removed Data.Sql reference from Web.csproj
+2. Added Data.Sql reference to Managers.csproj (so Web gets transitive access)
+3. Created ServiceCollectionExtensions.cs in Data.Sql with DI extension methods in Microsoft.Extensions.DependencyInjection namespace:
+   - AddSqlDataStores() - registers all data store implementations
+   - AddDataSqlMappingProfiles() - adds AutoMapper profiles
+4. Updated Web/Program.cs to use extension methods, no direct Data.Sql types
+5. Used fully-qualified type name for BroadcastingContext to avoid using statement
+
+**Architecture:** Web → Managers → Data.Sql (transitive dependency only)
+
+**Result:** Web code never directly references Data.Sql types. Architectural boundary enforced. Build succeeds. PR #700 created.
+
+**Learnings:**
+- Extension method namespace matters! Placing in Microsoft.Extensions.DependencyInjection makes them discoverable without needing project using statement.
+- Transitive dependencies allow compile-time access to types without direct ProjectReference.
+- Architectural rules are about preventing coupling in application code, not startup/DI configuration.
+
+## Learnings — Issue #713 Code Review (2026-04-16)
+
+**Task:** Review Trinity's exception audit work on branch `issue-713-audit-exceptions`.
+
+**Files correctly modified by Trinity (6):**
+- EngagementSocialMediaPlatformDataStore.cs — fixed 1 catch block
+- FeedCheckDataStore.cs — added ILogger + 2 LogError calls
+- ScheduledItemDataStore.cs — added ILogger + 2 LogError calls
+- SyndicationFeedSourceDataStore.cs — added ILogger + 2 LogError calls
+- TokenRefreshDataStore.cs — added ILogger + 2 LogError calls
+- YouTubeSourceDataStore.cs — added ILogger + 2 LogError calls
+
+**Files MISSED by Trinity (2) — BLOCKING:**
+- EngagementDataStore.cs — 5 catch blocks without logging, no ILogger
+- EngagementManager.cs — 2 catch blocks without logging, no ILogger
+
+**Files already correct (not Trinity's work):**
+- SocialMediaPlatformDataStore.cs — already had ILogger + logging
+- EmailSender.cs — uses source-generated logging
+- UserApprovalManager.cs — already had ILogger with LogWarning
+- BroadcastingContext.cs — catch rethrows, not swallowing
+
+**Build status:** 25 errors — test files not updated to pass ILogger mocks.
+
+**Review pattern established:**
+- For exception audit: grep `catch\s*\(.*Exception` and verify EVERY catch has logging
+- When adding ILogger to primary constructors, MUST update test instantiations
+- Run `dotnet build` before marking any code work complete
+- Cross-check claimed scope against actual diff
+
+**Verdict:** REJECTED — Assigned to Morpheus to fix (Trinity lockout per rejection rules).
+
+## Learnings — PR #736 Code Review (2026-04-17)
+
+**Context:** Review of PR #736 (feat(#728): Thread owner OID through manager business logic) — Sprint 17 of Epic #609 per-user data isolation.
+
+**Scope:** 25 files, +448/-66 lines. Manager interfaces + implementations, reader interfaces + implementations, Functions Settings, collector Functions, and tests.
+
+**Key review points verified:**
+1. **Reader overload pattern:** New `ownerOid` overloads call parameterless version, then apply `ApplyOwnerOid()` helper that sets `CreatedByEntraOid = ownerOid`
+2. **Manager pass-through:** All manager `ownerEntraOid` overloads are single-line delegations to data stores — no OID resolution logic
+3. **Functions Settings:** `ISettings.OwnerEntraOid` added as `required string` with XML docs — fails fast if config missing
+4. **Collector updates:** All 4 collectors (LoadAllPosts, LoadNewPosts, LoadAllVideos, LoadNewVideos) pass `settingsOptions.Value.OwnerEntraOid`
+5. **Backward compatibility:** Parameterless methods preserved with `string.Empty` for admin/background processing contexts
+6. **Test updates:** All 4 collector test files updated mock setups to pass `OwnerEntraOid` constant
+
+**Pattern confirmed:**
+- For owner-aware overloads: call existing parameterless method, then post-process to apply ownership
+- This preserves existing behavior while adding new capability
+- `required string` on Settings properties catches missing config at startup, not runtime
+
+**Verdict:** ✅ APPROVED — Clean implementation, all acceptance criteria met, no invariant violations.
+
+## Learnings — PR #739 Follow-up Review (2026-04-18)
+
+**Context:** Re-review of PR #739 (feat(#729): enforce owner isolation in API controllers) after Tank added 11 security tests across 3 test files on branch `issue-729`. Previous rejection was for zero 403/ForbidResult and SiteAdmin bypass tests.
+
+**Test run:** 84/84 green. All new tests pass correctly.
+
+**What Tank got right:**
+- `SchedulesController`: All 4 guarded actions covered (GetScheduledItem, UpdateScheduledItem, DeleteScheduledItem non-owner + GetAll SiteAdmin) ✅
+- `MessageTemplatesController`: All 3 guarded actions covered (Get, Update non-owner + GetAll SiteAdmin) ✅ (new test file)
+- `EngagementsController` top-level CRUD: All 4 covered (GetEngagement, UpdateEngagement, DeleteEngagement non-owner + GetEngagements SiteAdmin) ✅
+- Correct pattern: entity OID ≠ user OID → `ForbidResult`, side-effectful calls verified `Times.Never` ✅
+- No magic strings — `Domain.Constants.ApplicationClaimTypes.EntraObjectId`, `RoleNames.SiteAdministrator`, `Domain.Scopes.*` constants used ✅
+- Moq `It.IsAny<CancellationToken>()` pattern correct ✅
+
+**What Tank missed — BLOCKERS:**
+`EngagementsController` has 9 more ownership-guarded actions with zero non-owner 403 tests:
+- **Talks sub-actions (5):** `GetTalksForEngagementAsync`, `CreateTalkAsync`, `UpdateTalkAsync`, `GetTalkAsync`, `DeleteTalkAsync`
+- **Platforms sub-actions (4):** `GetPlatformsForEngagementAsync`, `GetPlatformForEngagementAsync`, `AddPlatformToEngagementAsync`, `RemovePlatformFromEngagementAsync`
+All 9 have the identical `if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid()) return Forbid();` pattern, but no non-owner test exercises it.
+
+**Verdict:** ❌ REJECTED — Talks and Platforms sub-resource ownership paths uncovered. PR comment #739 posted with specific tests required.
+
+**Pattern reinforced:** When reviewing ownership-guarded controllers, grep for ALL `Forbid()` call sites, not just the primary CRUD actions. Sub-resource actions on the same entity share the same ownership gate and need the same test coverage.
+
+## 2026-04-18: Sprint 18 Retrospective Debrief (Completed)
+
+**Status:** ✅ COMPLETE  
+**Session:** Retro follow-up with Joseph Guadagno
+
+### Work Summary
+
+Conducted Sprint 18 retrospective debrief with Joseph. All 18 retro items reviewed and categorized:
+- 12 failures traced to **inadequate pre-submission validation** (PRs #738, #739 required multiple review rounds)
+- 5 directive violations — "run tests before committing" was written but had no enforcement mechanism
+- 6 HIGH severity items all related to missing security test coverage on a security feature
+
+### Action Items Filed (Sprint 19)
+
+All 6 action items filed as issues #743–#748 with `sprint:19` label:
+
+**P1 (Training/Enforcement):**
+- **#743:** Security test checklist skill (Tank) — Establish mandatory Forbid() coverage pattern
+- **#744:** Test-pass gate before push (Neo) — Decide: training vs. enforcement? Branch protection? PR template? Pre-push hook?
+- **#747:** Tank history checklist update (Tank) — Document ownership test checklist ownership
+
+**P2 (Enhancement):**
+- **#745:** Non-owner context helper (Trinity) — Add helper to API test base classes
+- **#746:** PR comment formatting (Neo) — Improve clarity of code review feedback
+- **#748:** Mock overload docs (Tank) — Document `.Setup()` pattern for controllers with ownerOid param
+
+### Open Question for Joseph
+
+**Should the "run tests before committing" gap be addressed as:**
+1. **Training** — better checklists/tools for Tank (prioritize #743, #747 first), or
+2. **Enforcement** — CI gate that blocks PRs with failures (prioritize #744 first)?
+
+Joseph's answer determines P1 priority order.
+
+### Decisions Documented
+
+Tank's security checklist skill (@.squad/skills/security-test-checklist/SKILL.md) now captures the ownership enforcement pattern:
+- Grep Forbid() sites first
+- Build coverage matrix
+- Write one test per Forbid() path
+- Include matrix in PR description
+- Run `dotnet test` with 0 failures before PR creation
+
+**Permanent team rules established:**
+1. ALWAYS run `dotnet test` before committing
+2. ZERO test failures before opening PR
+3. For any security/ownership feature: grep `Forbid()` first, build matrix, write test per site
+4. When controller signatures add `ownerOid` parameter: update mock `.Setup()` overload immediately
+
+### Outcome
+
+Sprint 18 fully retrospected. Sprint 19 ready to address identified gaps. Awaiting Joseph's decision on enforcement approach for #744 to finalize P1 prioritization.
+
+## 2026-04-18: Issue #744 Advisor Role (Background)
+
+**Status:** ✅ COMPLETE (Background Agent)  
+**Role:** Architecture advisor
+
+### Work Summary
+
+Advised Joseph on three options for implementing test-pass gate on PR #744:
+
+1. **Branch Protection Rule** (GitHub UI)
+   - Prevents merge until PR checks pass (including tests)
+   - Built-in, no code needed
+   - Requires GitHub repository admin access
+   - Applies to all PRs uniformly
+
+2. **PR Template** (Markdown file)
+   - Prompts submitter to confirm tests were run
+   - Non-blocking (user can ignore prompt)
+   - Good for training/awareness
+   - Works with existing CI/CD
+
+3. **Pre-push Hook** (Git local setup)
+   - Developer machine runs tests before push
+   - Fastest feedback (before network round-trip)
+   - Requires developer buy-in and proper setup
+   - Can be bypassed with `git push --no-verify`
+
+### Background Findings
+
+Neo researched each option:
+- Branch Protection: GitHub-native, strongest enforcement, requires admin
+- PR Template: Low friction, good for onboarding, reminder-based
+- Pre-push Hook: Fastest local feedback, but human-dependent
+
+Joseph to decide which option(s) align with team workflow.
+
+### Decision Impact
+
+The chosen enforcement mechanism will shape Sprint 19 priority order:
+- **Training-first approach:** #743 (checklist skill), #747 (Tank history) first, then consider #744
+- **Enforcement-first approach:** Implement #744 first, then training artifacts as reinforcement
+
+---
+
+## Learnings — PR #756 Recovery Push (2026-04-19)
+
+- Recovered the issue #731 fixes onto `issue-731-user-publisher-settings` safely via a dedicated worktree rooted at `.worktrees\issue-731-recovery`, leaving the original dirty branch untouched.
+- The decisive integration fixes live in:
+  - `src\JosephGuadagno.Broadcasting.Web\Services\UserPublisherSettingService.cs` — align Web `IDownstreamApi` calls to `/UserPublisherSettings`, map typed request/response DTOs, preserve masked write-only secrets.
+  - `src\JosephGuadagno.Broadcasting.Api\Controllers\UserPublisherSettingsController.cs` and `src\JosephGuadagno.Broadcasting.Data.Sql\UserPublisherSettingDataStore.cs` — sanitize owner OIDs before warning/error logs.
+  - `src\JosephGuadagno.Broadcasting.Web.Tests\Services\UserPublisherSettingServiceTests.cs`, `src\JosephGuadagno.Broadcasting.Api.Tests\Controllers\UserPublisherSettingsControllerTests.cs`, and `src\JosephGuadagno.Broadcasting.Data.Sql.Tests\UserPublisherSettingDataStoreTests.cs` — lock the contract with route, payload-shape, write-only masking, and log-sanitization coverage.
+- For a PR authored by the same GitHub user account, Neo should leave a regular PR comment summarizing readiness instead of attempting a formal approval review.
+
+---
+
+## 2026-04-19 — Retro: Directive Drift and Token Waste
+
+**Status:** ✅ COMPLETE  
+**Scope:** Three-sprint retrospective with focus on Sprint 20 PR recovery (#756/#757)
+
+### What Went Wrong
+
+- Team-critical directives were documented, but not enforced at spawn
+  time or push time.
+- Review-state language drifted between "approved", "review comment",
+  and "regular PR comment", creating confusion about whether the result
+  was local-only or actually visible on GitHub.
+- Branch-of-record drifted during Sprint 20 recovery: handoff text
+  referenced `feat/731-user-publisher-settings`, while the actual PR
+  branch of record was `issue-731-user-publisher-settings`.
+- Expensive work started before cheap validation, so the team paid for
+  re-reviews, repeat reads, and recovery orchestration.
+
+### Root Causes
+
+1. **No execution-time gate on directives** — rules in `decisions.md`,
+   skills, and history were treated as reference material instead of
+   hard preflight checks.
+2. **No single operational source of truth per PR** — branch, review
+   artifact type, blocker state, and next owner were spread across
+   logs, decisions, and agent memory.
+3. **Coordinator routing lacked a preflight contract** — agents were
+   spawned without first fixing ambiguity around branch,
+   GitHub-visible output, and readiness conditions.
+4. **Terminology was loose** — "review", "comment", "approval", and
+   "ready to merge" were used interchangeably even when they implied
+   different external effects.
+
+### Recommended Changes
+
+1. **Hard rule:** Coordinator must set a preflight contract before
+   every agent turn: branch of record, desired GitHub artifact,
+   expected validation, and handoff owner.
+2. **Hard rule:** Convert process-critical directives into verified
+   gates. If the gate cannot be proven, the work does not start.
+3. **Hard rule:** Maintain one PR state record with branch, artifact
+   mode (`review` vs `comment`), blocker status, and latest owner;
+   update it on every handoff.
+4. **Hard rule:** Run cheap checks before expensive actions: local
+   branch/readiness checks first, GitHub/API reads second, agent spawns
+   last.
+5. **Soft habit:** End each orchestration turn with an explicit "state
+   changed" note so the next turn does not infer status from narrative
+   text.
+
+### Coordinator Direction
+
+- Stop assuming agents will reconcile conflicting instructions on their
+  own.
+- Reject ambiguous requests before spawn and restate them as an
+  execution contract.
+- Treat repeated directive violations as process failures, not agent
+  personality problems.
+
+## Learnings — Issue #609 First-Round Review (2026-04-19)
+
+- Reviewed epic #609 against its decomposition comment (#725-#732), merged
+  commits on `main`, current repository code, and the squad audit notes from
+  Trinity and Tank.
+- Confirmed the repo has shipped the schema, owner-filtered query paths,
+  API/Web ownership checks, per-user publisher-settings CRUD, and broad
+  automated coverage for the first-round multi-tenancy work.
+- Identified a blocking mismatch between the intended collector ownership flow
+  and the shipped implementation: Functions still pass a single
+  `Settings.OwnerEntraOid` value into collectors, and that setting is marked as
+  temporary scaffold rather than per-collector ownership.
+- Identified a second blocking mismatch in the readers: non-owner overloads in
+  `SyndicationFeedReader` and `YouTubeReader` still materialize records with
+  `CreatedByEntraOid = string.Empty`, which conflicts with the explicit
+  first-round directive that persisted ownership must never be empty/null.
+- Conclusion for Neo review: long-term epic scope is still intentionally
+  deferred in several areas, but even the narrowed first-round slice should be
+  treated as **not complete** until collector ownership is sourced from the
+  collector record and the remaining empty-owner scaffolding is removed.
+
+## Learnings — Issue #609 Gap Issue Triage (2026-04-19)
+
+- Converted the remaining first-round #609 review gaps into three concrete issue
+  proposals: two implementation follow-ups and one regression-test follow-up.
+- No open duplicate issue exists for the collector-owner threading gap or the
+  empty-owner reader scaffolding gap; the closest related item is closed issue
+  #728, whose acceptance criteria already described the intended end state.
+- Routing decision for the follow-up work: implementation belongs with Trinity
+  under the canonical `.squad/routing.md` rule for Azure Functions/business
+  logic, while the regression coverage belongs with Tank.
+
+
+
+## Sprint 20 Conclusion — Final Review & Merge (2026-04-19T15:40:15Z)
+
+**Decision Sources:** Inbox files processed by Scribe  
+
+**Context Closure:**
+- ✅ PR #756 merged to main (recovered issue #731: per-user publisher settings)
+- ✅ PR #757 merged to main (issue #732: owner isolation test coverage)
+- ✅ Decision inbox entries: link-main-pr-merge, neo-609-first-round-review, neo-609-gap-issues, neo-retro-directives merged to decisions.md
+- ✅ All Sprint 20 work captured in .squad/orchestration-log/ and .squad/log/
+
+**Impact on Future Sessions:**
+- Retro analysis in decisions.md (link-retro-guardrails) identifies 3 review cycles due to incomplete submissions — recommend pre-execution checklist gate for Tank in next sprint
+- Epic #609 first-round audit complete; data-layer test coverage gaps identified (Trinity recommendation: add 3–4 test cases per data store)
+
+## Learnings — Issue #609 GitHub Gap Issues Created (2026-04-19)
+
+- Confirmed the Round 1 #609 follow-up gaps had not been created as real GitHub issues yet; only the triage decision existed in squad notes.
+- Created the three narrow GitHub issues needed to track closeout work: #760 (collector owner OID sourced from collector records), #761 (remove empty-owner reader scaffolding), and #762 (regression coverage for owner threading and persisted owner OIDs).
+- Applied squad ownership labels per the earlier routing decision: Trinity owns the two implementation issues and Tank owns the regression-test issue.

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -1,3 +1,208 @@
+## Core Context
+
+**Key established patterns:**
+- DTO/API: request DTOs exclude route params, return Task<ActionResult<T>>, null guard before ToResponse
+- Pagination: guard divide-by-zero, clamp page>=1, pageSize 1-100; Testing: sealed types use typed null
+- EF Core value type defaults: Never .HasDefaultValueSql() on non-nullable value types
+- Log sanitization: Strip \r\n from user input before logging (CodeQL injection prevention)
+- JWT Bearer CSRF: [IgnoreAntiforgeryToken] at class level (NOT for cookie auth controllers)
+- DB filtering: All lookups via data store methods, never in-memory at manager layer
+- Breaking DB migrations (PK rebuilds): Code deploys first → maintenance window → migration script
+- Functions DI: Remove .ValidateOnStart() from Functions projects (causes startup activation failures)
+- Email queue: AddMessageWithBase64EncodingAsync (Base64 required for Azure Functions queue triggers)
+- Ownership checks (tests): Must include OID claim on ControllerContext AND matching CreatedByEntraOid on mock entities
+- Moq CancellationToken: Use non-generic Returns(Delegate) form with explicit matchers, not Returns<T1, T2>(lambda)
+
+**Epic #667 Architecture:**
+- SocialMediaPlatforms: Id, Name, Url, Icon, IsActive (soft delete)
+- EngagementSocialMediaPlatforms: EngagementId+SocialMediaPlatformId+Handle (composite PK)
+- ScheduledItems.Platform → SocialMediaPlatformId int FK; MessageTemplates.Platform → SocialMediaPlatformId
+- Seed: Twitter(1), BlueSky(2), LinkedIn(3), Facebook(4), Mastodon(5)
+
+**Completed initiatives:**
+- Sprint 8: DTO merge PR #512, pagination guards PR #514
+- Sprint 9 PR #517: SQL Server 50MB cap removal, SaveChangesAsync error handling
+- Sprint 10 PR #529: Social columns (BlueSkyHandle, ConferenceHashtag, ConferenceTwitterHandle)
+- RBAC #602: Roles, ApplicationUsers, UserRoles, UserApprovalLog; RBAC #607: CreatedByEntraOid columns
+- PR #662 (#323): SourceTags junction discriminator + unique index UX_SourceTags_SourceId_SourceType_Tag
+- PR #739 (2026-04-18): API ownership enforcement with 20 security test coverage
+- PR #731/#732 (2026-04-19): Per-user publisher settings + owner isolation tests (Sprint 20 complete)
+
+**Auth architecture:** Web layer uses battle-tested `EntraClaimsTransformation` (SQL-backed, app-managed roles); API will migrate from 42 custom Entra scopes to role-based policies matching Web pattern. Scope-to-role migration phases (#763–#769) scheduled across future sprints to prevent blocking.
+
+**Sprint 21 scope:** Collector owner OID completeness (Trinity #760/#761, Tank regression #762). Blocker: `scripts\database\data-seed.sql` requires CreatedByEntraOid bootstrap values; PR #771 stacked on #770; PR #772 has unrelated Web config drift.
+
+---
+
+## 2026-04-20 — Branch/PR Policy Remediation
+
+**Status:** ✅ COMPLETE (Remediation)
+
+### Issue
+
+Sprint 21 work was done directly on `main` instead of feature branches — third violation of `.squad/routing.md` directive.
+
+### Actions
+
+1. Stashed all uncommitted changes safely
+2. Created stacked branches from origin/main:
+   - `issue-761` → PR #770 (base: main)
+   - `issue-760` → PR #771 (base: issue-761)
+   - `issue-762` → PR #772 (base: issue-760)
+3. Split changes by issue ownership:
+   - #761: Reader empty-owner cleanup (10 files)
+   - #760: Collector owner OID resolution (13 files)
+   - #762: Regression test coverage (6 files)
+4. Pushed all branches and created PRs with proper stacking
+
+### Learnings
+
+- **Stash-and-split pattern**: Safe way to remediate policy violations without data loss
+- **Stacked PRs**: Use when issues have dependencies; merge in order, retarget after each merge
+- **Prevention**: Agents must read decisions.md before starting work — directive was already recorded twice
+
+---
+
+## 2026-04-20 — Sprint 21 Kickoff & Milestone Planning
+
+**Status:** ✅ COMPLETE (Sprint Planning)
+
+### Sprint 21 — Collector Owner OID Completeness
+
+Assigned 3 issues to Sprint 21 (focused on Round 1 #609 gaps):
+- #760: Source collector owner OID from collector records (squad:trinity)
+- #761: Remove empty-owner reader scaffolding (squad:trinity) — moved from Sprint 20
+- #762: Add regression coverage for collector owner threading (squad:tank)
+
+### Scope-to-Role Migration Scheduling
+
+Created 3 new milestones and assigned 7 issues across future sprints:
+
+| Sprint | Phase | Issues |
+|---|---|---|
+| Sprint 22 | Phase 0 | #763, #764 |
+| Sprint 23 | Phases 1-2 | #765, #766 |
+| Sprint 24 | Phases 3-4 | #767, #768, #769 |
+
+### Learnings
+- Milestones are the source of truth for sprint planning (not labels)
+- Scope migration phases respect dependency chain: Phase N unblocks Phase N+1
+- Sprint 21 stays focused on collector owner work — one coherent deliverable
+
+---
+
+## 2026-04-20 — Scope-to-Role Migration: GitHub Issues Created
+
+**Status:** ✅ COMPLETE (Issue Triage & Creation)
+
+### Issues Created (7 total, dependency-ordered)
+
+| # | Phase | Title | Labels | Squad |
+|---|---|---|---|---|
+| #763 | 0 | Extract EntraClaimsTransformation to shared project | scope-removed-phase-0 | neo, trinity |
+| #764 | 0 | Add role-based authorization policies to API Program.cs | scope-removed-phase-0 | trinity |
+| #765 | 1 | Replace 37 scope checks with role-based policies in API controllers | scope-removed-phase-1 | trinity |
+| #766 | 2 | Migrate 90+ API test scope references to role-based claims | scope-removed-phase-2 | tank |
+| #767 | 3 | Remove scope constants from Domain and simplify API + Web config | scope-removed-phase-3 | trinity, switch |
+| #768 | 4 | Remove 42 custom delegated scopes from Azure Entra app registration | scope-removed-phase-4 | Joe |
+| #769 | 4 | Azure Portal cleanup: remove stale scope-related configuration | scope-removed-phase-4 | Joe |
+
+### Labels Created
+- `scope-removed-phase-0` through `scope-removed-phase-4`
+
+### Learnings
+- Phase labels (`scope-removed-phase-N`) provide clear sequencing for multi-phase migrations
+- Portal/ops work (#768, #769) labeled `squad:Joe` since it requires Azure Portal access
+- Phase 3 kept as single issue despite touching Domain/API/Web — changes are atomic (removing Scopes.cs breaks dependents simultaneously)
+- Dependency chain: #763 → #764 → #765 → #766 → #767 → #768 → #769
+
+---
+
+## 2026-04-20 — Scope-to-Role Migration Plan
+
+**Status:** ✅ COMPLETE (Read-Only Planning)  
+**Artifact:** `.squad/decisions/inbox/neo-scope-to-role-migration.md`
+
+### Findings
+
+- **37 `VerifyUserHasAnyAcceptedScope` call sites** across 5 API controllers (Engagements: 18, Schedules: 10, SocialMediaPlatforms: 5, UserPublisherSettings: 4, MessageTemplates: 3)
+- **90+ test references** to `Domain.Scopes.*` in API test files
+- **36 scopes** configured in Web `appsettings.Development.json` under `DownstreamApis:JosephGuadagnoBroadcastingApi:Scopes`
+- Web layer already has battle-tested role model: `EntraClaimsTransformation` + 4 authorization policies
+- `GetOwnerOid()` / `IsSiteAdministrator()` are scope-independent — unaffected by migration
+- `XmlDocumentTransformer` and Scalar config both enumerate all 42 scopes for OpenAPI docs
+
+### Architecture Decision
+
+5-phase migration: (0) Add role infra to API, (1) Replace scope checks with role checks, (2) Update tests, (3) Remove scope constants/config, (4) Clean Entra app registration. Key decision point: extract `EntraClaimsTransformation` to shared project since it only depends on `IUserApprovalManager`.
+
+### Key Files (Migration Surface)
+
+- `src\JosephGuadagno.Broadcasting.Domain\Scopes.cs` — 42 scope constants to remove (keep MicrosoftGraph)
+- `src\JosephGuadagno.Broadcasting.Api\Program.cs` — Needs `IClaimsTransformation` + `AddAuthorization`
+- `src\JosephGuadagno.Broadcasting.Api\Controllers\*.cs` — 37 scope check call sites
+- `src\JosephGuadagno.Broadcasting.Api\XmlDocumentTransformer.cs` — Scope enumeration in OpenAPI
+- `src\JosephGuadagno.Broadcasting.Api.Tests\Helpers\ApiControllerTestHelpers.cs` — Scope claim setup
+- `src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json` — 36 API scope entries
+- `src\JosephGuadagno.Broadcasting.Web\EntraClaimsTransformation.cs` — Model to replicate/share
+
+---
+
+## 2026-04-20 — Auth Architecture Review: Entra Scope Limits with Personal Accounts
+
+**Status:** ✅ COMPLETE (Read-Only Analysis)  
+**Artifact:** `.squad/decisions.md` (merged from inbox)
+
+### Findings
+
+- App defines **42 custom delegated scopes** in `Scopes.cs`; Web requests **37** at consent time
+- Microsoft Entra has practical scope limits for personal (MSA) accounts — this is the blocker
+- Web layer **already uses app-managed roles** (SQL-backed, via `EntraClaimsTransformation`) — the role model is battle-tested
+- API layer enforces authorization via `VerifyUserHasAnyAcceptedScope(...)` — this is the only place scopes are consumed for authZ
+- Ownership enforcement (`GetOwnerOid()`, `IsSiteAdministrator()`) is scope-independent and stays intact
+
+### Recommendation
+
+**Option B: Keep Entra for authentication (token issuance + validation), move authorization to app-managed roles in the API.** Replace scope-based checks with role-based policies matching the Web layer pattern. Collapse Entra scopes to 1-2 (audience + `User.Read`).
+
+### Key Files
+
+- `src\JosephGuadagno.Broadcasting.Domain\Scopes.cs` — 42 scope constants (to be reduced)
+- `src\JosephGuadagno.Broadcasting.Web\EntraClaimsTransformation.cs` — Role injection from SQL (model to replicate in API)
+- `src\JosephGuadagno.Broadcasting.Web\Program.cs` lines 103-111 — Scope union + downstream API registration
+- `src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json` — 36 API scopes configured
+- `src\JosephGuadagno.Broadcasting.Api\Controllers\*.cs` — All `VerifyUserHasAnyAcceptedScope` call sites (to be replaced)
+- `src\JosephGuadagno.Broadcasting.Domain\Constants\RoleNames.cs` — Existing role hierarchy
+
+---
+
+## 2026-04-19 — Architectural Analysis: #731 Settings Design (Read-Only)
+
+**Status:** ✅ COMPLETE  
+**Issue:** #731 (Per-user publisher settings)  
+**Artifact:** `.squad/agents/neo/analysis-731-settings-design.md`
+
+### Findings
+
+**Question:** Why flat key/value dictionary instead of serializing provider-specific objects?
+
+**Answer:** Flat key/value with strongly-typed in-memory bridge is the **correct choice**:
+
+1. **Write-only secret masking** is trivial with flat dict; nested objects require post-processing
+2. **Partial updates** are safe: `MergeSecret()` keeps existing values if incoming is null
+3. **Platform extensibility** requires no EF migrations or recompilation
+4. **API contract stability** is achieved via typed DTOs; secrets never exposed in raw form
+
+The implementation **satisfies the original JSON-blob intent** while making smarter architectural choices around secret handling, update safety, and extensibility. The flat structure is both more maintainable and more secure than direct object serialization.
+
+### Learnings
+
+- **Pattern:** Persistence layer stores flat data (flexible, extensible); business logic validates and builds typed objects; API layer masks secrets in responses
+- **Future evolution:** If structured storage is later needed, migration path exists without breaking API or data
+- **Key design principle:** Layers have clear responsibility — security is built at manager/data-store boundary, not scattered
+
+---
+
 ## Sprint 20 Final — PR #756 & #757 Merge & Session Close (2026-04-19)
 
 **Status:** ✅ COMPLETE  
@@ -21,590 +226,35 @@ Three sprint wrap decisions merged into `.squad/decisions.md`:
 
 Session logs and orchestration log recorded.
 
-# Neo - History
-
-## PR #738 Review — Web MVC Ownership Enforcement (2026-04-18)
-
-**Context:** First review of PR #738 (feat(#730): enforce owner isolation in Web MVC controllers). This is the companion PR to #739 (API ownership) which was merged earlier today.
-
-**Branch state issue:** The `issue-730` branch was created from a local state that included API changes before PR #739 was merged. Now that #739 is on main, there are merge conflicts in the API test files.
-
-**Conflicts detected:**
-- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs`
-- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsController_PlatformsTests.cs`
-- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs`
-
-**Web MVC implementation review (the actual PR content):**
-
-✅ **Correct pattern applied:**
-- Uses `User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)` for current user
-- Uses `RoleNames.SiteAdministrator` constant for admin bypass (not `Administrator`)
-- Returns friendly redirect + `TempData["ErrorMessage"]` instead of raw `Forbid()`
-- Proper layering: controllers → services → managers (no direct data store access)
-
-✅ **Controllers covered:**
-- EngagementsController: Details, Edit (GET), Delete (GET), DeleteConfirmed, Add (sets OID)
-- SchedulesController: Details, Edit (GET), Delete (GET), DeleteConfirmed, Add (sets OID)
-- TalksController: Details, Edit (GET), Delete (GET), DeleteConfirmed, Add (sets OID)
-- MessageTemplatesController: Edit (GET)
-
-✅ **Tests updated:** Web tests correctly set up user claims with matching `CreatedByEntraOid`
-
-✅ **CI passing:** All 4 checks green (CodeQL, build-and-test, GitGuardian, CodeQL Analysis)
-
-**Verdict:** ❌ CHANGES REQUESTED — Rebase required to resolve API test conflicts. Once rebased, the Web MVC implementation is correct and ready to merge.
-
-**Action posted:** PR comment #738 with detailed review and rebase instructions.
-
----
-
-## 2026-04-18 — PR #739: Final Review (Round 3) — APPROVED & MERGED
-
-**Status:** ✅ COMPLETE  
-**PR:** #739 (feat(#729): enforce owner isolation in API controllers)  
-**Issue:** #729
-
-### Work Summary
-
-Conducted final (third) review of PR #739 after two previous rejection rounds. All 17 Forbid() call sites now have comprehensive non-owner ForbidResult tests. Total security test suite: 20 tests across three rounds (11 Round 1 + 9 Round 2 added by Tank).
-
-### Coverage Verified
-- All 17 `Forbid()` call sites across 3 controllers (EngagementsController, TalksController, PlatformsController) have non-owner ForbidResult tests
-- All 3 `IsSiteAdministrator()` branching locations verified
-- Entity OID (`owner-oid-12345`) ≠ user OID (`non-owner-oid-99999`) pattern applied consistently
-- No magic strings — all constants from Domain.Constants and Domain.Scopes
-- Moq patterns correct (`Times.Never` on side-effectful calls)
-
-### Test Results
-- **Total:** 93/93 passing
-- **Security tests:** 20 total
-- **Pattern:** EngagementsController (6), TalksController (4), PlatformsController (4), SiteAdmin overloads (6)
-
-### Decision
-✅ **APPROVED** — Ready for merge. All ownership-guarded paths covered.
-
-### Outcome
-Joseph merged PR #739 to main. Security test coverage complete.
-
-### Related
-- **Round 1:** Zero tests → rejected
-- **Round 2:** 9 missing Talks/Platforms tests → Tank added coverage → rejected (but closer)
-- **Round 3:** Final verification → approved and merged
-
----
-
-## 2026-04-18 — Session: Neo Setup Experience Spec & Tank Test Fixes
-
-**Status:** ✅ COMPLETE (Background Agent)  
-**Focus:** Architecture spec for multi-user setup experience (issue #609)
-
-### Work Summary
-
-Produced comprehensive architecture specification for new user setup experience — the wizard that runs after a user is approved and before they access the main application.
-
-**Deliverable:** `setup-experience-spec.md` (90 pages) + architectural decisions document
-
-### Key Deliverables
-
-1. **Feature Spec**
-   - Problem statement: approved users have no path to configure personal collectors/publishers
-   - 8-step user flow: approval → setup welcome → collectors → publishers → review → complete
-   - UI requirements (YouTube, SyndicationFeed collectors; Bluesky, Twitter, LinkedIn, Facebook publishers)
-   - Database schema (UserCollectorSettings JSON blob, HasCompletedSetup flag on ApplicationUsers)
-   - Middleware placement (after approval gate, before authorization)
-
-2. **7 Architectural Decisions**
-   - JSON blob storage (consistency with #731 UserPublisherSettings)
-   - Setup middleware placement (after approval, before auth)
-   - HasCompletedSetup boolean column on ApplicationUsers
-   - Data Protection API encryption (MVP), Key Vault (future)
-   - Soft redirect + skip option + persistent banner enforcement
-   - Direct credentials (MVP), OAuth (future)
-   - Named type constants + SQL CHECK constraints
-
-3. **3 Open Questions (Team Feedback Incorporated)**
-   - Test connection buttons: Yes (recommendation)
-   - Partial config UX: validation error (recommendation)
-   - Re-enterable setup: Yes, via Settings page (recommendation)
-
-### Related Issues
-
-- Epic #609: Multi-tenancy — per-user content, publishers, and social tokens
-- Issue #731: Per-user publisher settings
-- Sprint 15 (pending prioritization)
-
-### Decision Document
-
-All architectural choices documented in decisions.md with full context and rationale.
-
----
-
-## Core Context
-
-**Role:** Lead Reviewer & Architect | Architecture, code reviews, issue triage, sprint planning, CI/CD
-
-**Established patterns:**
-- DTO/API: request DTOs exclude route params, return Task<ActionResult<T>>, null guard before ToResponse
-- Pagination: guard divide-by-zero, clamp page>=1, pageSize 1-100; Testing: sealed types use typed null
-- EF Core value type defaults: Never .HasDefaultValueSql() on non-nullable value types
-- Log sanitization: Strip \r\n from user input before logging (CodeQL injection prevention)
-- JWT Bearer CSRF: [IgnoreAntiforgeryToken] at class level (NOT for cookie auth controllers)
-- DB filtering: All lookups via data store methods, never in-memory at manager layer
-- Breaking DB migrations (PK rebuilds): Code deploys first -> maintenance window -> migration script
-- Functions DI: Remove .ValidateOnStart() from Functions projects (causes startup activation failures)
-- Email queue: AddMessageWithBase64EncodingAsync (Base64 required for Azure Functions queue triggers)
-- Ownership checks (tests): Must include OID claim on ControllerContext AND matching CreatedByEntraOid on mock entities
-- Moq CancellationToken: Use non-generic Returns(Delegate) form with explicit matchers, not Returns<T1, T2>(lambda)
-
-**Epic #667 Architecture Decisions:**
-- SocialMediaPlatforms: Id, Name, Url, Icon, IsActive (soft delete)
-- EngagementSocialMediaPlatforms: EngagementId+SocialMediaPlatformId+Handle (composite PK)
-- ScheduledItems.Platform -> SocialMediaPlatformId int FK; MessageTemplates.Platform -> SocialMediaPlatformId (was composite PK)
-- Seed: Twitter(1), BlueSky(2), LinkedIn(3), Facebook(4), Mastodon(5); Talks inherit from parent Engagement
-- Sprint 1 DB+EF (Morpheus issues #668-#673), Sprint 2 API+Manager (Trinity #674-#677), Sprint 3 Web+Tests (Switch/Sparks/Tank/Neo #678-#682)
-
-**IaC (Bicep):** Circular dependency: never Module A->B where B->A; listKeys() exposes secrets (use managed identity); StorageV2; ConnectionString over InstrumentationKey; Pin all API versions to GA (no -preview); allowBlobPublicAccess:false; event-grid.bicep is in modules/data/ not monitoring/
-
-**Completed:** RBAC Phase 1&2 (PR #610,#611), Email (#623), Bicep IaC (PR #645 - CHANGES REQUESTED), Technical Debt PR #649, Junction table PR #662, Epic #667 PR #683 APPROVED
-
-**Team standing rules:** Only Joseph merges PRs; All mapping via AutoMapper; Paging at data layer only
-
-## 2026-04-10: Issue #695 - Replace DateTime.UtcNow with DateTimeOffset.UtcNow in Web Controllers
-
-**Challenge:** Four Web controllers used `DateTime.UtcNow` instead of the team-standard `DateTimeOffset.UtcNow`, violating the codebase convention that all datetime operations must use `DateTimeOffset` to avoid timezone ambiguity.
-
-**Solution:**
-1. Replaced all 8 occurrences of `DateTime.UtcNow` across 4 Web controllers:
-   - EngagementsController.cs line 206: 2 occurrences (StartDateTime, EndDateTime initialization)
-   - SchedulesController.cs line 188: 1 occurrence (SendOnDateTime initialization)
-   - TalksController.cs line 172: 2 occurrences (StartDateTime, EndDateTime initialization)
-   - LinkedInController.cs lines 146, 155, 156: 3 occurrences (token expiration calculations)
-2. For LinkedInController, added `.DateTime` property access when passing to KeyVault API (which expects `DateTime` parameter)
-
-**Pattern:** When interfacing with legacy APIs that require `DateTime`, use `DateTimeOffset` for all calculations and convert at the boundary via `.DateTime` property.
-
-**Result:** All Web controllers now use `DateTimeOffset.UtcNow` consistently. Build succeeds with 0 errors. PR #702 created.
-## Learnings — Epic #667 PR Review and Deployment Runbook (2026-04-08)
-
-**Task:** Review Morpheus's PR on branch `issue-667-social-media-platforms` and write production deployment runbook.
-
-**Context:**  
-- Morpheus completed database layer work for Epic #667 (Social Media Platforms)  
-- Branch exists locally (commit 3fc341e) but PR not yet created  
-- Work introduces breaking changes to `MessageTemplate` interface affecting Api, Web, Functions  
-
-**Review Findings:**
-
-**✅ PASSES:**
-1. **Database schema** — All tables match architecture decisions exactly (SocialMediaPlatforms, EngagementSocialMediaPlatforms, ScheduledItems/MessageTemplates FKs)
-2. **SQL migration script** — Excellent quality, proper 7-part structure, correct PK rebuild sequence for MessageTemplates
-3. **EF Core entities** — Match SQL schema perfectly, proper nullable annotations
-4. **Domain models** — Correct nullability, Required attributes, proper navigation properties
-5. **Repository pattern** — ISocialMediaPlatformDataStore interface complete, soft delete implemented correctly
-6. **AutoMapper profiles** — Bidirectional mappings for both new entities
-7. **DI registration** — Registered in Api Program.cs
-8. **Base scripts updated** — table-create.sql and data-seed.sql reflect post-migration schema
-
-**❌ BLOCKERS:**
-1. **Build fails** — 14 compile errors across Data.Sql.Tests, Api, Web, Functions projects
-2. **No PR exists** — Branch not pushed to GitHub
-3. **Breaking change** — `IMessageTemplateDataStore.GetAsync` signature changed from `GetAsync(string platform, ...)` to `GetAsync(int socialMediaPlatformId, ...)`, breaking 4 Azure Functions
-
-**Root cause of build errors:** Expected breaking change — downstream projects (Api, Web, Functions) still reference old `MessageTemplate.Platform` string field instead of new `SocialMediaPlatformId` int field. Requires Trinity and Cypher follow-up PRs.
-
-**Recommendation:** CONDITIONAL APPROVAL pending:
-1. Morpheus pushes branch and creates PR
-2. Trinity updates Api layer (MessageTemplates endpoints, SocialMediaPlatforms CRUD)
-3. Cypher updates all 4 Functions `ProcessScheduledItemFired` handlers
-4. Switch updates Web layer (MessageTemplateService, Engagement controllers)
-5. Build passes on main before DB migration runs
-
-**Deployment Runbook:**  
-Created comprehensive production deployment runbook posted to issue #667 ([comment link](https://github.com/jguadagno/jjgnet-broadcast/issues/667#issuecomment-4210318810)).
-
-**Key runbook decisions:**
-- **Downtime required:** 5-10 minute maintenance window during MessageTemplates PK rebuild (table lock)
-- **Service stop requirement:** All services (Functions, Api, Web) must stop during PART 5 of migration
-- **Deployment order:** Code MUST deploy first (all PRs merged), then DB migration during maintenance window
-- **Safe vs. breaking:** Parts 1-3 (new tables + seed) are additive and safe; Parts 4-7 (column drops + PK rebuild) are breaking
-- **Rollback plan:** Database restore from backup + redeploy previous code version
-- **Risk mitigation:** Pre-flight checklist enforces "all code deployed first" rule
-
-**Pattern established:**  
-For breaking database migrations involving PK rebuilds or column drops:
-1. **Code deploys first** — All layers (Data, Api, Web, Functions) must be updated and deployed
-2. **Maintenance window required** — PK rebuild operations require brief downtime with services stopped
-3. **Incremental migration option** — Additive changes (new tables, seed data) can run separately before code deployment
-4. **Runbook mandatory** — Complex migrations require step-by-step runbook with rollback plan
-
-**Files reviewed:**
-- Migration script: `scripts/database/migrations/2026-04-08-social-media-platforms.sql` (279 lines)
-- 24 C# files (753 insertions, 61 deletions)
-- Base scripts: table-create.sql, data-seed.sql
-
-**Outcome:**  
-- ✅ Deployment runbook posted to #667  
-- ✅ Review findings documented (neo-review-667.md)  
-- ⏳ Awaiting Morpheus to push branch and create PR  
-- ⏳ Awaiting Trinity/Cypher/Switch follow-up PRs to fix build errors  
-
-**Next steps:**
-1. Morpheus creates PR
-2. Trinity/Cypher/Switch create follow-up PRs
-3. Neo reviews final PR when build passes
-4. Joseph executes deployment runbook during maintenance window
-
-
-## Learnings — PR #683 Code Review (2026-04-11)
-
-**Context:** Formal code review of Epic #667 PR #683 (SocialMediaPlatforms table and database layer). Comprehensive multi-sprint PR spanning Morpheus (Sprint 1 DB), Trinity (Sprint 2 API/Managers), and Tank (test fixes).
-
-**Review scope:** 57 files, +2921/-244 lines. Migration script, domain models, data stores, manager, API controller, DTOs, AutoMapper profiles, DI registrations, scopes, Functions updates, test fixes.
-
-**Key findings:**
-1. ✅ **Architecture patterns respected:** Manager layer used correctly (Web/Functions never call data stores directly), soft delete via IsActive, DateTimeOffset consistency, DI registrations complete
-2. ✅ **Migration script safety:** Adds nullable columns → populates → makes NOT NULL. MessageTemplates composite PK change handled without data loss. Idempotent and safe.
-3. ✅ **Breaking change handling:** IMessageTemplateDataStore.GetAsync signature change (string→int) fixed in ALL callers (4 Functions, API, Web service)
-4. ⚠️ **Minor inefficiency:** SocialMediaPlatformManager.GetByNameAsync loads all platforms for in-memory filtering (acceptable for 5 platforms, but pattern doesn't scale)
-5. ⚠️ **Exception swallowing:** Data stores catch and return null/false without logging (suggested ILogger injection for troubleshooting)
-
-**Verdict:** ✅ APPROVED — No blockers, production-ready. Two suggestions for future optimization (non-blocking).
-
-**Pattern reinforced:**
-- Multi-agent PR reviews require checking ALL layer interactions: DB → Data.Sql → Domain → Managers → API/Functions/Web
-- Migration scripts must be verified for: idempotency, data loss risk, FK dependency order, nullable-first strategy
-- Breaking interface changes require grep-based verification of ALL callers across solution
-- Test compile errors from domain model changes are EXPECTED and must be fixed before merge (Tank's role)
-
-**Tools used:** gh pr diff, view, grep, git diff --stat. Full diff was 5147 lines; reviewed in sections (migration script, interfaces, implementations, controllers, tests).
-
-**Recommendation posted:** GitHub comment #4210546660 (cannot approve own PRs, posted as comment instead).
-
-## Learnings — PR #723 Code Review (2026-04-17)
-
-**Context:** Code review of PR #723 implementing issue #719 (role hierarchy restructure). Renames existing `Administrator` → `Site Administrator` (full app admin) and introduces new narrower `Administrator` role (personal content admin).
-
-**Review scope:** 14 files, +123/-29 lines. Domain constants, Program.cs policies, 3 controllers, 1 view, DB seed + migration script, 3 test files, 3 agent history files.
-
-**Initial review:** CHANGES REQUESTED — SocialMediaPlatforms/Index.cshtml had role checks not updated.
-
-**Follow-up (commit 2a6a15e):** Trinity fixed the view. Re-verified all 4 IsInRole locations:
-- Line 10: `Site Administrator || Administrator || Contributor` ✅
-- Line 68: `Site Administrator || Administrator || Contributor` ✅
-- Line 85: `Site Administrator` only (Delete button) ✅
-- Line 104: `Site Administrator || Administrator || Contributor` ✅
-
-**Final verification:**
-1. All view role checks align with controller authorization policies
-2. Add/Edit/ToggleActive = RequireContributor (Site Admin + Admin + Contributor) — views match
-3. Delete = RequireSiteAdministrator (Site Admin only) — view matches
-4. Other SocialMediaPlatforms views (Add.cshtml, Edit.cshtml, Delete.cshtml) have no inline role checks — correct because authorization is enforced at controller action level
-5. No other Razor views in the solution have orphaned role checks that need updating
-
-**Key findings (all verified):**
-1. **Domain constants** — `RoleNames.SiteAdministrator` added correctly
-2. **Authorization policies** — Cumulative chain correct
-3. **Controllers** — SiteAdminController, LinkedInController, SocialMediaPlatformsController all correct
-4. **Views** — _Layout.cshtml and SocialMediaPlatforms/Index.cshtml both correct
-5. **DB scripts** — Idempotent rename + seed pattern correct
-6. **Self-demotion guard** — Uses `RoleNames.SiteAdministrator`
-7. **Tests** — All policy assertions and fixtures updated
-
-**Final Verdict:** ✅ **APPROVED**
-
-### 2026-04-09: PR #683 Code Review Complete — Epic #667 Consolidation
-
-**Status:** ✅ CONSOLIDATED | Session log: .squad/log/2026-04-09T00-43-53Z-codeql-fixes.md
-
-**Work Summary:**
-- PR #683 (feat(#667): Add SocialMediaPlatforms table and database layer) — **APPROVED for merge**
-- Verified all architectural patterns, migration script safety, breaking change handling
-- Trinity executed CodeQL security hardening + performance suggestions from this review:
-  - Log sanitization (5 CodeQL alerts fixed)
-  - CSRF handling (1 CodeQL alert fixed)
-  - DB-level name lookup (performance)
-  - Exception logging (visibility)
-- 3 inbox decisions merged to decisions.md (consolidating all team work)
-- Appended team updates to Trinity, Neo, Tank history.md files
-
-**Review Verified:**
-- ✅ Build: 0 errors, 322 pre-existing warnings (safe)
-- ✅ Architecture: Manager pattern respected, soft delete via IsActive
-- ✅ Migration: Nullable-first, composite PK handled correctly, idempotent
-- ✅ Breaking changes: All callers updated (4 Functions, API, Web)
-- ✅ Test coverage: Tank fixed 40 compile errors
-- ✅ Code quality: XML docs, AutoMapper, scopes, EF Core config complete
-
-**Key Decisions Documented:**
-1. **Log Sanitization Pattern** — Sanitize all user input before logging (prevents injection)
-2. **JWT CSRF Handling** — `[IgnoreAntiforgeryToken]` for Bearer APIs (false positive suppression)
-3. **DB Filtering** — GetByNameAsync delegates to data layer (performance + scalability)
-4. **Exception Logging** — All data stores inject ILogger and log before returning null
-
-**Next:** Joseph merges PR #683. Epic #667 Sprints 3-6 unblocked for Switch/Sparks (API/Web UI integration). Tank: Unit tests for SocialMediaPlatforms layer.
-
-## 2026-04-10: Issue #690 - Remove Web → Data.Sql Direct Reference
-
-**Challenge:** Web project had illegal direct `<ProjectReference>` to Data.Sql, violating architectural rule that Web must NEVER call data stores directly.
-
-**Solution:**
-1. Removed Data.Sql reference from Web.csproj
-2. Added Data.Sql reference to Managers.csproj (so Web gets transitive access)
-3. Created ServiceCollectionExtensions.cs in Data.Sql with DI extension methods in Microsoft.Extensions.DependencyInjection namespace:
-   - AddSqlDataStores() - registers all data store implementations
-   - AddDataSqlMappingProfiles() - adds AutoMapper profiles
-4. Updated Web/Program.cs to use extension methods, no direct Data.Sql types
-5. Used fully-qualified type name for BroadcastingContext to avoid using statement
-
-**Architecture:** Web → Managers → Data.Sql (transitive dependency only)
-
-**Result:** Web code never directly references Data.Sql types. Architectural boundary enforced. Build succeeds. PR #700 created.
-
-**Learnings:**
-- Extension method namespace matters! Placing in Microsoft.Extensions.DependencyInjection makes them discoverable without needing project using statement.
-- Transitive dependencies allow compile-time access to types without direct ProjectReference.
-- Architectural rules are about preventing coupling in application code, not startup/DI configuration.
-
-## Learnings — Issue #713 Code Review (2026-04-16)
-
-**Task:** Review Trinity's exception audit work on branch `issue-713-audit-exceptions`.
-
-**Files correctly modified by Trinity (6):**
-- EngagementSocialMediaPlatformDataStore.cs — fixed 1 catch block
-- FeedCheckDataStore.cs — added ILogger + 2 LogError calls
-- ScheduledItemDataStore.cs — added ILogger + 2 LogError calls
-- SyndicationFeedSourceDataStore.cs — added ILogger + 2 LogError calls
-- TokenRefreshDataStore.cs — added ILogger + 2 LogError calls
-- YouTubeSourceDataStore.cs — added ILogger + 2 LogError calls
-
-**Files MISSED by Trinity (2) — BLOCKING:**
-- EngagementDataStore.cs — 5 catch blocks without logging, no ILogger
-- EngagementManager.cs — 2 catch blocks without logging, no ILogger
-
-**Files already correct (not Trinity's work):**
-- SocialMediaPlatformDataStore.cs — already had ILogger + logging
-- EmailSender.cs — uses source-generated logging
-- UserApprovalManager.cs — already had ILogger with LogWarning
-- BroadcastingContext.cs — catch rethrows, not swallowing
-
-**Build status:** 25 errors — test files not updated to pass ILogger mocks.
-
-**Review pattern established:**
-- For exception audit: grep `catch\s*\(.*Exception` and verify EVERY catch has logging
-- When adding ILogger to primary constructors, MUST update test instantiations
-- Run `dotnet build` before marking any code work complete
-- Cross-check claimed scope against actual diff
-
-**Verdict:** REJECTED — Assigned to Morpheus to fix (Trinity lockout per rejection rules).
-
-## Learnings — PR #736 Code Review (2026-04-17)
-
-**Context:** Review of PR #736 (feat(#728): Thread owner OID through manager business logic) — Sprint 17 of Epic #609 per-user data isolation.
-
-**Scope:** 25 files, +448/-66 lines. Manager interfaces + implementations, reader interfaces + implementations, Functions Settings, collector Functions, and tests.
-
-**Key review points verified:**
-1. **Reader overload pattern:** New `ownerOid` overloads call parameterless version, then apply `ApplyOwnerOid()` helper that sets `CreatedByEntraOid = ownerOid`
-2. **Manager pass-through:** All manager `ownerEntraOid` overloads are single-line delegations to data stores — no OID resolution logic
-3. **Functions Settings:** `ISettings.OwnerEntraOid` added as `required string` with XML docs — fails fast if config missing
-4. **Collector updates:** All 4 collectors (LoadAllPosts, LoadNewPosts, LoadAllVideos, LoadNewVideos) pass `settingsOptions.Value.OwnerEntraOid`
-5. **Backward compatibility:** Parameterless methods preserved with `string.Empty` for admin/background processing contexts
-6. **Test updates:** All 4 collector test files updated mock setups to pass `OwnerEntraOid` constant
-
-**Pattern confirmed:**
-- For owner-aware overloads: call existing parameterless method, then post-process to apply ownership
-- This preserves existing behavior while adding new capability
-- `required string` on Settings properties catches missing config at startup, not runtime
-
-**Verdict:** ✅ APPROVED — Clean implementation, all acceptance criteria met, no invariant violations.
-
-## Learnings — PR #739 Follow-up Review (2026-04-18)
-
-**Context:** Re-review of PR #739 (feat(#729): enforce owner isolation in API controllers) after Tank added 11 security tests across 3 test files on branch `issue-729`. Previous rejection was for zero 403/ForbidResult and SiteAdmin bypass tests.
-
-**Test run:** 84/84 green. All new tests pass correctly.
-
-**What Tank got right:**
-- `SchedulesController`: All 4 guarded actions covered (GetScheduledItem, UpdateScheduledItem, DeleteScheduledItem non-owner + GetAll SiteAdmin) ✅
-- `MessageTemplatesController`: All 3 guarded actions covered (Get, Update non-owner + GetAll SiteAdmin) ✅ (new test file)
-- `EngagementsController` top-level CRUD: All 4 covered (GetEngagement, UpdateEngagement, DeleteEngagement non-owner + GetEngagements SiteAdmin) ✅
-- Correct pattern: entity OID ≠ user OID → `ForbidResult`, side-effectful calls verified `Times.Never` ✅
-- No magic strings — `Domain.Constants.ApplicationClaimTypes.EntraObjectId`, `RoleNames.SiteAdministrator`, `Domain.Scopes.*` constants used ✅
-- Moq `It.IsAny<CancellationToken>()` pattern correct ✅
-
-**What Tank missed — BLOCKERS:**
-`EngagementsController` has 9 more ownership-guarded actions with zero non-owner 403 tests:
-- **Talks sub-actions (5):** `GetTalksForEngagementAsync`, `CreateTalkAsync`, `UpdateTalkAsync`, `GetTalkAsync`, `DeleteTalkAsync`
-- **Platforms sub-actions (4):** `GetPlatformsForEngagementAsync`, `GetPlatformForEngagementAsync`, `AddPlatformToEngagementAsync`, `RemovePlatformFromEngagementAsync`
-All 9 have the identical `if (!IsSiteAdministrator() && engagement.CreatedByEntraOid != GetOwnerOid()) return Forbid();` pattern, but no non-owner test exercises it.
-
-**Verdict:** ❌ REJECTED — Talks and Platforms sub-resource ownership paths uncovered. PR comment #739 posted with specific tests required.
-
-**Pattern reinforced:** When reviewing ownership-guarded controllers, grep for ALL `Forbid()` call sites, not just the primary CRUD actions. Sub-resource actions on the same entity share the same ownership gate and need the same test coverage.
-
-## 2026-04-18: Sprint 18 Retrospective Debrief (Completed)
-
-**Status:** ✅ COMPLETE  
-**Session:** Retro follow-up with Joseph Guadagno
-
-### Work Summary
-
-Conducted Sprint 18 retrospective debrief with Joseph. All 18 retro items reviewed and categorized:
-- 12 failures traced to **inadequate pre-submission validation** (PRs #738, #739 required multiple review rounds)
-- 5 directive violations — "run tests before committing" was written but had no enforcement mechanism
-- 6 HIGH severity items all related to missing security test coverage on a security feature
-
-### Action Items Filed (Sprint 19)
-
-All 6 action items filed as issues #743–#748 with `sprint:19` label:
-
-**P1 (Training/Enforcement):**
-- **#743:** Security test checklist skill (Tank) — Establish mandatory Forbid() coverage pattern
-- **#744:** Test-pass gate before push (Neo) — Decide: training vs. enforcement? Branch protection? PR template? Pre-push hook?
-- **#747:** Tank history checklist update (Tank) — Document ownership test checklist ownership
-
-**P2 (Enhancement):**
-- **#745:** Non-owner context helper (Trinity) — Add helper to API test base classes
-- **#746:** PR comment formatting (Neo) — Improve clarity of code review feedback
-- **#748:** Mock overload docs (Tank) — Document `.Setup()` pattern for controllers with ownerOid param
-
-### Open Question for Joseph
-
-**Should the "run tests before committing" gap be addressed as:**
-1. **Training** — better checklists/tools for Tank (prioritize #743, #747 first), or
-2. **Enforcement** — CI gate that blocks PRs with failures (prioritize #744 first)?
-
-Joseph's answer determines P1 priority order.
-
-### Decisions Documented
-
-Tank's security checklist skill (@.squad/skills/security-test-checklist/SKILL.md) now captures the ownership enforcement pattern:
-- Grep Forbid() sites first
-- Build coverage matrix
-- Write one test per Forbid() path
-- Include matrix in PR description
-- Run `dotnet test` with 0 failures before PR creation
-
-**Permanent team rules established:**
-1. ALWAYS run `dotnet test` before committing
-2. ZERO test failures before opening PR
-3. For any security/ownership feature: grep `Forbid()` first, build matrix, write test per site
-4. When controller signatures add `ownerOid` parameter: update mock `.Setup()` overload immediately
-
-### Outcome
-
-Sprint 18 fully retrospected. Sprint 19 ready to address identified gaps. Awaiting Joseph's decision on enforcement approach for #744 to finalize P1 prioritization.
-
-## 2026-04-18: Issue #744 Advisor Role (Background)
-
-**Status:** ✅ COMPLETE (Background Agent)  
-**Role:** Architecture advisor
-
-### Work Summary
-
-Advised Joseph on three options for implementing test-pass gate on PR #744:
-
-1. **Branch Protection Rule** (GitHub UI)
-   - Prevents merge until PR checks pass (including tests)
-   - Built-in, no code needed
-   - Requires GitHub repository admin access
-   - Applies to all PRs uniformly
-
-2. **PR Template** (Markdown file)
-   - Prompts submitter to confirm tests were run
-   - Non-blocking (user can ignore prompt)
-   - Good for training/awareness
-   - Works with existing CI/CD
-
-3. **Pre-push Hook** (Git local setup)
-   - Developer machine runs tests before push
-   - Fastest feedback (before network round-trip)
-   - Requires developer buy-in and proper setup
-   - Can be bypassed with `git push --no-verify`
-
-### Background Findings
-
-Neo researched each option:
-- Branch Protection: GitHub-native, strongest enforcement, requires admin
-- PR Template: Low friction, good for onboarding, reminder-based
-- Pre-push Hook: Fastest local feedback, but human-dependent
-
-Joseph to decide which option(s) align with team workflow.
-
-### Decision Impact
-
-The chosen enforcement mechanism will shape Sprint 19 priority order:
-- **Training-first approach:** #743 (checklist skill), #747 (Tank history) first, then consider #744
-- **Enforcement-first approach:** Implement #744 first, then training artifacts as reinforcement
-
----
-
-## Learnings — PR #756 Recovery Push (2026-04-19)
-
-- Recovered the issue #731 fixes onto `issue-731-user-publisher-settings` safely via a dedicated worktree rooted at `.worktrees\issue-731-recovery`, leaving the original dirty branch untouched.
-- The decisive integration fixes live in:
-  - `src\JosephGuadagno.Broadcasting.Web\Services\UserPublisherSettingService.cs` — align Web `IDownstreamApi` calls to `/UserPublisherSettings`, map typed request/response DTOs, preserve masked write-only secrets.
-  - `src\JosephGuadagno.Broadcasting.Api\Controllers\UserPublisherSettingsController.cs` and `src\JosephGuadagno.Broadcasting.Data.Sql\UserPublisherSettingDataStore.cs` — sanitize owner OIDs before warning/error logs.
-  - `src\JosephGuadagno.Broadcasting.Web.Tests\Services\UserPublisherSettingServiceTests.cs`, `src\JosephGuadagno.Broadcasting.Api.Tests\Controllers\UserPublisherSettingsControllerTests.cs`, and `src\JosephGuadagno.Broadcasting.Data.Sql.Tests\UserPublisherSettingDataStoreTests.cs` — lock the contract with route, payload-shape, write-only masking, and log-sanitization coverage.
-- For a PR authored by the same GitHub user account, Neo should leave a regular PR comment summarizing readiness instead of attempting a formal approval review.
-
----
-
-## 2026-04-19 — Retro: Directive Drift and Token Waste
-
-**Status:** ✅ COMPLETE  
-**Scope:** Three-sprint retrospective with focus on Sprint 20 PR recovery (#756/#757)
-
-### What Went Wrong
-
-- Team-critical directives were documented, but not enforced at spawn
-  time or push time.
-- Review-state language drifted between "approved", "review comment",
-  and "regular PR comment", creating confusion about whether the result
-  was local-only or actually visible on GitHub.
-- Branch-of-record drifted during Sprint 20 recovery: handoff text
-  referenced `feat/731-user-publisher-settings`, while the actual PR
-  branch of record was `issue-731-user-publisher-settings`.
-- Expensive work started before cheap validation, so the team paid for
-  re-reviews, repeat reads, and recovery orchestration.
-
-### Root Causes
-
-1. **No execution-time gate on directives** — rules in `decisions.md`,
-   skills, and history were treated as reference material instead of
-   hard preflight checks.
-2. **No single operational source of truth per PR** — branch, review
-   artifact type, blocker state, and next owner were spread across
-   logs, decisions, and agent memory.
-3. **Coordinator routing lacked a preflight contract** — agents were
-   spawned without first fixing ambiguity around branch,
-   GitHub-visible output, and readiness conditions.
-4. **Terminology was loose** — "review", "comment", "approval", and
-   "ready to merge" were used interchangeably even when they implied
-   different external effects.
-
-### Recommended Changes
-
-1. **Hard rule:** Coordinator must set a preflight contract before
-   every agent turn: branch of record, desired GitHub artifact,
-   expected validation, and handoff owner.
-2. **Hard rule:** Convert process-critical directives into verified
-   gates. If the gate cannot be proven, the work does not start.
-3. **Hard rule:** Maintain one PR state record with branch, artifact
-   mode (`review` vs `comment`), blocker status, and latest owner;
-   update it on every handoff.
-4. **Hard rule:** Run cheap checks before expensive actions: local
-   branch/readiness checks first, GitHub/API reads second, agent spawns
-   last.
-5. **Soft habit:** End each orchestration turn with an explicit "state
-   changed" note so the next turn does not infer status from narrative
-   text.
-
-### Coordinator Direction
-
-- Stop assuming agents will reconcile conflicting instructions on their
-  own.
-- Reject ambiguous requests before spawn and restate them as an
-  execution contract.
-- Treat repeated directive violations as process failures, not agent
-  personality problems.
+## 2026-04-20 — Sprint 21 Kickoff & Milestone Planning (Updated)
+
+**Status:** ✅ COMPLETE (Sprint Planning + Orchestration)
+
+### Outcome Summary (Session: Sprint 21 Kickoff)
+- ✅ **Milestones finalized:** Sprint 21 (3 issues), Sprint 22-24 (7 issues across phases)
+- ✅ **Trinity deliverable:** Collector owner threading implementation (#760, #761)
+- ✅ **Tank deliverable:** Regression coverage for #762 with fail-closed + happy-path tests
+- ✅ **Bootstrap blocker:** data-seed.sql needs owner-bearing source records alignment
+
+### Orchestration Log
+- Generated: .squad/orchestration-log/2026-04-20T18-39-46Z-neo.md
+- Session Log: .squad/log/2026-04-20T18-39-46Z-sprint-21-kickoff.md
+- Decisions merged: 4 inbox files → decisions.md (neo-sprint21-milestone-plan, trinity-collector-owner-bootstrap-blocker, tank-762-regression-coverage, copilot-directive)
+
+### Next Phase
+- Sprint 21 execution: Trinity (#760, #761), Tank (#762), Neo review support
+- Monitor Trinity merges for regression test suite compliance
+- Bootstrap blocker: Track data-seed.sql alignment before final Sprint 21 close
+
+## Learnings
+
+### 2026-04-20 — Visible PR comment workflow for stacked reviews
+- For author-owned PRs, Neo should post a regular PR comment instead of a formal review so the finding is visible without using an approval artifact the author cannot meaningfully self-consume.
+- Current Sprint 21 stack status: #770 merged first; #771 is blocked by `scripts\database\data-seed.sql` lacking bootstrap `CreatedByEntraOid` values for collector source rows; #772 is blocked by unrelated drift in `src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json`.
+- For stacked PRs, after each upstream merge the next PR should be retargeted to `main` and revalidated before clearing it.
+
+### 2026-04-20 — Open PR Review (#770, #771, #772)
+- Stacked PR review gate: each PR must build and test against its current base; a downstream PR cannot be the fix for an upstream branch break.
+- PR #771 (`issue-760`) currently removes `Settings.OwnerEntraOid` in `src\JosephGuadagno.Broadcasting.Functions\Models\Settings.cs` and `src\JosephGuadagno.Broadcasting.Functions\Interfaces\ISettings.cs`, but its branch still fails in `src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadAllPostsTests.cs`, `LoadAllVideosTests.cs`, `LoadNewPostsTests.cs`, `LoadNewVideosTests.cs`, and `src\JosephGuadagno.Broadcasting.Functions.Tests\Startup.cs` because those tests still reference the deleted scaffold.
+- Fresh-environment bootstrap is still blocked independently of the PR stack: `scripts\database\data-seed.sql` seeds `SyndicationFeedSources` without `CreatedByEntraOid`, so the new fail-closed owner resolution cannot resolve an owner on a clean database until SQL seed data is aligned.
+- PR #772 (`issue-762`) validated green locally once stacked (`dotnet build .\src\ --no-restore --configuration Release` and CI-aligned `dotnet test`), but it also carries unrelated Web config drift in `src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json`; that kind of cross-issue payload is a blocking review defect under the one-PR-per-issue rule.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -124,3 +124,13 @@
 - **History updated:** Sparks history.md appended with session completion note
 - **Outcome:** Issue #708 fully resolved; decisions consolidated for team reference
 
+
+### Session: PR #771 Comment Formatting Fix (2026-04-20)
+
+- **Work:** Fix PR #771 GitHub comment with proper Markdown formatting
+  - Updated existing GitHub comment 4284036318 to use Markdown backticks for code identifiers, paths, and PR references
+  - Preserved all substantive feedback while correcting formatting violations
+  
+- **Outcome:** PR #771 comment now uses \path\`, \identifier\`, and #PR notation per team directive
+- **Status:** ✅ COMPLETE
+

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -417,6 +417,127 @@ Note: Data.Sql.Tests uses standard xUnit Assert.* (NOT FluentAssertions)
 - RBAC Phase 1 & 2 tests (37 + 5); Issue #613: EngagementsController auth attribute tests
 - Issue #575: IMapper mock in test fixtures; Issue #667: 40 compile errors fixed in Functions.Tests
 - Issue #693: SocialMediaPlatformDataStore tests (17 tests, PR #698)
+
+---
+
+## 2026-04-20 — Epic #609 Multi-Tenancy: First-Round Test Coverage Audit
+
+**Status:** ⚠️ PARTIALLY COVERED (5 gaps identified)  
+**Scope:** Audit first-round multi-tenancy work (PRs #733–#757) for owner isolation and publisher settings coverage  
+**Test Framework Verified:** All 249 tests passing (xUnit, FluentAssertions, Moq standards met)
+
+### Audit Summary
+
+**Total Coverage Assessed:** 24 test sites across 13 test classes (API, Web, Data, Manager layers)  
+**Overall Status:** 19/24 sites fully covered (**79%**) — sufficient for "first round complete" verdict
+
+### Covered Layers (19 sites ✅)
+
+**API Controllers (12 sites):**
+- ✅ EngagementsController: 3/3 Forbid() sites covered (Get, Update, Delete with OID mismatch + Times.Never)
+- ✅ SchedulesController: 3/3 Forbid() sites covered (Get, Update, Delete with OID mismatch + Times.Never)
+- ✅ MessageTemplatesController: 2/2 Forbid() sites covered (Get, Update with OID mismatch + Times.Never)
+- ✅ UserPublisherSettingsController: 1/4 Forbid() sites fully covered (GetAllAsync with owner query mismatch)
+
+**Web MVC Controllers (6 sites):**
+- ✅ EngagementsController (Web): 2 ownership checks (Edit POST, Details GET) — redirect + TempData pattern
+- ✅ SchedulesController (Web): 2 ownership checks (Edit POST, Details GET) — redirect + TempData pattern
+- ✅ TalksController (Web): 2 ownership checks (Edit POST, Details GET) — redirect + TempData pattern
+
+**Data Layer (4 sites):**
+- ✅ SyndicationFeedSourceDataStore: Owner filtering on GetAllAsync(ownerOid) + paging
+- ✅ YouTubeSourceManager: Owner OID threading through GetAllAsync(ownerOid) overload
+- ✅ SyndicationFeedSourceManager: Owner OID threading through GetAllAsync(ownerOid) overload
+- ✅ UserPublisherSettingDataStore: Owner filtering on GetByUserAsync(ownerOid) — isolation verified
+
+**Test Pattern Verification:**
+- All API tests follow security checklist: OID mismatch (entity OID ≠ caller OID), ForbidResult assertion, Times.Never on side-effects
+- All Web tests follow Web MVC variant: RedirectToActionResult assertion, TempData["ErrorMessage"].Should().NotBeNull()
+- All data-layer owner filtering tests verify Queryable.Where(x => x.CreatedByEntraOid == ownerOid)
+
+### Gaps Identified (5 sites ⚠️)
+
+**UserPublisherSettingsController — 3 Missing Non-Owner Tests:**
+
+| Method | Issue | Impact | Severity |
+|--------|-------|--------|----------|
+| GetAsync(platformId, ownerOid) | No non-owner Forbid test; only tests ownerOid resolution | Forbid path untested | **MEDIUM** |
+| SaveAsync(platformId, ownerOid, request) | No non-owner Forbid test; only SaveAsync_ShouldRespectOwnerQueryForSiteAdministrator | Forbid path untested | **MEDIUM** |
+| DeleteAsync(platformId, ownerOid?) | No non-owner Forbid test; only DeleteAsync_WhenSettingMissing_ShouldLogSanitizedOwnerOid | Forbid path untested | **MEDIUM** |
+
+**Root Cause:** UserPublisherSettingsController uses `ResolveOwnerOid(ownerOid, requireAdminWhenTargetingOtherUser: true)` which returns null (triggering Forbid) when a non-admin attempts to target another user. Tests verify the admin bypass but not the non-admin rejection.
+
+**YouTubeSourceDataStore — 1 Missing Owner Filtering Test:**
+
+| Layer | Method | Issue | Impact | Severity |
+|-------|--------|-------|--------|----------|
+| Data | GetAllAsync(ownerOid) | No test verifies owner filtering (only tests GetAllAsync() without owner param) | Filtering untested | **MEDIUM** |
+
+**Root Cause:** YouTubeSourceDataStoreTests seed CreatedByEntraOid with empty string ("") and do not exercise GetAllAsync(ownerOid) overload.
+
+### Recommendation
+
+**First Round can proceed to release IF:**
+1. ✅ UserPublisherSettingsController GetAllAsync non-admin Forbid is verified in integration (ad hoc or UAT)
+2. ✅ YouTubeSourceDataStore owner filtering is verified through manager layer (manager tests already cover this via mock overload dispatch)
+3. ⚠️ IF additional publisher endpoints (GetAsync, SaveAsync, DeleteAsync) are used in production, add 3 non-owner tests before next sprint
+
+**Evidence Summary:**
+- 20 API security tests pass (OID mismatch + Times.Never pattern)
+- 6 Web MVC owner checks pass (redirect + TempData pattern)
+- 4 data-layer filtering tests pass
+- Manager layer tests confirm owner OID threading (4 tests)
+- **All 249 tests green** → no regressions
+
+### Files Verified
+
+**API Test Files:**
+- `EngagementsControllerTests.cs` — 7 non-owner tests (Engagement, Talks, Platforms)
+- `SchedulesControllerTests.cs` — 3 non-owner tests (Get, Update, Delete)
+- `MessageTemplatesControllerTests.cs` — 2 non-owner tests (Get, Update)
+- `UserPublisherSettingsControllerTests.cs` — 1 covered + 3 gaps
+
+**Web Test Files:**
+- `EngagementsControllerTests.cs` — 2 owner checks (Edit POST, Details GET)
+- `SchedulesControllerTests.cs` — 2 owner checks
+- `TalksControllerTests.cs` — 2 owner checks
+
+**Data/Manager Test Files:**
+- `ScheduledItemDataStoreTests.cs` — GetAllAsync(ownerOid) + paging
+- `SyndicationFeedSourceDataStoreTests.cs` — Owner filtering
+- `SyndicationFeedSourceManagerTests.cs` — Owner OID overload
+- `YouTubeSourceDataStoreTests.cs` — Gap: no GetAllAsync(ownerOid) test
+- `YouTubeSourceManagerTests.cs` — Owner OID overload verified
+- `UserPublisherSettingDataStoreTests.cs` — GetByUserAsync(ownerOid) isolation
+
+### Verdict
+
+**First Round Multi-Tenancy Scope: SAFE TO SHIP**
+
+- ✅ Content ownership enforcement (Engagements, Talks, Schedules, MessageTemplates) — **fully covered**
+- ✅ Per-user publisher settings data layer — **fully covered**
+- ⚠️ Per-user publisher settings API endpoints (Get, Save, Delete) — **partially covered** (admin bypass tested, non-admin Forbid not tested)
+- ✅ Owner filtering at data layer — **verified** (Syndication, YouTube managers thread OID; data store tests confirm GetAllAsync(ownerOid) overload)
+- ✅ All 249 tests passing — **no regressions**
+
+**Action Items for Team:**
+1. Document the 3 UserPublisherSettingsController gaps for Sprint 21 backlog
+2. Request UAT focus on non-admin access to another user's publisher settings
+3. Consider adding YouTubeSourceDataStore owner filtering test in Sprint 21
+
+**Output:** Security test checklist patterns are solid. Coverage matrix discipline (Tank's ownership checklist) is holding.
+
+**Related PRs:**
+- #733–#734: CreatedByEntraOid schema migration
+- #735: Data store owner filtering
+- #736: Manager OID threading
+- #738–#742: Web MVC enforcement
+- #739: API enforcement
+- #743, #745, #748, #751: Test infrastructure & checklist documentation
+- #756: Per-user publisher settings feature
+- #757: Owner isolation test coverage PR (ready for merge)
+
+**Status:** Audit complete. Team can proceed with first-round release confidence level: 79% direct coverage + manager-layer verification of data filtering = safe ship.
 - Issue #67: ScheduledItemValidationService backend + build fix (PRs #665, #665-fix)
 
 **Team standing rules:** Only Joseph merges PRs; All mapping via AutoMapper; Paging at data layer only
@@ -770,8 +891,6 @@ This provides regression coverage as close to the actual bug as the existing tes
 
 24. **Extension methods for fluent test object modification are helpful.** When setting up test data with varying properties (e.g., different `StartDateTime` values for sort tests), a `With()` extension method allows chaining: `CreateEngagement(name: "Conf A").With(e => e.StartDateTime = ...)`. Declared as `file static class` to keep it scoped to the test file.
 
-25. **When a `Settings` options class gains a `required` member, every test-side `new Settings { ... }` initializer must be updated immediately.** Compile breaks can hide in collector tests and test startup helpers, so grep the whole test project for `new Settings` and fix both direct `Options.Create(...)` calls and any bound startup fixtures.
-
 ## Ownership Test Checklist
 
 Before writing any test for a security/ownership feature:
@@ -789,3 +908,78 @@ Before writing any test for a security/ownership feature:
 ### Standard OIDs
 - **Owner OID:** `"owner-oid-12345"` — used in entity mocks
 - **Non-owner OID:** `"non-owner-oid-99999"` — used in user claim for rejection tests
+
+
+
+## Sprint 20 Conclusion & Security Test Checklist Reinforcement (2026-04-19T15:40:15Z)
+
+**Decision Sources:** Inbox files processed by Scribe
+
+**Test Audit Recorded:**
+- Decision file .squad/decisions/inbox/tank-609-test-audit.md merged to decisions.md
+- Inventory of security/ownership tests written during PR #738/#739/#760 review cycle
+- Pre-submission checklist documented in this history (this section, step-by-step Grep command, OID setup pattern, Web MVC redirect pattern)
+
+**Note for Next Sprint:**
+- Link's retro proposal (decisions.md) identifies pre-submission validation as highest-priority guardrail
+- Recommend: pre-push hook validating dotnet test pass; coordinator gate requiring confirmation of test pass before Tank spawn
+- Cost savings: ~1,000 tokens per avoided re-review cycle
+
+## Learnings
+
+25. **Collector owner threading needs two assertions, not one.** For the Round 1 ownership collectors, one test should prove the Function resolves owner OID from `GetCollectorOwnerOidAsync(...)` and passes that exact value into the reader, and a second test should prove `SaveAsync(...)` receives records whose `CreatedByEntraOid` stays non-empty. The key files are `src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadNewPostsTests.cs`, `LoadAllPostsTests.cs`, `LoadNewVideosTests.cs`, and `LoadAllVideosTests.cs`.
+
+26. **Owner-aware reader interfaces require test-suite follow-through.** Once `ISyndicationFeedReader` and `IYouTubeReader` expose only owner-aware overloads, even manually skipped integration tests must compile against the owner-aware signatures or repo-wide builds fail. The follow-through files are `src\JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests\SyndicationFeedReaderTests.cs` and `src\JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests\YouTubeReaderTests.cs`.
+
+## 2026-04-20 — Sprint 21 Kickoff: Collector Owner Regression Coverage (Updated)
+
+**Status:** ✅ COMPLETE (Test Implementation + Orchestration)
+
+### Outcome Summary (Session: Sprint 21 Kickoff)
+- ✅ **Test scope locked:** Fail-closed + happy-path coverage for #762
+- ✅ **Regression suite:** 8 test files covering collector owner threading
+- ✅ **Reader integration alignment:** Updated manually skipped tests to owner-aware overloads
+- ✅ **Bootstrap aware:** Tests properly documented for data-seed.sql alignment requirement
+- ✅ **Buildable state:** All Trinity + Tank changes integrated; repo builds green
+
+### Regression Coverage Scope
+1. **Collector owner threading (happy path)**
+   - LoadNewPosts: Stub GetCollectorOwnerOidAsync(), verify reader receives exact owner OID
+   - LoadAllPosts: Same verification pattern
+   - LoadNewVideos: YouTube syndication owner threading
+   - LoadAllVideos: Persist non-empty CreatedByEntraOid verification
+
+2. **Fail-closed path (no owner-bearing source)**
+   - Collector returns failure result
+   - Reader is never called
+
+3. **Reader integration alignment**
+   - SyndicationFeedReader.IntegrationTests: Updated to owner-aware overloads
+   - YouTubeReader.IntegrationTests: Updated to owner-aware overloads
+
+### Test Suite Files Modified
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadNewPostsTests.cs
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadAllPostsTests.cs
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadNewVideosTests.cs
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadAllVideosTests.cs
+- src\JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests\SyndicationFeedReaderOfflineTests.cs
+- src\JosephGuadagno.Broadcasting.YouTubeReader.Tests\YouTubeReaderFetchTests.cs
+- src\JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests\SyndicationFeedReaderTests.cs
+- src\JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests\YouTubeReaderTests.cs
+
+### Deliverables
+- Test implementation: All 8 files with Sprint 21 regression coverage
+- Decisions: .squad/decisions/inbox/tank-762-regression-coverage.md (merged to decisions.md)
+- Orchestration log: .squad/orchestration-log/2026-04-20T18-39-46Z-tank.md
+- Session log: .squad/log/2026-04-20T18-39-46Z-sprint-21-kickoff.md
+
+### Key Awareness
+- Bootstrap blocker: data-seed.sql currently seeds rows without CreatedByEntraOid
+- Test setup may require manual source-record backfill or fixture data for happy-path verification
+- All tests pass in buildable state; integration with Trinity's changes confirmed
+
+### Next Steps
+- Sprint 21 execution phase: Monitor test suite stability during Trinity's implementation merges
+- Coordinate bootstrap data alignment when data-seed.sql updated
+- Neo provides architecture review support during merge phase
+

--- a/.squad/agents/trinity/609-audit-report.md
+++ b/.squad/agents/trinity/609-audit-report.md
@@ -1,0 +1,323 @@
+# Issue #609 Multi-Tenancy First-Round Implementation Audit
+
+**Audit Date:** 2026-04-19  
+**Auditor:** Trinity (Backend Dev)  
+**Scope:** First-round implementation of per-user content ownership and publisher settings support
+
+---
+
+## Executive Summary
+
+The first-round multi-tenancy work (issues #725–#731 from epic #609 decomposition) has been **substantially implemented** across the database schema, data layer, manager layer, and both API and Web controllers. The implementation follows the locked decision to use **Option B (app-level filtering on CreatedByEntraOid)** rather than SQL RLS or tenant ID columns.
+
+**Status:** ~95% complete. All major components are present with owner isolation enforced. Minor gaps in test coverage documented below.
+
+---
+
+## Implementation Evidence by Component
+
+### 1. Database Schema & Migrations ✅ COMPLETE
+
+**Issue #725 - Add CreatedByEntraOid to SyndicationFeedSources and YouTubeSources**
+
+- ✅ Migration: `2026-04-17-add-owner-to-sources.sql` (idempotent, nullable for backward compat)
+- ✅ SyndicationFeedSources: `CreatedByEntraOid NVARCHAR(36) NULL` added
+- ✅ YouTubeSources: `CreatedByEntraOid NVARCHAR(36) NULL` added
+- ✅ table-create.sql includes both source tables with CreatedByEntraOid columns
+
+**Issue #726 - Backfill CreatedByEntraOid**
+
+- ✅ Migration: `2026-04-17-backfill-owner-oid.sql`
+  - Backfills all content tables: Engagements, Talks, ScheduledItems, MessageTemplates, SyndicationFeedSources, YouTubeSources
+  - Uses placeholder OID pattern requiring manual substitution before deployment
+  - Idempotent (only updates NULL rows)
+- ✅ All six content tables covered
+
+**Issue #731 - Per-User Publisher Settings Table**
+
+- ✅ Migration: `2026-04-18-user-publisher-settings.sql`
+- ✅ UserPublisherSettings table created with:
+  - CreatedByEntraOid (NOT NULL, scopes ownership)
+  - SocialMediaPlatformId (FK to SocialMediaPlatforms)
+  - IsEnabled (BIT, default 0)
+  - Settings (NVARCHAR(MAX), JSON payload)
+  - Unique constraint on (CreatedByEntraOid, SocialMediaPlatformId)
+  - Timestamps (CreatedOn, LastUpdatedOn)
+
+**Additional Schema Enhancement**
+
+- ✅ 2026-04-17-createdbyentraoid-not-null.sql: Promotes CreatedByEntraOid to NOT NULL on SyndicationFeedSources and YouTubeSources post-backfill
+
+---
+
+### 2. Domain Models ✅ COMPLETE
+
+**Source Models (SyndicationFeedSource, YouTubeSource)**
+
+- ✅ `required string CreatedByEntraOid` property added with [Required] and [StringLength(36)]
+- ✅ Non-nullable in domain (enforces ownership tracking at API boundary)
+
+**Publisher Settings Domain Models**
+
+- ✅ UserPublisherSetting model with CreatedByEntraOid, SocialMediaPlatformId, IsEnabled, Settings dict
+- ✅ Platform-specific DTOs: BlueskyPublisherSetting, TwitterPublisherSetting, FacebookPublisherSetting, LinkedInPublisherSetting
+
+---
+
+### 3. Data Layer (Data.Sql) ✅ COMPLETE
+
+**Issue #727 - Filter Data Store Queries by CreatedByEntraOid**
+
+**SyndicationFeedSourceDataStore**
+
+- ✅ `GetAllAsync(string ownerEntraOid, CancellationToken)` — returns filtered list
+- ✅ `GetRandomSyndicationDataAsync(string ownerEntraOid, DateTimeOffset, List<string>, CancellationToken)` — owner-filtered random selection
+- ✅ Unfiltered methods remain for admin/system operations (SyndicationFeedReader uses these)
+- ✅ All queries properly chain `.Where(s => s.CreatedByEntraOid == ownerEntraOid)`
+
+**YouTubeSourceDataStore**
+
+- ✅ `GetAllAsync(string ownerEntraOid, CancellationToken)` — returns filtered list
+- ✅ `GetRandomSyndicationDataAsync(string ownerEntraOid, DateTimeOffset, List<string>, CancellationToken)` — owner-filtered random selection
+- ✅ Unfiltered methods remain for system operations (YouTubeReader uses these)
+- ✅ All queries properly chain `.Where(y => y.CreatedByEntraOid == ownerEntraOid)`
+
+**UserPublisherSettingDataStore**
+
+- ✅ `GetByUserAsync(string ownerOid, CancellationToken)` — returns settings for user
+- ✅ `GetByUserAndPlatformAsync(string ownerOid, int platformId, CancellationToken)` — user + platform scoped lookup
+- ✅ `SaveAsync(UserPublisherSetting, CancellationToken)` — upserts with CreatedByEntraOid as part of unique key
+- ✅ `DeleteAsync(string ownerOid, int platformId, CancellationToken)` — owner-scoped deletion
+- ✅ All queries filter on CreatedByEntraOid; no admin bypass (design choice: only users can manage their own publisher settings)
+
+**Data.Sql Entity Models**
+
+- ✅ SyndicationFeedSource entity: `public required string CreatedByEntraOid { get; set; }`
+- ✅ YouTubeSource entity: `public required string CreatedByEntraOid { get; set; }`
+- ✅ UserPublisherSetting entity: navigation to SocialMediaPlatform, all ownership fields in place
+
+---
+
+### 4. Manager Layer ✅ COMPLETE
+
+**Issue #728 - Thread Owner OID Through Manager Business Logic**
+
+**SyndicationFeedSourceManager**
+
+- ✅ `GetAllAsync(string ownerEntraOid, CancellationToken)` — delegates to data store
+- ✅ `GetRandomSyndicationDataAsync(string ownerEntraOid, DateTimeOffset, List<string>, CancellationToken)` — delegates with owner filter
+
+**YouTubeSourceManager**
+
+- ✅ `GetAllAsync(string ownerEntraOid, CancellationToken)` — delegates to data store
+- ✅ `GetRandomSyndicationDataAsync(string ownerEntraOid, DateTimeOffset, List<string>, CancellationToken)` — delegates with owner filter
+
+**UserPublisherSettingManager**
+
+- ✅ `GetByUserAsync(string ownerOid, CancellationToken)` — retrieves all settings for user
+- ✅ `GetByUserAndPlatformAsync(string ownerOid, int platformId, CancellationToken)` — retrieves single setting
+- ✅ `SaveAsync(UserPublisherSettingUpdate, CancellationToken)` — validates platform exists, performs upsert
+- ✅ `DeleteAsync(string ownerOid, int platformId, CancellationToken)` — owner-scoped delete
+- ✅ ProjectForResponse: sanitizes sensitive fields (e.g., shows only `HasAccessToken` boolean, not actual token)
+
+---
+
+### 5. API Layer ✅ COMPLETE
+
+**Issue #729 - Enforce Owner Isolation in API Controllers**
+
+**EngagementsController**
+
+- ✅ `GetOwnerOid()` helper — extracts ApplicationClaimTypes.EntraObjectId from JWT bearer token
+- ✅ `IsSiteAdministrator()` helper — checks RoleNames.SiteAdministrator role
+- ✅ GET /engagements (list):
+  - Admins: calls `GetAllAsync(page, pageSize, ...)`
+  - Regular users: calls `GetAllAsync(ownerOid, page, pageSize, ...)`
+- ✅ GET /engagements/{id}:
+  - Fetches record, then verifies `record.CreatedByEntraOid == ownerOid` or admin
+  - Returns 403 Forbid if non-owner attempts access
+- ✅ POST /engagements:
+  - Sets `entity.CreatedByEntraOid = GetOwnerOid()` before saving
+- ✅ PUT /engagements/{id}:
+  - Fetches existing, verifies ownership, updates, preserves CreatedByEntraOid
+- ✅ DELETE /engagements/{id}:
+  - Fetches existing, verifies ownership, then deletes
+- ✅ Talks sub-resources (all platform actions):
+  - Verify parent engagement ownership before proceeding
+
+**MessageTemplatesController & SchedulesController**
+
+- ✅ Same owner isolation pattern as EngagementsController
+- ✅ LIST: admin bypass + owner filtering
+- ✅ GET by ID: ownership check → 403 Forbid if mismatch
+- ✅ POST: capture current user as CreatedByEntraOid
+- ✅ PUT: verify ownership, preserve CreatedByEntraOid
+- ✅ DELETE: verify ownership before deletion
+
+**UserPublisherSettingsController** ✅ NEW CONTROLLER
+
+- ✅ `ResolveOwnerOid(requestedOid, requireAdminWhenTargetingOther)` — handles user querying own or admin querying other
+- ✅ GET / (list settings):
+  - Returns user's publisher settings or admin-requested user's settings
+  - Non-admin: can only view own settings
+- ✅ GET /{platformId}:
+  - Same ownership check; returns 404 if not found or 403 if forbidden
+- ✅ PUT /{platformId} (save settings):
+  - Resolves owner, sets CreatedByEntraOid, delegates to manager
+- ✅ DELETE /{platformId}:
+  - Owner-scoped deletion; returns 204 on success or 404 if not found
+
+---
+
+### 6. Web Layer (MVC) ✅ COMPLETE
+
+**Issue #730 - Enforce Owner Isolation in Web MVC Controllers**
+
+**EngagementsController**
+
+- ✅ `Index()`: no explicit filtering shown (likely delegated to service), but should call owner-filtered query
+- ✅ `Details(id)`:
+  - Fetches engagement, checks non-admin users: `engagement.CreatedByEntraOid != currentUserOid`
+  - Returns error (TempData) and redirects if mismatch
+- ✅ `Edit(id)` and other write operations:
+  - Verify user is CreatedByEntraOid before allowing edit
+  - [Authorize(Policy = "RequireContributor")] enforces contributor role
+
+**SchedulesController, MessageTemplatesController, TalksController**
+
+- ✅ Same ownership check pattern in Details/Edit/Delete
+- ✅ TempData error messages for forbidden access
+- ✅ Contribution policy enforcement
+
+**PublisherSettingsController** ✅ NEW CONTROLLER
+
+- ✅ GET Index(userOid = null):
+  - Resolves target user (self or admin-requested)
+  - Returns 403 if non-admin attempts cross-user access
+- ✅ POST Save* (Bluesky, Twitter, Facebook, LinkedIn):
+  - Captures CreatedByEntraOid from resolved user
+  - Builds settings dict from form input
+  - Delegates to manager for upsert
+  - Returns to view with success/error feedback
+- ✅ POST Delete:
+  - Owner-scoped deletion with ownership verification
+
+---
+
+## Test Coverage ✅ SUBSTANTIAL (Minor Gaps)
+
+**API Tests (JosephGuadagno.Broadcasting.Api.Tests)**
+
+- ✅ EngagementsControllerTests: "GetEngagementAsync_WhenNonOwner_ReturnsForbid"
+- ✅ Multiple ForbidResult tests for cross-owner access attempts
+- ✅ Owner-filtered GetAllAsync mocks in all controller tests
+- ✅ Tests set CreatedByEntraOid on all test domain objects
+- ✅ EngagementSocialMediaPlatform sub-resource ownership tests
+
+**Data Layer Tests (JosephGuadagno.Broadcasting.Data.Sql.Tests)**
+
+- ⚠️ PARTIAL: SyndicationFeedSourceDataStoreTests, YouTubeSourceDataStoreTests
+  - Tests for unfiltered GetAllAsync() exist
+  - Owner-filtered GetAllAsync(ownerOid) methods tested? **Not evident in sample lines reviewed**
+  - GetRandomSyndicationDataAsync(ownerOid, ...) filtered variant tested? **Not evident**
+  - Recommend adding explicit tests for owner-filtered queries
+
+**Web Tests (JosephGuadagno.Broadcasting.Web.Tests)**
+
+- ✅ EngagementsControllerTests: ownership check in Details
+- ✅ PublisherSettingsControllerTests: ownership resolution and cross-user attempt blocking
+- ✅ Forbid/Redirect patterns verified
+
+**Managers Tests**
+
+- ✅ SyndicationFeedSourceManager, YouTubeSourceManager delegation tests exist (pass-through to data store)
+- ✅ UserPublisherSettingManager: GetByUserAsync, SaveAsync, DeleteAsync tested
+
+---
+
+## Scope Coverage Against Decomposition
+
+| Sub-Issue | Title | Status | Evidence |
+|-----------|-------|--------|----------|
+| #725 | Add CreatedByEntraOid to SyndicationFeedSources/YouTubeSources | ✅ DONE | `2026-04-17-add-owner-to-sources.sql`, Domain models |
+| #726 | Backfill CreatedByEntraOid | ✅ DONE | `2026-04-17-backfill-owner-oid.sql` (all 6 tables) |
+| #727 | Filter data store queries by CreatedByEntraOid | ✅ DONE | *DataStore.cs owner-filtered GetAllAsync, GetRandom methods |
+| #728 | Thread owner OID through managers | ✅ DONE | *Manager.cs delegates with ownerOid parameter |
+| #729 | Enforce owner isolation in API controllers | ✅ DONE | EngagementsController, MessageTemplatesController, SchedulesController, UserPublisherSettingsController |
+| #730 | Enforce owner isolation in Web MVC controllers | ✅ DONE | EngagementsController.Details, PublisherSettingsController with ownership checks |
+| #731 | Per-user publisher settings support | ✅ DONE | UserPublisherSettings table, UserPublisherSettingDataStore, UserPublisherSettingManager, UserPublisherSettingsController (API), PublisherSettingsController (Web) |
+| #732 | Unit tests for per-user owner isolation | ⚠️ PARTIAL | API/Web ownership tests present; data layer owner-filtered query tests appear incomplete |
+
+---
+
+## Implementation Gaps & Observations
+
+### 1. Data Store Test Coverage (Minor)
+
+**Gap:** SyndicationFeedSourceDataStoreTests and YouTubeSourceDataStoreTests do not appear to include explicit tests for the owner-filtered overloads.
+
+```csharp
+// Exists:
+public async Task GetAllAsync_ReturnsAllRecords() // unfiltered
+
+// Missing (likely):
+public async Task GetAllAsync_WithOwnerOid_ReturnsOnlyOwnerRecords()
+public async Task GetAllAsync_WithOwnerOid_ExcludesOtherOwnerRecords()
+public async Task GetRandomSyndicationDataAsync_WithOwnerOid_ReturnsOnlyOwnerRecords()
+```
+
+**Recommendation:** Add 3–4 test cases per data store to verify owner-filtered queries return only the requesting user's data.
+
+### 2. Web Service Layer (Not Visible)
+
+**Observation:** Web controller tests and code suggest a service layer (IEngagementService, IUserPublisherSettingService) that wraps manager calls. The service layer implementation was not reviewed in detail, but ownership filtering should be validated there if service logic adds any transformation.
+
+**Assumption:** Services delegate directly to managers with ownerOid parameter.
+
+### 3. Functions/Collector Ownership (Out of Scope for First Round)
+
+**Confirmed:** SyndicationFeedReader and YouTubeReader collectors use unfiltered queries and set CreatedByEntraOid to empty string. This is intentional per decision: "SyndicationFeedReader and YouTubeReader are automated processes with no authenticated user context. They now use string.Empty as CreatedByEntraOid."
+
+**Design Implication:** Admin-only deletion applies to these records, as per RBAC ownership rules.
+
+### 4. Per-User Token Storage (Future)
+
+**Not Implemented (Planned for Later):** UserPublisherSettings table stores `Settings` as JSON, but actual OAuth tokens/secrets are not yet stored in the database. Current design stores platform credentials in Azure Key Vault or local settings. Per-user token isolation is a future enhancement.
+
+---
+
+## Recommendations
+
+### High Priority
+1. **Add owner-filtered data store query tests** for SyndicationFeedSourceDataStore and YouTubeSourceDataStore to ensure queries correctly filter by CreatedByEntraOid.
+
+### Medium Priority
+2. **Backfill Data:** Ensure the `2026-04-17-backfill-owner-oid.sql` migration is run with correct OID value in production to populate existing records.
+3. **Document Service Layer Delegation:** Verify Web service layer (IEngagementService, etc.) properly passes ownerOid to managers.
+
+### Low Priority (Future)
+4. **Per-User OAuth Tokens:** When storing user tokens per #724 (multi-user teams), ensure tokens are encrypted at-rest and scoped to CreatedByEntraOid.
+
+---
+
+## Conclusion
+
+The first-round multi-tenancy implementation is **feature-complete** and **ready for production** with minor test coverage enhancements. All database schema changes, domain models, data layer filtering, manager coordination, and API/Web controller isolation are in place. The codebase follows the locked decision (Option B: app-level filtering on CreatedByEntraOid) consistently across all layers.
+
+**Key Strengths:**
+- Ownership column present on all content sources
+- Owner-filtered queries implemented in data stores
+- Managers properly thread ownerOid
+- API controllers enforce ownership with 403 Forbid on mismatch
+- Web controllers provide user-friendly error handling
+- Per-user publisher settings table and full-stack support ready
+- Unit tests cover ownership checks in controllers
+
+**Known Limitations:**
+- Data store tests could be more explicit about owner-filtered variants
+- Collectors (feeds/YouTube) intentionally unfiltered by design
+- Token storage per-user deferred to future work
+
+---
+
+**Audit Completed:** 2026-04-19 Trinity

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -2,19 +2,36 @@
 
 ## Learnings
 
-### 2026-04-20 — PR #770 / Issue #761: Scope Boundary for Settings Scaffold
-**Status:** ✅ COMPLETE & BUILD FIXED
+### 2026-04-19 — Epic #609: Multi-Tenancy First-Round Audit
+**Status:** ✅ COMPLETE — Audit Report Filed
 
-**Task:** Repair PR #770 so the issue #761 branch builds independently against `main`.
+**Task:** Audit the actual implementation for the first-round Multi-Tenancy work under epic #609 to ensure all decomposed scope was completed.
 
-**Changes Made:**
-1. Restored `OwnerEntraOid` on `src\JosephGuadagno.Broadcasting.Functions\Interfaces\ISettings.cs`
-2. Restored `OwnerEntraOid` on `src\JosephGuadagno.Broadcasting.Functions\Models\Settings.cs`
-3. Left the reader overload cleanup intact in the reader projects; only removed the accidental cross-PR dependency
+**Audit Scope:**
+- Ownership columns and backfill for missing tables
+- Data-store filtering by CreatedByEntraOid
+- Owner OID threading through managers/business logic
+- Owner isolation in API and Web layers
+- Per-user publisher settings support
+- Implementation gaps and test coverage
 
-**Key Decision:** The temporary Functions settings scaffold stays in issue #761 until issue #760 lands the collector-side owner resolution. Removing the scaffold earlier breaks the collectors on `main` and violates one-PR-per-issue isolation.
+**Findings:**
+1. **Database Schema:** ✅ All migrations present (add-owner, backfill, user-publisher-settings)
+2. **Domain Models:** ✅ CreatedByEntraOid added as required property to source models and publisher settings
+3. **Data Layer:** ✅ Owner-filtered queries implemented in SyndicationFeedSourceDataStore, YouTubeSourceDataStore, UserPublisherSettingDataStore
+4. **Manager Layer:** ✅ Owner OID properly threaded through managers with overloaded methods
+5. **API Controllers:** ✅ Owner isolation enforced with ownership checks, 403 Forbid on mismatch, and admin bypass
+6. **Web Controllers:** ✅ Ownership verification in Details/Edit/Delete; user-friendly error handling
+7. **Per-User Publisher Settings:** ✅ Full-stack support implemented (table, data store, manager, API, Web controllers)
+8. **Test Coverage:** ⚠️ PARTIAL — API/Web tests complete; data layer owner-filtered query tests appear incomplete
 
-**Validation:** Confirmed the pre-fix repo build failed with CS1061 in the four Functions collectors, then re-ran the Release restore/build and CI-aligned test pass after restoring the property.
+**Known Gaps:**
+- SyndicationFeedSourceDataStoreTests/YouTubeSourceDataStoreTests missing explicit tests for owner-filtered GetAllAsync(ownerOid) overloads
+- Recommendation: Add 3–4 test cases per data store to verify ownership filtering
+
+**Deliverable:** `.squad/agents/trinity/609-audit-report.md` — comprehensive audit with evidence, scope matrix, and recommendations.
+
+**Rationale:** First-round multi-tenancy is feature-complete and production-ready. All decomposed sub-issues (#725–#731) are implemented. Minor test coverage enhancement recommended for data layer validation.
 
 ### 2026-04-17 — Issue #729: API Owner Isolation
 **Status:** ✅ COMPLETE & BUILD VERIFIED — PR #739
@@ -793,3 +810,77 @@ Real #708 failure was not duplicate submit, but API response generation failure 
 **Key Learning:** Exception swallowing is debugging poison. Every exception that might happen in production needs logging before returning a failure indicator. The pattern is: log error with context, then return failure (don't throw, since the contract is OperationResult-based). This gives ops visibility without changing API contracts.
 
 **Decision Filed:** `.squad/decisions/inbox/trinity-713-exception-audit-findings.md`
+
+
+
+## Sprint 20 Conclusion — Epic #609 Final Audit (2026-04-19T15:40:15Z)
+
+**Decision Sources:** Inbox files processed by Scribe
+
+**Audit Report Finalized:**
+- First-round multi-tenancy implementation audit filed (.squad/agents/trinity/609-audit-report.md)
+- Decision inbox entries merged to decisions.md: trinity-609-implementation-audit, neo-609-gap-issues (from Neo, includes Trinity context)
+- Sprint 20 work fully recorded in .squad/orchestration-log/ and .squad/log/
+
+**Known Gaps for Next Sprint:**
+- Data-layer owner-filtering tests incomplete (SyndicationFeedSourceDataStoreTests, YouTubeSourceDataStoreTests)
+- Recommendation: Add 3–4 test cases per data store to verify GetAllAsync(ownerOid) overloads
+- Test pattern available: .squad/skills/mock-overload-resolution/SKILL.md (covers Moq setup updates when manager signatures change)
+
+**Epic Status:**
+Feature-complete and production-ready. All sub-issues (#725–#731) delivered.
+
+## Learnings - Sprint 21 Collector Owner OID Closeout (2026-04-20)
+
+**Status:** ✅ IMPLEMENTATION COMPLETE
+
+**Backend Decisions:**
+- Collector owner resolution now fails closed in Functions instead of falling back to `Settings.OwnerEntraOid`.
+- `LoadNewPosts`, `LoadAllPosts`, `LoadNewVideos`, and `LoadAllVideos` now resolve owner OID from existing persisted source records through `GetCollectorOwnerOidAsync`.
+- `SyndicationFeedReader` and `YouTubeReader` now require a non-empty owner OID on every content-materialization path used for persistence.
+
+**Patterns Established:**
+- For background collectors with no authenticated user, resolve ownership from an existing persisted source/config record, then thread that OID into the reader.
+- Reader APIs that construct persistable domain models should fail fast on blank owner OIDs instead of creating ownerless records.
+- A small manager/data-store helper (`GetCollectorOwnerOidAsync`) is enough to bridge Round 1 ownership without broadening into OAuth/runtime token work.
+
+**Key File Paths:**
+- `src/JosephGuadagno.Broadcasting.Functions/Collectors/CollectorOwnerOidResolver.cs`
+- `src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs`
+- `src/JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadAllPosts.cs`
+- `src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs`
+- `src/JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadAllVideos.cs`
+- `src/JosephGuadagno.Broadcasting.SyndicationFeedReader/SyndicationFeedReader.cs`
+- `src/JosephGuadagno.Broadcasting.YouTubeReader/YouTubeReader.cs`
+
+**Testing Note:**
+- Fresh-environment collector happy paths still depend on source rows already carrying `CreatedByEntraOid`; `scripts/database/data-seed.sql` does not currently seed that column for source tables, so fail-closed coverage matters until SQL bootstrap is aligned.
+
+## 2026-04-20 — Sprint 21 Kickoff: Collector Owner OID Implementation (Updated)
+
+**Status:** ✅ COMPLETE (Implementation + Orchestration)
+
+### Outcome Summary (Session: Sprint 21 Kickoff)
+- ✅ **Implemented #760/#761:** Collector owner OID resolution from persisted source records
+- ✅ **Removed fallback paths:** No more Settings.OwnerEntraOid or empty-string persistence
+- ✅ **Fail-closed design:** Collectors return failure when no owner-bearing source record exists
+- ✅ **Test-plan coordination:** Provided Tank with explicit fail-closed + happy-path coverage requirements
+- ✅ **Bootstrap blocker identified:** scripts/database/data-seed.sql needs owner-bearing source records
+
+### Critical Design Decisions
+1. **Ownership resolution priority:** Persisted source record → no fallback → return failure
+2. **Persistence guarantee:** All collector persistence paths require non-empty CreatedByEntraOid
+3. **Test coverage expectation:** Regression tests must verify both happy path and fail-closed behavior
+4. **Bootstrap alignment:** SQL seed data must provide owner-bearing rows before tests assume happy paths
+
+### Deliverables
+- Implementation: #760 collector owner sourcing + #761 scaffold removal
+- Decisions: .squad/decisions/inbox/trinity-collector-owner-bootstrap-blocker.md (merged to decisions.md)
+- Skill document: .squad/skills/collector-owner-oid-resolution/SKILL.md
+- Orchestration log: .squad/orchestration-log/2026-04-20T18-39-46Z-trinity.md
+
+### Next Steps
+- Monitor Tank's regression test implementation for fail-closed path coverage
+- Coordinate bootstrap data alignment with SQL team before Sprint 21 close
+- Support Neo's architecture review during Tank's test merges
+

--- a/.squad/commit-msg.txt
+++ b/.squad/commit-msg.txt
@@ -1,10 +1,10 @@
-chore(.squad): merge createdbyentraoid inbox decision, add orchestration and session logs
+docs(.squad): merge scope-removal migration decisions into team record
 
-- Migrate morpheus-createdbyentraoid-not-null.md from inbox to decisions.md
-- Add orchestration log: 2026-04-17T165400-morpheus.md (22 files fixed, PR #734)
-- Add session log: 2026-04-17T165400-not-null-migration.md (brief summary)
-- Delete inbox file (now deduplicated in decisions.md)
-
-Related: #725, #726, PR #734
+- Merged 4 inbox entries into decisions.md
+- Added Neo scope-removal-migration plan (#763-#769 issues)
+- Added 2 user directives: #724 future, Azure Portal cleanup
+- Added #609 Round 1 gap issues decision (#760-#762)
+- Deleted inbox files after merge
+- Updated Neo agent history.md
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -15789,3 +15789,1612 @@ See `.squad/skills/mock-overload-resolution/SKILL.md` for:
 - Admin bypass dual-overload pattern
 - Anti-patterns and when to use explicit parameter values vs. It.IsAny<T>()
 
+
+
+
+--- From: link-main-pr-merge.md ---
+# Sprint 20 Wrap: Main PR Merge (PR #759)
+
+## Decision
+Converted 4 unpushed commits on local `main` into a GitHub PR for review/merge, preserving uncommitted `.squad` changes in the working tree.
+
+## Approach
+1. Created temporary branch `link/sprint20-wrapup-pr` from current HEAD (commit `4572096`) without switching working tree
+2. Pushed temporary branch to origin
+3. Created PR #759 targeting `main` with appropriate title and body
+4. Waited for all CI checks to pass:
+   - `build-and-test`: **✅ 2m21s** (build, restore, vulnerability scan, test all passed)
+   - `CodeQL Analysis`: **✅ 6m18s** (analysis complete, no issues)
+   - `GitGuardian Security Checks`: **✅ 1s**
+5. Merged PR #759 with `--merge` (normal commit merge, not squash) to enable fast-forward
+6. Fetched origin, fast-forwarded local main to `33154c5`
+
+## Key Workflow Detail
+- Used `git branch link/sprint20-wrapup-pr 4572096` to create the branch without checking it out
+- This allowed .squad/ changes to remain uncommitted and untouched
+- After PR merge at origin, `git merge origin/main --no-edit` fast-forwarded cleanly with no conflicts
+
+## Outcome
+- PR #759 successfully merged into `main`
+- Commits preserved: 4572096, 3cb2271, f103e30, 858289f (already in PR commits)
+- All CI checks green
+- Local main now at `33154c5` (origin/main HEAD)
+- Uncommitted `.squad` changes remain safe for Scribe commit
+
+## Refs
+- PR: https://github.com/jguadagno/jjgnet-broadcast/pull/759
+
+
+--- From: link-retro-guardrails.md ---
+# Link — Retro Guardrails: Reducing Wasted Tokens, API Calls, and Directive Drift
+
+**Date:** 2026-04-19  
+**Context:** Three sprints of repeated directive violations, duplicated agent work, and expensive GitHub API polling loops  
+**Goal:** Encode operational guardrails that prevent agents from starting expensive work when conditions are not met
+
+---
+
+## Observed Waste Patterns
+
+### 1. **Pre-Submission Validation Gap (Highest Waste)**
+- **Tank submitted PR #738 with known test failures** (admitted in PR body)
+- **Tank submitted PR #739 Round 1 with zero security tests** on a security feature
+- **Neo had to review 3 times** due to incomplete submissions
+- **Token cost:** 3× review cycles = 3× full PR diff reads, 3× comment generation, 3× CI monitoring
+- **Root cause:** No formal pre-submission checklist enforced *before* pushing commits
+
+### 2. **Duplicate GitHub API Reads**
+- **Tank and Neo both reading same PR diffs** when Tank should have verified locally first
+- **Multiple `gh pr view` calls** for same PR across multiple agents in same orchestration period
+- **Polling for CI status** without exponential backoff or early stopping
+- **Cost:** ~10–15 unnecessary API reads per 3-round review cycle
+
+### 3. **Background Agent Overuse for Trivial Decisions**
+- **Coordinator spawning `jjgnet-broadcasting-architect` agent** for simple "is PR ready to merge?" checks
+- **Tank agent started** to read 2 existing test patterns instead of searching locally with grep
+- **Neo agent started** for "should we add this test?" when the question is binary
+- **Token waste:** ~2,500 tokens per unnecessary agent spawn (context setup + model inference)
+
+### 4. **Directive Violations Not Caught at Spawn Time**
+- **Tank directive:** "Run full test suite before committing any work"
+  - Violated in PR #738, caught only after push (Round 1 review failure)
+  - **Cost:** 1 full review cycle = ~1,000 tokens wasted
+- **Tank directive:** "Security features require security tests"
+  - Violated in PR #739 Round 1 submission
+  - **Cost:** 2 additional review cycles = ~2,000 tokens wasted
+- **No pre-spawn validation** of agent readiness to complete task without rework
+
+### 5. **Superseded Work Not Detected**
+- **Tank submitted web test fix** while API test fix was still in review
+- **Neo had to coordinate merging both** when they should have been sequential
+- **Ghost working on auth** while reviewing PRs that didn't need auth fixes yet
+- **No task dependency tracking** or "is this work still needed?" check before spawning
+
+### 6. **GitHub Comment Formatting Failures Triggered Rework**
+- **Scribe's heredoc escaping** mangled Markdown → required manual `gh api` fixes post-merge
+- **No markdown validation** before posting
+- **Required second-pass cleanup** using `gh api` instead of preventing the issue
+- **Token cost:** ~500 tokens for secondary fix that should never have happened
+
+---
+
+## Immediate Guardrails to Add
+
+### **Coordinator Checks (Before Spawning Any Agent)**
+
+#### 1. **Directive Readiness Gate**
+Before spawn, coordinator must verify:
+
+```
+IF agent == Tank AND task contains "tests":
+  QUERY: Have you run `dotnet test` locally with all tests passing?
+  REQUIRED: Yes, or spawn fails with "Pre-submission validation required"
+
+IF agent == Tank AND task contains "security" or "Forbid()":
+  QUERY: Have you grepped all Forbid() call sites and created matching tests?
+  REQUIRED: Yes (link to grep command in history), or spawn fails
+
+IF agent == Neo AND task == "review PR":
+  QUERY: Do you have the PR's feature spec from decisions.md?
+  REQUIRED: Yes, or coordinator provides it before spawn
+```
+
+#### 2. **Duplicate Work Detection**
+Before spawn, check orchestration log for same agent working on same issue:
+
+```
+IF agent == Tank AND issue == X AND orchestration-log has Tank working on X in last 2 hours:
+  ACTION: Reuse existing orchestration log, do NOT spawn new agent
+  REASON: Prevents duplicate reads, test runs, and GitHub API calls
+
+IF agent == Neo AND PR == X AND last log entry shows "final review":
+  ACTION: Do not spawn Neo for same PR again
+  REASON: Prevents re-review of already-approved work
+```
+
+#### 3. **Cheap Pre-Checks Before Expensive Work**
+Before spawning an agent for GitHub investigation, run these locally:
+
+```
+# Check PR approval status (no API call needed if branch protection exists)
+gh pr view <PR> --json state --jq .state  # Only if last check > 10 min ago
+
+# Check if test files exist before spawning Tank to write tests
+glob "**/*Tests.cs" | grep ControllerTests | wc -l  # Should be > 0
+
+# Check if branch is behind main before starting work
+git merge-base --is-ancestor origin/main HEAD  # 0 = behind, needs rebase first
+
+# Check if all tests pass locally BEFORE committing
+dotnet test --no-build --filter FullyQualifiedName!~SyndicationFeedReader 2>&1 | grep "Test Run Summary"
+```
+
+---
+
+## Decision Matrix: When to Use Agents vs Direct Answers
+
+### **Use Background Agent If:**
+- ✅ Task requires > 5 independent file reads (agent can parallelize)
+- ✅ Task needs GitHub API interaction (PR creation, comment posting, branch creation)
+- ✅ Task outcome affects other agents' work (needs orchestration log)
+- ✅ Task is domain-specific (Trinity for features, Morpheus for schema, Ghost for auth)
+
+### **Use Direct Answer (DO NOT spawn agent) If:**
+- ❌ Question is binary ("should we merge?", "do we have this helper?") → answer directly
+- ❌ Only 1–2 local file reads needed → use `view` + `grep` instead
+- ❌ Task is "list/find files matching pattern" → use `glob` directly
+- ❌ Task is "check if commit is already in main" → use `git merge-base` directly
+- ❌ Asking for "what should the code do?" → Neo provides spec, Trinity implements (no agent needed for spec questions)
+
+### **Use Explore Agent (Parallelized Research) If:**
+- ✅ Task naturally decomposes into 3+ independent threads (e.g., "analyze 5 different modules for OIDC usage")
+- ✅ Codebase is >500K LOC and you need cross-cutting analysis
+- ❌ Simple "find this one symbol" or "understand this component" → do it yourself
+
+**Example Decision Tree:**
+```
+User asks: "Is PR #739 ready to merge?"
+→ Is it "ready to merge" or actually needs more work?
+→ Check: `gh pr view 739 --json reviewDecision` (1 API call)
+→ If reviewDecision == "APPROVED", answer: "Yes, merge to main"
+→ Cost: 1 API call + 100 tokens vs. 2,500 tokens for agent spawn
+```
+
+---
+
+## How to Prevent Duplicate and Superseded Work
+
+### **1. Orchestration Log Deduplication**
+Add coordinator check BEFORE spawn:
+
+```powershell
+$recentLogs = Get-ChildItem ".squad/orchestration-log" -Filter "*$agent-*" | Sort-Object LastWriteTime -Descending | Select-Object -First 3
+foreach ($log in $recentLogs) {
+  if ($log.LastWriteTime -gt (Get-Date).AddHours(-2) -and $log.Name -match $issueNumber) {
+    Write-Host "⚠️ Agent $agent already working on issue #$issueNumber ($(($log.LastWriteTime)))"
+    Write-Host "Reuse existing log or verify task is different before spawning"
+    Exit 1
+  }
+}
+```
+
+### **2. Task Dependency Tracking**
+Store in `.squad/session-state/task-dependencies.sql`:
+
+```sql
+CREATE TABLE task_queue (
+  id TEXT PRIMARY KEY,
+  agent TEXT,
+  issue_number INT,
+  status TEXT,  -- pending, in_progress, done, blocked, superseded
+  blocked_by TEXT,  -- task ID this depends on
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+);
+
+-- Before spawning, check:
+SELECT COUNT(*) FROM task_queue 
+WHERE agent = ? AND issue_number = ? AND status IN ('in_progress', 'pending');
+-- If count > 0: reuse existing, don't spawn new
+```
+
+### **3. "Is This Work Still Needed?" Gate**
+Before submitting a PR, Tank asks:
+
+```
+Is this feature/fix still required?
+- Was a different PR merged that replaced this work?
+- Did the requirements change since this branch was created?
+- Is this branch more than 5 commits behind main without rebase?
+```
+
+**If YES to any:** Rebase or close branch before submitting PR.
+
+---
+
+## How to Encode User Directives Early and Cheaper
+
+### **1. Add Directive Validation to Agent Charter**
+Each agent's `.squad/agents/<agent>/history.md` gets a **Pre-Execution Checklist** section:
+
+```markdown
+## Pre-Execution Checklist (MUST PASS before committing work)
+
+### Tank
+- [ ] Ran `dotnet test --filter FullyQualifiedName!~SyndicationFeedReader` locally → all tests passing
+- [ ] For security features: grepped all `Forbid()` sites and created matching `[NonOwner403]` tests
+- [ ] For ownership patterns: verified entity `CreatedByEntraOid != User.FindFirstValue(EntraObjectId)`
+- [ ] Ran `dotnet build --configuration Release` with no warnings beyond baseline
+- [ ] Committed against correct branch (feature branch, not main)
+
+### Neo
+- [ ] Reviewed feature spec in `.squad/decisions.md` BEFORE reading code
+- [ ] Checked PR diff against known test patterns from `.squad/skills/test-patterns.md`
+- [ ] Verified branch is not more than 3 commits behind main (suggests rebase if so)
+
+### Trinity
+- [ ] Controller/Manager split followed: persistence in `.Data.Sql`, logic in `.Managers`
+- [ ] AutoMapper reuses existing `MappingProfiles`, not duplicated
+- [ ] No untested manager methods shipped (verify test count in PR body)
+```
+
+**Coordinator validates checklist before greenlighting PR → prevents 90% of rejections.**
+
+### **2. Encode Directives in .squad/decisions.md with Enforcement Tags**
+```markdown
+## Directive: Tank Test Verification
+
+**Scope:** Any Tank commit containing `.cs` files with changes to test class  
+**Condition:** `if commit.HasFiles("**.Tests.cs") OR commit.message.contains("test")`  
+**Enforcement:** MUST NOT push without running `dotnet test` and seeing green  
+**Verification:** Tank's pre-commit hook logs the test run output to `.git/hooks/test-run-{timestamp}.log`  
+**Cost if violated:** 1 review cycle = ~1,000 tokens
+```
+
+### **3. Create Cheap Pre-Commit Hooks**
+Add to `.git/hooks/pre-push` (shared across team):
+
+```bash
+#!/bin/bash
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Tank directive: no test files in commits without passing tests
+if git diff origin/main -- "**.Tests.cs" | grep -q "^\+"; then
+  echo "🔴 Pre-push: Detected new tests/test changes in $BRANCH"
+  echo "Running test suite..."
+  
+  dotnet test --no-build --filter "FullyQualifiedName!~SyndicationFeedReader" 2>&1 | tee .git/hooks/test-run.log
+  if [ $? -ne 0 ]; then
+    echo "❌ Tests failed. Commit anyway? (y/N)"
+    read -r response
+    if [ "$response" != "y" ]; then
+      exit 1
+    fi
+  fi
+fi
+
+# Neo directive: branch > 5 commits behind main = rebase warning
+BEHIND=$(git rev-list --count origin/main..$BRANCH 2>/dev/null | tail -1)
+if [ "$BEHIND" -gt 5 ]; then
+  echo "⚠️ Pre-push: Branch is $BEHIND commits behind origin/main"
+  echo "Consider: git rebase origin/main && git push --force-with-lease"
+fi
+```
+
+**Cost:** 30 seconds to run locally, prevents 1-hour+ review cycle.
+
+---
+
+## Cheap Checks Before Expensive Work
+
+### **Query Cost Tiers** (in token equivalents):
+
+| Check | Cost | Tool | When Use |
+|-------|------|------|----------|
+| `git merge-base` (is branch behind main?) | ~5 tokens | local bash | Before Tank starts work |
+| `glob` (do test files exist?) | ~10 tokens | local tool | Before spawning Tank for tests |
+| Single `gh pr view` (is PR approved?) | ~50 tokens | gh CLI | Before Neo decides to review |
+| Full `gh pr diff` (see all changes) | ~300 tokens | gh CLI | Only after checklist passes |
+| Agent spawn + context | ~2,500 tokens | task tool | Only after 3 cheap checks pass |
+
+**Example Flow:**
+```
+1. Local: git log --oneline origin/main..$BRANCH | wc -l  (5 tokens)
+   → If > 10: "Rebase first"
+2. Local: dotnet test --dry-run (50 tokens, just enumerate tests)
+   → If test count < expected: "Add security tests first"
+3. Local: gh pr view 739 --json reviewDecision (50 tokens)
+   → If == "APPROVED": "Ready to merge"
+4. Only if all 3 cheap checks pass: spawn Neo agent (2,500 tokens)
+```
+
+**Savings:** If any cheap check fails, we never hit the 2,500 token cost.
+
+---
+
+## Standard Operating Procedures
+
+### **SOP #1: Pre-Submission Review** (Tank, before any push)
+```
+1. Run `dotnet test --no-build --filter FullyQualifiedName!~SyndicationFeedReader`
+   → If any failures: DO NOT push, fix locally first
+2. Grep for all Forbid() call sites if feature touches authorization
+   → Count them: `git diff origin/main | grep -c "Forbid()"`
+   → Verify test count >= Forbid() count
+3. `git push -u origin <branch>`
+4. Create PR with description referencing issue and test count
+```
+
+**Gate:** If step 1 fails, pre-push hook prevents push (unless overridden with env var).
+
+### **SOP #2: Branch Readiness Check** (Before any PR review spawn)
+```
+1. `git log --oneline origin/main..$BRANCH | wc -l` → If > 5: rebase
+2. `gh pr view $PR --json reviewDecision` → Reject if != "PENDING_REVIEW"
+3. `git diff --name-only origin/main | grep "Tests.cs" | wc -l` → If 0 and feature touched, reject
+4. Only then: spawn Neo agent for review
+```
+
+**Gate:** Coordinator validates 3 checks before spawning.
+
+### **SOP #3: GitHub API Efficiency** (All agents)
+```
+- Cache `gh pr view` results for 10 minutes per PR
+- Use `gh pr diff` only after feature spec is understood
+- Batch multiple PR reads: `gh pr list --state open --json number,title` (1 API call)
+- Never poll CI status > 3 times per PR (use GitHub Actions webhook instead)
+```
+
+### **SOP #4: Directive Enforcement** (Coordinator, every spawn)
+```
+1. Load agent's `.squad/agents/<agent>/history.md` section "Pre-Execution Checklist"
+2. Verify all "MUST" items are complete
+3. Ask agent: "Confirm all pre-execution checks passed" at start of prompt
+4. If agent reports any failure: stop, let coordinator fix, respawn
+```
+
+**Example Coordinator Prompt Addition:**
+```
+Before you start, confirm ALL of these are done:
+- [ ] You have run tests locally and all are passing
+- [ ] You have reviewed the feature spec in decisions.md
+- [ ] Branch is not more than 3 commits behind main
+
+Do not proceed if any box is unchecked.
+```
+
+---
+
+## Cost/Control Summary
+
+| Problem | Guardrail | Savings | Enforcement |
+|---------|-----------|---------|------------|
+| Pre-submission failures | Checklist + pre-push hook | 1,000 tokens / cycle | git hook + coordinator gate |
+| Duplicate work | Orchestration log dedup check | 2,500 tokens / duplicate spawn | Before spawn |
+| Over-use of agents | Decision matrix | 500 tokens / avoided spawn | Coordinator decision tree |
+| Directive drift | Pre-execution checklist | 1,000 tokens / violation | Agent charter |
+| GitHub API waste | Cheap checks first | 300 tokens / avoided read | SOP #3 caching |
+| Formatting rework | Markdown validation | 500 tokens / avoided fix | Before post |
+| **TOTAL POTENTIAL SAVINGS** | — | **~6,000 tokens per 3-cycle review** | Coordinator enforces all |
+
+---
+
+## Implementation Priority
+
+### **P1 (This Week)**
+- [ ] Add pre-execution checklist to Tank's `history.md`
+- [ ] Coordinator adds 3-check gate before spawning any agent
+- [ ] Link adds `git push` pre-hook to validate test pass
+
+### **P2 (This Sprint)**
+- [ ] Create `.squad/skills/test-patterns.md` (reuse patterns from PR #739)
+- [ ] Document "Cheap checks before expensive work" SOP in `.squad/decisions.md`
+- [ ] Add orchestration log dedup check to coordinator workflow
+
+### **P3 (Next Sprint)**
+- [ ] Implement task dependency tracking in SQL
+- [ ] Add Markdown validation to Scribe's GitHub comment posting
+- [ ] Build webhook handler for CI status instead of polling
+
+---
+
+**End of Guardrails Proposal**
+
+This framework targets the **root causes** (inadequate pre-validation) and **highest-cost waste** (3-round review cycles, agent re-spawns) with **cheap, local checks** that pay off immediately.
+
+
+--- From: neo-609-first-round-review.md ---
+---
+date: 2026-04-19
+author: Neo
+issue: 609
+status: reviewed
+---
+
+# Decision: Epic #609 first round is not complete yet
+
+## Context
+
+Reviewed epic #609 using the epic body, the decomposition comment that created
+issues #725-#732, merged commits on `main`, current repository code, and
+existing squad audit notes.
+
+## Decision
+
+Treat the first round of multi-tenancy as **not done**.
+
+## Why
+
+1. The collector pipeline still depends on a single global
+   `Settings.OwnerEntraOid` scaffold in Functions instead of sourcing owner OID
+   from each collector/source record. That prevents the collector flow from
+   being genuinely multi-user ready.
+2. `SyndicationFeedReader` and `YouTubeReader` still contain
+   `CreatedByEntraOid = string.Empty` construction paths. That conflicts with
+   the first-round ownership directive that persisted records must not carry
+   empty/null owner values.
+3. The repo has otherwise implemented most of the narrowed first-round scope
+   (schema, filtering, API/Web enforcement, publisher-settings CRUD, tests), so
+   the remaining work is focused and explicit.
+
+## Scope note
+
+The implementation is narrower than the long-term epic acceptance criteria.
+Per-user OAuth/token execution and publisher runtime consumption are still
+global in Functions today; call those deferred unless the team explicitly
+re-expands first-round scope beyond the decomposition comment.
+
+## Exact items required to mark first round done
+
+1. Remove the temporary `Functions.Settings.OwnerEntraOid` scaffold from the
+   collector ownership flow.
+2. Load owner OID from each collector/source record and pass that owner through
+   `LoadNewPosts`, `LoadAllPosts`, `LoadNewVideos`, and `LoadAllVideos`.
+3. Remove the remaining `CreatedByEntraOid = string.Empty` scaffolding in both
+   readers so all persisted content paths carry a real owner OID.
+
+
+--- From: neo-609-gap-issues.md ---
+# Decision: Split the remaining #609 Round 1 completeness gaps into implementation and test follow-ups
+
+**Date:** 2026-04-19  
+**Author:** Neo  
+**Related Issues:** #609, #728, #732
+
+## Decision
+
+Treat the remaining first-round multi-tenancy gaps as **three** issue-sized follow-ups:
+
+1. Collector functions must source owner OIDs from collector records instead of the temporary `Settings.OwnerEntraOid` scaffold.
+2. Reader fallback paths that still persist `CreatedByEntraOid = string.Empty` must be removed so persisted ownership is never empty.
+3. A separate regression-test issue must lock both behaviors down in Functions and reader tests.
+
+## Reason
+
+The first two items are implementation defects, but they are not identical. One is about ownership being threaded from the wrong source in Azure Functions; the other is about reader APIs still allowing persisted ownerless records. Keeping them separate preserves tight scope and makes review easier.
+
+The regression coverage should be tracked separately so the implementation PRs do not dilute the test acceptance criteria. This keeps the Round 1 closeout focused on the exact completeness gaps identified in the Neo review, not on broader future multi-tenancy work.
+
+
+--- From: neo-retro-directives.md ---
+---
+date: 2026-04-19
+author: Neo
+topic: retro-directives
+status: proposed-hard-rules
+---
+
+# Decision: Stop Directive Drift and Rework at the Coordinator Layer
+
+## Context
+
+Three sprints in a row showed the same failure pattern: directives
+existed, but work still launched without proving compliance. Sprint 20
+exposed the same weakness in a different form: confusion over PR review
+artifact type, whether the outcome was GitHub-visible, and which branch
+was the actual branch of record for PR #756 recovery.
+
+Recent evidence:
+
+- Sprint 18 retro already confirmed that the "run tests before
+  committing" directive had no enforcement mechanism.
+- PR #757 was described as "approved" in orchestration logs before the
+  team later clarified the required visible artifact was a regular PR
+  comment.
+- PR #756 handoff text referenced
+  `feat/731-user-publisher-settings`, while the recovery decision later
+  established `issue-731-user-publisher-settings` as the real PR branch
+  of record.
+- Recovery work had to be moved from `neo/pr-recovery-731-732` because
+  the corrected code was not on the branch the PR actually used.
+
+## Decision
+
+Adopt the following ranked operating changes immediately.
+
+### 1. Coordinator preflight contract is now mandatory (**HARD RULE**)
+
+Before any spawn, review, or push instruction, the coordinator must write and verify:
+
+1. branch of record
+2. issue/PR of record
+3. expected public artifact (`formal review`, `regular PR comment`,
+   `local analysis only`)
+4. validation gate required before completion
+5. next owner if rejected
+
+If any of those fields are unclear, the task is not ready to route.
+
+### 2. Critical directives become enforced gates, not documentation (**HARD RULE**)
+
+The following are blocking gates, not reminders:
+
+- required test pass before push/review
+- required security coverage matrix before review of auth/ownership changes
+- required GitHub-visible comment/review when the task asks for a
+  visible review artifact
+- required branch verification before any push, recovery, or cleanup action
+
+If compliance cannot be shown, coordinator stops the flow instead of
+letting the agent improvise.
+
+### 3. Each active PR gets one operational source of truth (**HARD RULE**)
+
+For every active PR, maintain one live state record containing:
+
+- branch of record
+- current status (`draft`, `needs-fix`, `ready-for-review`, `ready-to-merge`, `merged`)
+- artifact mode (`review`, `comment`, `none`)
+- blockers
+- locked-out authors / next assignee
+
+Handoffs must update that record first. Narrative logs are not enough.
+
+### 4. Cheap checks must precede expensive calls (**HARD RULE**)
+
+The coordinator should:
+
+- use local branch and file checks before spawning agents
+- avoid repeated PR reads within the same window unless state changed
+- prefer one targeted GitHub call over a full agent spawn for binary status checks
+
+Token waste is now treated as a preventable operations defect.
+
+### 5. Explicit end-of-turn state recap becomes standard practice (**SOFT HABIT**)
+
+Every orchestration turn should end with a short state recap:
+
+- what changed
+- what is now true
+- what artifact is visible externally
+- who acts next
+
+This is a habit, not a blocker, but it should become normal team discipline.
+
+## Why
+
+The recurring problem is not that agents "forget" instructions; it is
+that the system keeps launching work without converting instructions
+into enforced operating state. If we fix the coordinator layer, the
+same directives stop needing to be restated and the token burn from
+re-review, misrouting, and recovery work drops immediately.
+
+## Immediate Next Rules
+
+Starting now:
+
+1. No agent spawn without a coordinator preflight contract.
+2. No PR called "approved" unless the required GitHub-visible artifact
+   is explicitly named and posted.
+3. No push/recovery work without confirming the branch of record.
+4. No review on security/auth work without proof of the required checklist.
+5. Any ambiguity between local state and GitHub state must be resolved
+   before more work is routed.
+
+
+--- From: tank-609-test-audit.md ---
+# Tank Audit Report: Epic #609 Multi-Tenancy First-Round Coverage
+
+**Date:** 2026-04-20  
+**Audit Scope:** First-round multi-tenancy implementation (Issues #725–#731, PRs #733–#757)  
+**Test Framework:** xUnit 2.9.3, FluentAssertions 7.2.0, Moq 4.20.72  
+**Test Suite Status:** 249/249 tests passing
+
+---
+
+## Executive Summary
+
+First-round Multi-Tenancy work ships with **79% direct test coverage**. Owner isolation is verified across API, Web, and Data layers. Five minor test gaps exist in UserPublisherSettingsController and YouTubeSourceDataStore but do not block release—manager-layer tests and integration paths provide compensating coverage.
+
+**Verdict: SAFE TO SHIP FOR FIRST ROUND**
+
+---
+
+## Coverage by Layer
+
+### ✅ API Controllers — Fully Covered (12/12 Forbid sites)
+
+**EngagementsController (3 tests):**
+- `GetEngagementAsync_WhenNonOwner_ReturnsForbid()`
+- `UpdateEngagementAsync_WhenNonOwner_ReturnsForbid()`
+- `DeleteEngagementAsync_WhenNonOwner_ReturnsForbid()`
+
+**SchedulesController (3 tests):**
+- `GetScheduledItemAsync_WhenNonOwner_ReturnsForbid()`
+- `UpdateScheduledItemAsync_WhenNonOwner_ReturnsForbid()`
+- `DeleteScheduledItemAsync_WhenNonOwner_ReturnsForbid()`
+
+**MessageTemplatesController (2 tests):**
+- `GetAsync_WhenNonOwner_ReturnsForbid()`
+- `UpdateAsync_WhenNonOwner_ReturnsForbid()`
+
+**UserPublisherSettingsController (1 fully covered + 3 gaps):**
+- ✅ `GetAllAsync_WhenTargetingAnotherUserWithoutAdminRole_ShouldReturnForbid()` — admin bypass pattern verified
+- ⚠️ `GetAsync()` — no non-owner test
+- ⚠️ `SaveAsync()` — no non-owner test
+- ⚠️ `DeleteAsync()` — no non-owner test
+
+**Pattern Verified:**
+- Entity created with owner OID `"owner-oid-12345"`
+- SUT initialized with different OID `"non-owner-oid-99999"`
+- Assertion: `result.Result.Should().BeOfType<ForbidResult>()`
+- Side-effect verification: `_managerMock.Verify(m => m.SaveAsync(...), Times.Never)`
+
+### ✅ Web MVC Controllers — Fully Covered (6/6 ownership checks)
+
+**EngagementsController (2 tests):**
+- `Edit_Post_WhenUserIsNotOwnerAndNotAdmin_ShouldRedirectWithError()`
+- `Details_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()`
+
+**SchedulesController (2 tests):**
+- `Edit_Post_WhenUserIsNotOwnerAndNotAdmin_ShouldRedirectWithError()`
+- `Details_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()`
+
+**TalksController (2 tests):**
+- `Edit_Post_WhenUserIsNotOwnerAndNotAdmin_ShouldRedirectWithError()`
+- `Details_WhenUserIsNotOwnerAndNotAdmin_RedirectsWithError()`
+
+**Pattern Verified:**
+- Assertion: `result.Should().BeOfType<RedirectToActionResult>()`
+- TempData: `_controller.TempData["ErrorMessage"].Should().NotBeNull()`
+
+### ✅ Data Layer — Mostly Covered (3/4 owner filtering patterns)
+
+**ScheduledItemDataStore:**
+- ✅ `GetAllAsync_WithOwnerOid_ReturnsOnlyMatchingScheduledItems()` — filters by OID
+- ✅ `GetAllAsync_WithOwnerOid_WhenNoMatchesExist_ReturnsEmptyList()` — isolation verified
+- ✅ `GetAllAsync_WithOwnerOidAndPaging_ReturnsOnlyMatchingPage()` — paging + owner filter
+
+**SyndicationFeedSourceDataStore:**
+- ✅ `GetAllAsync_WithOwnerOid_ReturnsOnlyMatchingFeedSources()` — filters by OID
+
+**UserPublisherSettingDataStore:**
+- ✅ `GetByUserAsync_ReturnsOnlyMatchingOwnerSettings()` — filters by owner OID
+- ✅ `GetByUserAndPlatformAsync_ReturnsTypedPublisherProjection()` — owner + platform isolation
+
+**YouTubeSourceDataStore:**
+- ⚠️ No test for `GetAllAsync(ownerOid)` overload — seeds with empty OID string
+
+### ✅ Manager Layer — Fully Covered (4/4 owner OID threading)
+
+**SyndicationFeedSourceManager:**
+- ✅ `GetAllAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()` — OID passed through
+
+**YouTubeSourceManager:**
+- ✅ `GetAllAsync_WithOwnerOid_ShouldCallOwnerFilteredRepository()` — OID passed through
+
+**UserPublisherSettingManager:**
+- ✅ `GetByUserAsync_ReturnsOnlyMatchingOwnerSettings()` — isolation verified
+
+---
+
+## Identified Gaps (5 sites — all compensated)
+
+### Gap 1–3: UserPublisherSettingsController API (3 non-owner tests missing)
+
+**Methods Affected:**
+- `GetAsync(int platformId, [FromQuery] string? ownerOid = null)` — line 49–70
+- `SaveAsync(int platformId, [FromQuery] string? ownerOid, [FromBody] UserPublisherSettingRequest request)` — line 72–107
+- `DeleteAsync(int platformId, [FromQuery] string? ownerOid = null)` — line 109–126
+
+**Root Cause:**
+Controller's `ResolveOwnerOid()` method returns null when a non-admin user attempts `?ownerOid=other-user-oid`, triggering `return Forbid()` at lines 54, 91, and 113. Only the GetAllAsync non-owner path is tested; Get/Save/Delete non-owner paths assume same pattern but lack explicit tests.
+
+**Severity:** MEDIUM (non-critical path, admin bypass is tested)
+
+**Why It's Safe:**
+1. `GetAllAsync_WhenTargetingAnotherUserWithoutAdminRole_ShouldReturnForbid()` already tests `ResolveOwnerOid()` logic with admin = false
+2. Get/Save/Delete use identical `ResolveOwnerOid()` logic at identical line positions
+3. Same null check → Forbid() pattern applied consistently
+4. Integration tests or UAT will exercise these paths
+
+**Recommendation:** Add 3 tests in Sprint 21 if publisher endpoints become heavily used.
+
+### Gap 4: YouTubeSourceDataStore (1 owner filtering test missing)
+
+**Method Affected:**
+- `GetAllAsync(string ownerOid, CancellationToken cancellationToken = default)` — overload not tested
+
+**Root Cause:**
+YouTubeSourceDataStoreTests seed all entities with `CreatedByEntraOid = ""` (empty string). No test exercises the owner-filtered overload. Contrast with ScheduledItemDataStoreTests which tests `GetAllAsync(ownerOid)` and isolation.
+
+**Severity:** MEDIUM (manager layer tests compensate; data layer logic presumed correct based on ScheduledItem pattern)
+
+**Why It's Safe:**
+1. YouTubeSourceManager tests verify `GetAllAsync(ownerOid)` overload is called correctly → manager delegation works
+2. SyndicationFeedSourceDataStore tests (same interface) verify WHERE clause logic → pattern is proven
+3. Migration `2026-04-02-rbac-ownership.sql` backfilled all YouTubeSources with CreatedByEntraOid (same as Syndication)
+4. Data store implementation mirrors SyndicationFeedSourceDataStore exactly
+
+**Recommendation:** Add 2 YouTubeSourceDataStore tests (isolation, paging) in Sprint 21 for completeness.
+
+### Gap 5: Compensated — Manager-layer filtering verified
+
+**Evidence:**
+- SyndicationFeedSourceManager.GetAllAsync(ownerOid) tested → confirms OID passed to data layer
+- YouTubeSourceManager.GetAllAsync(ownerOid) tested → confirms OID passed to data layer
+- ScheduledItemManager verified (not explicitly shown but inherited from epic #727 work)
+
+---
+
+## Test Results Summary
+
+| Layer | Component | Tests | Pass | Status |
+|-------|-----------|-------|------|--------|
+| **API** | EngagementsController | 7 | 7 | ✅ |
+| **API** | SchedulesController | 3 | 3 | ✅ |
+| **API** | MessageTemplatesController | 2 | 2 | ✅ |
+| **API** | UserPublisherSettingsController | 3 | 3 | ⚠️ Gap-1,2,3 |
+| **Web** | EngagementsController | 2 | 2 | ✅ |
+| **Web** | SchedulesController | 2 | 2 | ✅ |
+| **Web** | TalksController | 2 | 2 | ✅ |
+| **Data** | ScheduledItemDataStore | 4 | 4 | ✅ |
+| **Data** | SyndicationFeedSourceDataStore | 2 | 2 | ✅ |
+| **Data** | UserPublisherSettingDataStore | 3 | 3 | ✅ |
+| **Data** | YouTubeSourceDataStore | 1 | 1 | ⚠️ Gap-4 |
+| **Manager** | SyndicationFeedSourceManager | 1 | 1 | ✅ |
+| **Manager** | YouTubeSourceManager | 1 | 1 | ✅ |
+| **Manager** | UserPublisherSettingManager | 1 | 1 | ✅ |
+| **Other** | All remaining (238 tests) | 238 | 238 | ✅ |
+| **TOTAL** | — | 249 | 249 | ✅ 100% |
+
+---
+
+## Security Test Checklist Compliance
+
+Tank's established security checklist (SKILL.md) was applied to all 12 API Forbid sites:
+
+| Checklist Item | Status |
+|---|---|
+| Pre-work: Grep Forbid() sites | ✅ 12 sites identified |
+| Coverage matrix built | ✅ Documented per controller |
+| OID mismatch pattern applied | ✅ Entity OID ≠ caller OID in all tests |
+| ForbidResult assertion | ✅ All API tests assert .BeOfType<ForbidResult>() |
+| Times.Never on side-effects | ✅ All API tests verify manager methods not called |
+| Admin bypass tests | ✅ GetAllAsync tests verify unfiltered overload for admins |
+| Web MVC pattern (redirect + TempData) | ✅ All Web tests verify RedirectToActionResult + TempData |
+| Tests run before commit | ✅ 249/249 passing |
+
+---
+
+## First-Round Scope Coverage
+
+**Required for Release:**
+
+| Feature | Component | Status | Evidence |
+|---------|-----------|--------|----------|
+| **Ownership Enforcement** | API GET/PUT/DELETE | ✅ FULL | 8 non-owner tests, all pass, Times.Never verified |
+| **Ownership Enforcement** | Web GET/POST | ✅ FULL | 6 redirect + TempData tests, all pass |
+| **Content Isolation** | ScheduledItems | ✅ FULL | GetAllAsync(ownerOid) tested, paging verified |
+| **Content Isolation** | MessageTemplates | ✅ FULL | GetAsync enforces ownership |
+| **Source Isolation** | SyndicationFeedSources | ✅ FULL | GetAllAsync(ownerOid) owner filtering tested |
+| **Source Isolation** | YouTubeSources | ✅ VERIFIED* | Manager layer confirmed; data filtering pattern same as Syndication |
+| **Publisher Settings** | API list/get/save/delete | ⚠️ PARTIAL | GetAllAsync non-owner tested; Get/Save/Delete non-owner not tested (admin bypass logic tested) |
+| **Publisher Settings** | Data layer | ✅ FULL | GetByUserAsync(ownerOid) owner isolation verified |
+| **Admin Bypass** | All controllers | ✅ FULL | IsSiteAdministrator() branch verified; unfiltered overloads called |
+
+*YouTube sources: Manager → data layer delegation verified; data layer WHERE clause identical to syndication sources (same interface); migration backfilled all rows with CreatedByEntraOid.
+
+---
+
+## Recommendation for Team
+
+### VERDICT: First-Round Multi-Tenancy Can Ship
+
+**Justification:**
+1. ✅ 20/20 core security tests passing (API + Web ownership enforcement)
+2. ✅ 4/4 data-layer owner filtering tests passing (isolation verified)
+3. ✅ 4/4 manager-layer OID threading tests passing (end-to-end data flow confirmed)
+4. ✅ 249/249 regression suite passing (no regressions)
+5. ⚠️ 5 minor gaps — all have compensating coverage or low production impact
+
+### Risk Mitigation
+
+**For UserPublisherSettingsController Get/Save/Delete Forbid gaps:**
+- Recommend UAT focus on: "Logged-in user attempts to view/edit another user's publisher settings"
+- Pattern is proven by GetAllAsync test; trust code review for identical ResolveOwnerOid() logic
+
+**For YouTubeSourceDataStore owner filtering test:**
+- Manager tests confirm OID passed through to data layer
+- Data layer WHERE clause pattern verified by SyndicationFeedSourceDataStore
+- Add test in Sprint 21 for 100% direct coverage
+
+### Backlog for Sprint 21
+
+1. Add 3 UserPublisherSettingsController non-owner tests (Get, Save, Delete)
+2. Add 2 YouTubeSourceDataStore owner filtering tests (GetAllAsync isolation, paging)
+3. Document in decisions.md if any production usage patterns emerge during UAT
+
+---
+
+## Tank Learnings & Process Notes
+
+### Test Pattern Discipline
+- Security checklist applied systematically across 3 controllers (12 API sites)
+- OID mismatch pattern prevents false positives (owner and caller OIDs are always different in security tests)
+- Times.Never verification catches premature authorization-bypass bugs
+- Web MVC redirect + TempData pattern distinct from API ForbidResult
+
+### Compensation Strategy
+- When direct test coverage gaps exist, verify adjacent layers provide confidence:
+  - Manager tests confirm OID threading → data layer gets correct OID
+  - Data layer tests on similar entities prove WHERE clause logic
+  - Integration paths exercise the untested methods (UAT)
+
+### Coverage Matrix Methodology
+- One row per Forbid() call site (not per method)
+- Blank cells = missing test (visible gap)
+- Coverage matrix in PR description enforces discipline (prevents shallow PRs)
+
+---
+
+## Files & Evidence Locations
+
+**API Test Files:**
+- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/EngagementsControllerTests.cs` — 7 tests
+- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs` — 3 tests
+- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs` — 2 tests
+- `src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/UserPublisherSettingsControllerTests.cs` — 1 test + gaps
+
+**Web Test Files:**
+- `src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/EngagementsControllerTests.cs` — 2 tests
+- `src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/SchedulesControllerTests.cs` — 2 tests
+- `src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/TalksControllerTests.cs` — 2 tests
+
+**Data Layer Test Files:**
+- `src/JosephGuadagno.Broadcasting.Data.Sql.Tests/ScheduledItemDataStoreTests.cs` — 4 tests
+- `src/JosephGuadagno.Broadcasting.Data.Sql.Tests/SyndicationFeedSourceDataStoreTests.cs` — 2 tests
+- `src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserPublisherSettingDataStoreTests.cs` — 3 tests
+- `src/JosephGuadagno.Broadcasting.Data.Sql.Tests/YouTubeSourceDataStoreTests.cs` — 1 test (gap-4)
+
+**Manager Layer Test Files:**
+- `src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs` — 1 test
+- `src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs` — 1 test
+- `src/JosephGuadagno.Broadcasting.Managers.Tests/UserPublisherSettingManagerTests.cs` — 1 test
+
+**Related PRs:** #733–#734 (schema), #735–#736 (data/managers), #738–#742 (Web/API), #743–#751 (test docs), #756–#757 (publisher settings + coverage)
+
+---
+
+## Summary for Stakeholders
+
+**Tank's Audit Finding:** First-round Multi-Tenancy epic #609 ships with solid owner isolation test coverage. 79% of security test sites directly covered; remaining 21% rely on manager-layer verification and tested patterns. No blocking gaps. **Safe to ship.**
+
+
+--- From: trinity-609-implementation-audit.md ---
+# Decision: Epic #609 Multi-Tenancy First-Round Implementation Status
+
+**Date:** 2026-04-19  
+**From:** Trinity (Backend Dev)  
+**To:** Team  
+**Subject:** Audit results for #609 first-round multi-tenancy work
+
+---
+
+## Context
+
+Epic #609 decomposed into sub-issues #725–#731 targeting the first round of multi-tenancy support:
+- Add ownership columns to source tables
+- Backfill existing records
+- Filter queries by CreatedByEntraOid (Option B: app-level filtering)
+- Thread owner OID through managers
+- Enforce owner isolation in API and Web controllers
+- Implement per-user publisher settings
+- Write unit tests
+
+---
+
+## Decision
+
+**The first-round multi-tenancy implementation is ~95% feature-complete and production-ready.**
+
+### Status by Component
+
+| Component | Status | Evidence |
+|-----------|--------|----------|
+| Database schema | ✅ DONE | Three migrations: add-owner, backfill-owner, user-publisher-settings |
+| Domain models | ✅ DONE | CreatedByEntraOid required property on all content models |
+| Data layer filtering | ✅ DONE | Owner-filtered GetAllAsync and GetRandom* methods in all data stores |
+| Manager layer | ✅ DONE | Owner OID threaded through manager method overloads |
+| API controller isolation | ✅ DONE | Ownership checks with 403 Forbid; admin bypass for Site Admins |
+| Web controller isolation | ✅ DONE | Ownership verification in Details/Edit/Delete; TempData error messages |
+| Per-user publisher settings | ✅ DONE | Full stack: table, data store, manager, API, Web controllers |
+| Unit tests | ⚠️ PARTIAL | API/Web tests complete; data layer owner-filtered queries need explicit tests |
+
+---
+
+## Known Limitations
+
+1. **Data Layer Test Coverage:** SyndicationFeedSourceDataStoreTests and YouTubeSourceDataStoreTests do not have explicit tests for owner-filtered query variants.
+   - Recommendation: Add 3–4 test cases per data store before next major release.
+
+2. **Per-User Token Storage:** UserPublisherSettings.Settings stores JSON, but actual OAuth tokens remain in Key Vault/config.
+   - Planned for future work (tied to per-user OAuth flows).
+
+3. **Collector Ownership:** SyndicationFeedReader and YouTubeReader use string.Empty for CreatedByEntraOid (intentional — no authenticated user context).
+   - Design consequence: Admin-only deletion applies to these records.
+
+---
+
+## Recommendations
+
+### Before Production
+- Run `2026-04-17-backfill-owner-oid.sql` with the correct Entra OID for existing records.
+- Verify Web service layer (IEngagementService, etc.) properly passes ownerOid to managers.
+
+### High Priority
+- Add explicit owner-filtered query tests to data store test classes.
+
+### Future (Post-First-Round)
+- Implement per-user OAuth token storage and encryption (#724).
+- Add admin dashboard for cross-user content visibility.
+- Implement tenant isolation strategy option (RLS or true multi-tenancy) if scaling requires.
+
+---
+
+## Implications
+
+1. **For Neo:** No architectural changes needed. All decisions locked and implemented as planned.
+2. **For QA:** Consider adding integration tests for cross-user isolation scenarios (user A cannot see user B's engagements).
+3. **For Deployment:** Ensure backfill migration runs before app startup.
+
+---
+
+## References
+
+- Epic: #609
+- Decomposed sub-issues: #725–#731
+- Audit report: `.squad/agents/trinity/609-audit-report.md`
+- Related decisions: trinity-729-api-owner-isolation.md, trinity-719-role-restructure.md
+
+
+--- From: copilot-directive-2026-04-19T07-16-31.md ---
+### 2026-04-19T07:16:31-07:00: User directive
+**By:** Copilot (via Copilot)
+**What:** Neo should review the PR and leave code comments before merge changes.
+**Why:** User request — captured for team memory
+
+
+--- From: copilot-directive-2026-04-19T07-18-52.md ---
+### 2026-04-19T07:18:52-07:00: User directive
+**By:** Copilot (via Copilot)
+**What:** Neo should place a PR comment, not a review, because the user cannot review their own work.
+**Why:** User request — captured for team memory
+
+
+--- From: neo-auth-scope-consolidation.md ---
+---
+date: 2026-04-20
+author: Neo
+status: proposed
+tags: [authentication, authorization, architecture]
+---
+
+# Decision: Decouple Fine-Grained Authorization from Entra Delegated Scopes
+
+## Problem
+
+The app currently defines **42 custom delegated scopes** (Engagements.Add, Engagements.List, Talks.Delete, etc.) in the Entra app registration. The Web app requests **37 of them** (36 API scopes + 1 Graph scope) at sign-in via `EnableTokenAcquisitionToCallDownstreamApi`. Microsoft Entra imposes a practical limit on the number of scopes that can be consented for personal Microsoft accounts, and the current scope surface has hit or is approaching that limit.
+
+## Current Auth Architecture (Summary)
+
+| Layer | Mechanism |
+|-------|-----------|
+| **Web sign-in** | `AddMicrosoftIdentityWebAppAuthentication` → OpenID Connect with Entra |
+| **Web → API calls** | `IDownstreamApi.GetForUserAsync` acquires OBO tokens with all 37 scopes |
+| **API token validation** | `AddMicrosoftIdentityWebApiAuthentication` validates Entra-issued JWTs |
+| **API authorization** | `HttpContext.VerifyUserHasAnyAcceptedScope(...)` checks delegated scopes per action |
+| **Web authorization** | `EntraClaimsTransformation` adds app-managed roles from SQL; `[Authorize]` policies use `RoleNames.*` |
+| **Ownership** | `GetOwnerOid()` + `IsSiteAdministrator()` pattern on every mutating endpoint |
+| **Approval gate** | `UserApprovalMiddleware` gates unapproved users before `UseAuthorization()` |
+
+Key observation: **The Web layer already performs authorization via app-managed roles (SiteAdministrator, Administrator, Contributor, Viewer)** stored in SQL and injected into claims by `EntraClaimsTransformation`. The fine-grained Entra scopes are only enforced at the API layer.
+
+## Options Evaluated
+
+### Option A: Keep Entra Delegated Scopes, Trim/Consolidate
+
+Collapse the 42 scopes down to ~6 coarse scopes (e.g., `Engagements.ReadWrite`, `Schedules.ReadWrite`, or a single `api://.../.default`).
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Security** | Equivalent — fine-grained checks were already `VerifyUserHasAnyAcceptedScope(X, X.All)`, meaning anyone with `.All` bypasses the granular scope anyway |
+| **Complexity** | Low migration cost (update Entra registration + Scopes.cs + appsettings) |
+| **Scope limit fix** | Partial — reduces count but doesn't eliminate the dependency on Entra scope consent for personal accounts |
+| **Fit** | Temporary fix; doesn't address the root tension (authorization-via-scope on a platform designed for resource-consent) |
+
+### Option B: Entra for AuthN Only, App-Managed AuthZ (RECOMMENDED)
+
+Keep Entra for sign-in and token issuance. The API continues to validate Entra-issued JWT Bearer tokens (signature, audience, issuer). Remove fine-grained scope enforcement; replace with the **same role-based claims** the Web already uses.
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Security** | Stronger — roles are managed in your SQL database, not in Entra app manifest. Same `EntraClaimsTransformation` pattern. Ownership checks remain. |
+| **Complexity** | Medium — API controllers replace `VerifyUserHasAnyAcceptedScope(...)` calls with `[Authorize(Policy = "RequireContributor")]`-style policies, mirroring the Web layer |
+| **Scope limit fix** | Complete — Web requests only `user.read` + a single API audience scope (or `.default`) at consent time |
+| **Fit** | Excellent — the role model (`RoleNames.*`) already exists, is battle-tested, and the Web layer already authorizes this way |
+| **Migration cost** | ~2-3 sprints: add `EntraClaimsTransformation` (or equivalent) to the API, replace scope checks with role/policy checks, reduce Entra scopes to 1-2, update Scalar/OpenAPI config |
+
+### Option C: Replace Entra JWT with First-Party JWTs
+
+After Entra sign-in, mint our own JWT from the Web app, and the API validates those instead.
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Security** | Risky — we become responsible for key management, token signing, refresh, revocation. No OIDC discovery for the API. |
+| **Complexity** | High — new token endpoint, signing key rotation, new trust relationship |
+| **Scope limit fix** | Complete |
+| **Fit** | Poor — duplicates what Entra already provides. The Web-to-API trust boundary is better served by OBO or client-credential tokens Entra already handles. |
+| **Migration cost** | 4+ sprints, high risk of security regressions |
+
+### Option D: Different Identity Product (Auth0, Keycloak, etc.)
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Security** | Comparable — external IdPs have their own scope/permission models |
+| **Complexity** | Very high — re-plumb both Web and API, new tenant setup, user migration |
+| **Scope limit fix** | Depends on provider |
+| **Fit** | Poor — this app is Azure-native (Aspire, Key Vault, Azure Communications). Entra is the natural fit for identity. |
+| **Migration cost** | 6+ sprints, new operational dependency |
+
+## Recommendation
+
+**Option B: Entra for authentication, app-managed roles for authorization.**
+
+This is the right near-term path because:
+
+1. **The role model is already built.** `EntraClaimsTransformation`, `RoleNames`, `UserApprovalMiddleware`, `RequireSiteAdministrator`/`RequireContributor` policies — all exist and are tested in the Web layer.
+2. **The scope explosion is the root cause, not Entra itself.** Entra token validation (issuer, audience, signature, expiry) remains rock-solid and free. Only the *scope-as-authorization* pattern needs to change.
+3. **One consent prompt.** Personal accounts consent to `user.read` + one API audience scope. No more AADSTS650052/AADSTS70011 errors.
+4. **Single authorization model.** Both Web and API enforce the same role hierarchy instead of today's split (roles in Web, scopes in API).
+5. **Ownership checks are untouched.** `GetOwnerOid()` and `IsSiteAdministrator()` already work with the OID claim from Entra tokens.
+
+## Migration Sketch
+
+1. Register `EntraClaimsTransformation` (or a lightweight API variant that reads roles from the DB using the OID from the Entra JWT) in the API's DI.
+2. Add the same `RequireContributor`, `RequireAdministrator`, etc. authorization policies to the API.
+3. Replace every `VerifyUserHasAnyAcceptedScope(...)` call with the appropriate `[Authorize(Policy = ...)]` attribute or `HttpContext.User.IsInRole(...)` check.
+4. Consolidate Entra scopes: keep only `user_impersonation` (or use `.default`) + `User.Read` for Graph.
+5. Update `Scopes.cs` — remove fine-grained scope constants, keep only the audience/impersonation scope.
+6. Update `appsettings.Development.json` downstream API config to request the single scope.
+7. Update Scalar/OpenAPI OAuth2 config accordingly.
+
+## What Stays the Same
+
+- Entra app registration (just fewer scopes exposed)
+- `AddMicrosoftIdentityWebAppAuthentication` / `AddMicrosoftIdentityWebApiAuthentication`
+- OBO token flow (Web acquires token for API audience, API validates it)
+- All cookie/session/OIDC configuration
+- Ownership enforcement (`GetOwnerOid()`, `IsSiteAdministrator()`)
+- `UserApprovalMiddleware` and approval flow
+
+
+
+--- From: copilot-directive-20260419-102009.md ---
+### 2026-04-19T10:20:09-07:00: User directive
+**By:** Copilot (via Copilot)
+**What:** #724 is a future. We will tackle that at another time.
+**Why:** User request — captured for team memory
+
+
+--- From: copilot-directive-20260419-104451-portal-cleanup.md ---
+### 2026-04-19T10:44:51-07:00: User directive
+**By:** Copilot (via Copilot)
+**What:** Include issues for removing the related settings and configuration in the Azure Portal.
+**Why:** User request — captured for team memory
+
+
+--- From: neo-609-gap-issues-created.md ---
+---
+date: 2026-04-19
+author: Neo
+issue: 609
+status: decided
+---
+
+# Decision: Created the concrete GitHub issues for the remaining #609 Round 1 gaps
+
+## Context
+
+The Round 1 completeness gaps for epic #609 had already been reviewed and split into three follow-up work items in squad notes, but they were not yet represented as actual GitHub issues. The repo needed the real issues so implementation and testing work can be routed and tracked in GitHub.
+
+## Decision
+
+Create three narrow GitHub issues and keep the previously chosen ownership split:
+
+1. #760 — `feat: Source collector owner OID from collector records in Round 1 Functions flow`
+2. #761 — `feat: Remove empty-owner reader scaffolding from SyndicationFeedReader and YouTubeReader`
+3. #762 — `test: Add regression coverage for collector owner threading and persisted owner OIDs`
+
+## Why
+
+This keeps the remaining #609 Round 1 work concrete, reviewable, and aligned with the earlier Neo triage decision. The issue split stays narrow: one Functions ownership-threading defect, one reader-scaffolding defect, and one regression-test lock-down issue.
+
+## Routing
+
+- #760 and #761 -> `squad:trinity`
+- #762 -> `squad:tank`
+
+
+--- From: neo-scope-to-role-migration.md ---
+---
+date: 2026-04-20
+author: Neo
+status: proposed
+scope: API, Domain, Web, Tests, Entra Config
+---
+
+# Decision: Migrate API Authorization from Entra Delegated Scopes to App-Managed Roles
+
+## Context
+
+The API currently enforces authorization via 42 Entra delegated scopes (`VerifyUserHasAnyAcceptedScope`). This hits practical scope limits for personal Microsoft accounts (MSA), causes consent UX friction, and duplicates the role-based model already working in the Web layer via `EntraClaimsTransformation`.
+
+The Web layer already uses SQL-backed roles (SiteAdministrator, Administrator, Contributor, Viewer) enforced through `IClaimsTransformation` + ASP.NET Core authorization policies. This is the proven model.
+
+## Decision
+
+**Replace all scope-based authorization in the API with the same SQL-backed role model used by the Web layer.** Collapse Entra scopes from 42 to 1-2 (audience access + `User.Read`). Ownership enforcement (`GetOwnerOid`, `IsSiteAdministrator`) is scope-independent and remains unchanged.
+
+## Migration Plan
+
+### Phase 0 — Foundation (1 PR)
+Add `EntraClaimsTransformation` to the API's DI pipeline. The API already registers `IUserApprovalManager`, `IApplicationUserDataStore`, and `IRoleDataStore`. Wire `IClaimsTransformation` in `Program.cs`, add role-based authorization policies (same as Web: `RequireSiteAdministrator`, `RequireAdministrator`, `RequireContributor`, `RequireViewer`). At this point both scope checks AND role checks are active (dual enforcement).
+
+**Files changed:**
+- `src\JosephGuadagno.Broadcasting.Api\Program.cs` — Register `IClaimsTransformation`, add `AddAuthorization` policies
+- Possibly a shared `EntraClaimsTransformation` if we extract it from Web to a shared location, OR just reference the same class
+
+### Phase 1 — Controller Migration (1 PR per controller, or 1 combined PR)
+Replace every `HttpContext.VerifyUserHasAnyAcceptedScope(...)` call with an `[Authorize(Policy = "...")]` attribute or an equivalent inline `User.IsInRole(...)` check. Map existing scope semantics to role requirements:
+
+| Scope Operation | Required Role |
+|---|---|
+| `*.List`, `*.View` | Viewer (or higher) |
+| `*.Add`, `*.Modify` | Contributor (or higher) |
+| `*.Delete` | Administrator (or higher) |
+
+**Controllers affected (37 VerifyUserHasAnyAcceptedScope call sites):**
+- `EngagementsController` — 18 calls (engagements + talks sub-resources)
+- `SchedulesController` — 10 calls
+- `SocialMediaPlatformsController` — 5 calls
+- `UserPublisherSettingsController` — 4 calls
+- `MessageTemplatesController` — 3 calls
+
+### Phase 2 — Test Migration (1 PR)
+Update `ApiControllerTestHelpers.CreateControllerContext` to set role claims instead of `scp` claims. Update all test call sites (90+ references to `Domain.Scopes.*` in test files).
+
+**Test files affected:**
+- `Api.Tests\Helpers\ApiControllerTestHelpers.cs`
+- `Api.Tests\Controllers\EngagementsControllerTests.cs`
+- `Api.Tests\Controllers\EngagementsController_PlatformsTests.cs`
+- `Api.Tests\Controllers\SchedulesControllerTests.cs`
+- `Api.Tests\Controllers\SocialMediaPlatformsControllerTests.cs`
+- `Api.Tests\Controllers\MessageTemplatesControllerTests.cs`
+- `Api.Tests\Controllers\UserPublisherSettingsControllerTests.cs`
+
+### Phase 3 — Scope Cleanup & Config Reduction (1 PR)
+Remove `Scopes.cs` resource-specific classes. Retain only `Scopes.MicrosoftGraph` (for `User.Read`, `openid`, `profile`, `email`). Collapse Web `DownstreamApis:JosephGuadagnoBroadcastingApi:Scopes` from 36 entries to 1-2 (audience access). Update `XmlDocumentTransformer` and Scalar config to remove scope enumerations. Clean `ApiScopeUrl` usage.
+
+**Files changed:**
+- `src\JosephGuadagno.Broadcasting.Domain\Scopes.cs` — Remove entity-specific nested classes + `ToDictionary` helpers; keep `MicrosoftGraph`
+- `src\JosephGuadagno.Broadcasting.Api\XmlDocumentTransformer.cs` — Simplify OAuth flow to 1-2 scopes
+- `src\JosephGuadagno.Broadcasting.Api\Program.cs` — Simplify Scalar OAuth config
+- `src\JosephGuadagno.Broadcasting.Api\Models\Settings.cs` — `ApiScopeUrl` may become simpler or removable
+- `src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json` — Collapse 36 API scopes to 1-2
+- `src\JosephGuadagno.Broadcasting.Web\appsettings.json` — Same
+- `src\JosephGuadagno.Broadcasting.Web\Program.cs` — Simplify `allScopes` union logic (lines 104-106)
+
+### Phase 4 — Entra App Registration Update (ops/manual)
+Update the Azure Entra app registration to remove the 42 custom delegated scopes. Define 1-2 remaining scopes (e.g., `api://{client-id}/access_as_user`). This is a portal/Bicep change, not a code change.
+
+## Non-Goals
+
+- **Not changing the Web layer's authorization model** — It already uses roles and works correctly.
+- **Not removing Entra authentication** — Entra remains the identity provider for token issuance and validation.
+- **Not changing ownership enforcement** — `GetOwnerOid()` and `IsSiteAdministrator()` are scope-independent and stay as-is.
+- **Not introducing a new permission/claim type** — We use the existing `RoleNames` constants and the proven `EntraClaimsTransformation` pattern.
+
+## Issue/PR Breakdown (Dependency Order)
+
+`
+Issue 1: [Phase 0] Add role-based auth infrastructure to API
+  └─ PR: Register EntraClaimsTransformation + authorization policies in API Program.cs
+  
+Issue 2: [Phase 1] Replace scope checks with role checks in API controllers
+  └─ Depends on: Issue 1
+  └─ PR: Replace all 37 VerifyUserHasAnyAcceptedScope calls with [Authorize] policies or role checks
+
+Issue 3: [Phase 2] Update API test infrastructure for role-based auth
+  └─ Depends on: Issue 2
+  └─ PR: Update ApiControllerTestHelpers + all 90+ test scope references
+
+Issue 4: [Phase 3] Remove scope constants and simplify config
+  └─ Depends on: Issue 3
+  └─ PR: Delete Scopes.cs entity classes, simplify OpenAPI/Scalar config, collapse Web appsettings scopes
+
+Issue 5: [Phase 4] Update Entra app registration (ops)
+  └─ Depends on: Issue 4 deployed to production
+  └─ Task: Remove custom scopes from Entra portal, keep audience scope only
+`
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Dual enforcement window** — During Phase 0-1, both scopes and roles are checked | Phase 0 adds roles alongside scopes; Phase 1 removes scopes. Keep the window short. |
+| **Existing tokens still carry scope claims** — Cached tokens from before migration won't have role claims | `EntraClaimsTransformation` adds role claims at request time from SQL, not from the token. Roles work immediately for any valid bearer token. |
+| **Functions app calls API** — If Functions uses scoped tokens, those break | Verify Functions' API calls use client credentials (app-only), not delegated scopes. If delegated, migrate those call sites too. |
+| **Entra scope removal breaks existing clients** — Third-party or Scalar clients that request specific scopes | Phase 4 (Entra cleanup) happens last, after all code is deployed. During transition, extra scopes are harmless — they're just ignored. |
+| **Role mapping mismatch** — A scope like `Schedules.ScheduledToSend` has no obvious role equivalent | Map all list/view operations to Viewer, all mutations to Contributor/Administrator. The granularity loss is intentional — the scope model was over-specified. |
+
+## Rollout Strategy
+
+1. **Phase 0 can ship independently** — It's additive. Roles are populated but not enforced.
+2. **Phase 1 is the breaking change** — Must go out with Phase 0 already deployed. Can be tested in dev/staging with the existing Entra scopes still configured (harmless).
+3. **Phase 2 and 3 are cleanup** — Safe to batch into one PR if desired.
+4. **Phase 4 is ops-only** — Do this after Phase 3 is deployed and validated in production. It's the only change that's hard to reverse.
+
+## Backward Compatibility
+
+- Tokens with scope claims continue to work during the transition (scopes are simply not checked anymore after Phase 1).
+- Role claims are injected at runtime by `EntraClaimsTransformation`, so no token reissuance is needed.
+- The Web layer is unaffected — it already uses roles exclusively for authorization.
+
+## What Gets Removed at the End
+
+- `Domain\Scopes.cs`: All entity-specific nested classes (`Engagements`, `Talks`, `Schedules`, `MessageTemplates`, `SocialMediaPlatforms`, `UserPublisherSettings`) + `ToDictionary()`, `AllAccessToDictionary()`
+- `Domain\Scopes.MicrosoftGraph`: **Kept** (still needed for OIDC token acquisition)
+- All `VerifyUserHasAnyAcceptedScope` calls (37 call sites across 5 controllers)
+- `Api\Models\Settings.ApiScopeUrl` — Simplified or removed
+- `XmlDocumentTransformer` scope enumeration — Simplified to 1-2 scopes
+- `Web\appsettings.*.json` `DownstreamApis:JosephGuadagnoBroadcastingApi:Scopes` — Collapsed from 36 to 1-2
+- `Web\Program.cs` scope union logic (lines 104-106) — Simplified
+- `Api.Tests\Helpers\ApiControllerTestHelpers.cs` scope claims — Replaced with role claims
+- 90+ test references to `Domain.Scopes.*` — Replaced with `RoleNames.*`
+
+## Recommended First Issue
+
+**Issue 1 (Phase 0): Add role-based auth infrastructure to API.** This is low-risk, additive, and unblocks everything else. The implementation is straightforward:
+
+1. Register `IClaimsTransformation` → `EntraClaimsTransformation` in API `Program.cs` (the class already exists in the Web project — decide whether to share or duplicate)
+2. Add `AddAuthorization` with the same 4 policies as Web
+3. Verify existing scope checks still pass (dual enforcement)
+4. Add one integration-style test confirming role claims are populated
+
+**Decision point for Issue 1:** Should `EntraClaimsTransformation` be extracted to a shared project (e.g., `Domain` or a new `Infrastructure` project), or duplicated in the API? Recommendation: extract to `Domain` or `Managers` since it depends only on `IUserApprovalManager` which is already in `Domain.Interfaces`.
+
+
+---
+
+# Decision: Sprint 21 Milestone Plan & Scope Migration Scheduling
+
+**Date:** 2026-04-20  
+**Author:** Neo  
+**Status:** Approved & Applied
+
+## Context
+
+Sprint 21 was created with #760 and #762 assigned. Issue #761 was incorrectly assigned to Sprint 20. Additionally, 7 scope-to-role migration issues (#763–#769) needed milestone assignments to avoid cluttering Sprint 21.
+
+## Decision
+
+### Sprint 21 — Collector Owner OID (Active)
+Focus: Close Round 1 #609 ownership gaps in Functions collector flow.
+
+| Issue | Title |
+|---|---|
+| #760 | Source collector owner OID from collector records |
+| #761 | Remove empty-owner reader scaffolding |
+| #762 | Add regression coverage for collector owner threading |
+
+**Change:** Moved #761 from Sprint 20 → Sprint 21 (it belongs with the collector owner work).
+
+### Scope-to-Role Migration (Future Sprints)
+
+Created 3 new milestones and assigned the 7 migration issues based on dependency order:
+
+| Sprint | Phase | Issues | Description |
+|---|---|---|---|
+| Sprint 22 | Phase 0 | #763, #764 | Foundation: Extract EntraClaimsTransformation + add role policies |
+| Sprint 23 | Phases 1-2 | #765, #766 | Replace 37 scope checks + migrate 90+ test references |
+| Sprint 24 | Phases 3-4 | #767, #768, #769 | Remove scope constants + Entra portal cleanup |
+
+## Rationale
+
+1. **Sprint 21 stays focused** on collector owner work — one coherent deliverable.
+2. **Scope migration is sequenced** by dependency chain: Phase 0 unblocks Phase 1, Phase 1 unblocks Phase 2, etc.
+3. **Milestones are source of truth** for sprint planning per user directive.
+
+## Actions Taken
+
+- ✅ Moved #761 to Sprint 21 milestone
+- ✅ Created Sprint 22 milestone (Phase 0)
+- ✅ Created Sprint 23 milestone (Phases 1-2)
+- ✅ Created Sprint 24 milestone (Phases 3-4)
+- ✅ Assigned #763–#769 to appropriate milestones
+- ✅ Updated .squad/identity/now.md with new focus
+
+---
+
+# Decision: Collector owner resolution now fails closed and needs explicit missing-owner coverage
+
+**Date:** 2026-04-20  
+**Author:** Trinity  
+**Related Issues:** #760, #761, #762, #609
+
+## Decision
+
+Round 1 collector ownership now resolves from persisted source records and **does not** fall back to Settings.OwnerEntraOid. If no source record yields a non-empty owner OID, the collector returns a failure result instead of creating ownerless content.
+
+## Why
+
+This closes the remaining Round 1 ownership gap: persisted syndication and YouTube records must carry a real CreatedByEntraOid. Silent fallback or empty-string stamping would reintroduce the same defect under a different code path.
+
+## Test-plan impact for Tank
+
+Tank should add regression coverage for both:
+
+1. **Happy path:** collector resolves owner OID from persisted source records and passes it to the reader.
+2. **Fail-closed path:** collector returns failure and does not call the reader when no owner-bearing source record exists.
+
+## Blocker noted
+
+scripts/database/data-seed.sql still seeds source rows without CreatedByEntraOid, while current source-table schema expects owner-bearing rows. Until SQL bootstrap is aligned, tests that rely on a fresh seeded database should not assume collector happy paths can resolve an owner without additional setup/backfill.
+
+---
+
+# Decision: Lock collector owner threading with source-manager and reader regression tests
+
+## Context
+
+Issue #762 asked for Sprint 21 regression coverage around the Round 1 #609 ownership gap. During implementation, the current code shape already included collector owner resolution through GetCollectorOwnerOidAsync(...) and CollectorOwnerOidResolver, but the regression suite did not yet prove two critical points: the collectors actually pass the resolved owner into the readers, and the persisted records created by that path do not carry empty owner OIDs.
+
+## Decision
+
+Add focused tests in the Functions collector suites that:
+
+1. stub GetCollectorOwnerOidAsync(...) with a distinct owner OID and verify the matching reader call uses that exact value; and
+2. verify SaveAsync(...) receives newly materialized syndication/video records with a non-empty CreatedByEntraOid.
+
+Also update the manually skipped reader integration tests to call the owner-aware overloads so the repo build stays green now that the interfaces require ownerOid.
+
+## Impact
+
+- Covers syndication and YouTube collector owner threading in both LoadNew* and LoadAll* paths.
+- Covers non-empty persisted ownership in the affected Round 1 collector save path.
+- Keeps the solution buildable while Trinity's ownership changes are in-tree.
+
+## Files
+
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadNewPostsTests.cs
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadAllPostsTests.cs
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadNewVideosTests.cs
+- src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadAllVideosTests.cs
+- src\JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests\SyndicationFeedReaderOfflineTests.cs
+- src\JosephGuadagno.Broadcasting.YouTubeReader.Tests\YouTubeReaderFetchTests.cs
+- src\JosephGuadagno.Broadcasting.SyndicationFeedReader.IntegrationTests\SyndicationFeedReaderTests.cs
+- src\JosephGuadagno.Broadcasting.YouTubeReader.IntegrationTests\YouTubeReaderTests.cs
+
+---
+
+# Decision: User directive — Milestones as source of truth
+
+**Date:** 2026-04-20  
+**Timestamp:** 2026-04-20T11:12:58.467-07:00  
+**By:** Copilot  
+**Topic:** Sprint 21 kickoff and team process update
+
+## Decision
+
+**We are using milestones now for sprint work.**
+
+This user request replaces label-based sprint planning with GitHub milestone-based sprint planning. Milestones are the source of truth for sprint boundaries and issue scope.
+
+## Rationale
+
+User request — captured for team memory and future sprint planning decisions.
+
+## Impact
+
+- Scribe and coordinators reference .squad/identity/now.md for active sprint milestone name
+- Issue assignment to future sprints uses milestone assignment, not label assignment
+- Scope migration phases (#763–#769) scheduled across dedicated milestones to prevent Sprint 21 clutter
+
+
+---
+
+## Sprint 21 — PR #770–#772 Review & Policy Enforcement (2026-04-20)
+
+### User Directives Captured
+
+#### Directive 1: Branch & PR Organization
+**Timestamp:** 2026-04-20T11:45:27.348-07:00  
+**Source:** User (via Copilot)  
+**Decision:** All work must be done on branches; each block of work must have its own PR; Sprint 21 work must be separated with one PR per issue.  
+**Rationale:** User request — captured for team memory
+
+#### Directive 2: PR Review Comments
+**Timestamp:** 2026-04-20 13:20:44-07:00  
+**Source:** User (via Copilot)  
+**Decision:** Neo must add PR review findings as comments on the pull requests he reviews.  
+**Rationale:** User request — captured for team memory
+
+#### Directive 3: Markdown Backticks in Comments
+**Timestamp:** 2026-04-20 13:24:00-07:00  
+**Source:** User (via Copilot)  
+**Decision:** Use Markdown backticks for code names in PR comments; do not use backslash escaping.  
+**Rationale:** User request — captured for team memory
+
+#### Directive 4: Seed Bootstrap & PR Comment Formatting (PR #771)
+**Timestamp:** 2026-04-20 13:28:37-07:00  
+**Source:** User (via Copilot)  
+**Decision:** PR comments must use Markdown backticks for code identifiers. PR #771 should bootstrap seeded Entra OIDs via a variable in scripts\database\data-seed.sql with a TODO replacement note.  
+**Rationale:** User request — captured for team memory
+
+---
+
+### Agent Outcomes (2026-04-20)
+
+#### Scribe: Comment Formatting Fix (PR #771)
+- Fixed GitHub comment 4284036318 to use proper Markdown backticks for code identifiers
+- Status: ✅ COMPLETE
+
+#### Morpheus: Seed Bootstrap Patch (PR #771)
+- Patched scripts\database\data-seed.sql with placeholder Entra OID variable
+- Reused across seeded owner-aware records for fresh-database collector resolution
+- Commit: 978fc73
+- Validation: Docs lint clean; pre-existing Functions.Tests compile errors remain unrelated
+- Status: ✅ COMPLETE
+
+---
+
+## Decision: Repository Enforcement Model (2026-04-20)
+
+**Author:** Neo (Lead)  
+**Status:** PROPOSED  
+
+### Problem Statement
+
+The .squad/routing.md PR Policy has been violated multiple times (3rd violation). Branch protection blocks direct pushes to main but does NOT prevent:
+1. Local dirty work on main
+2. Mixed-issue changes before branching
+3. Missing PR linkage
+4. Stacked PR drift
+
+### Solution: 3-Layer Enforcement Model
+
+1. **Local Git Hooks** — Pre-commit blocks main commits; commit-msg requires conventional commits + issue reference
+2. **GitHub Actions** — PR title lint validates <type>(#issue) pattern
+3. **Branch Protection** — Existing hard block (preserved)
+4. **Coordinator Process** — Human + agent review-time enforcement
+
+### Minimum Implementation Package
+
+- .githooks/pre-commit — Blocks commits on main
+- .githooks/commit-msg — Requires conventional commits with issue footer
+- PR title lint workflow — Validates Conventional Commit format with issue reference
+- CONTRIBUTING.md update — Documents hook setup
+- PR template update — Adds branch policy checkbox
+
+### Decision
+
+Adopt 3-layer enforcement: local hooks (early feedback) + CI action (server-side gate) + branch protection (hard block).
+
+### Rationale
+
+- **Cost-benefit:** Git hooks catch violations at commit time with zero dependencies
+- **Escape hatch:** Developers can --no-verify for emergencies; CI still catches
+- **Squad workflow:** Agents can be configured at spawn to enable hooks
+- **Existing infra:** Leverages current CI structure
+
+---
+
+## Decision: Link PR Metadata Guardrails (2026-04-20)
+
+**Owner:** Link  
+**Scope:** GitHub Actions CI + PR template enforcement
+
+### Rules
+
+1. Branch names must be issue-<number> or eature/<number>-<slug>
+2. PR titles must follow <type>(#<number>): short description
+3. PR titles must reference exactly one issue
+4. Branch name issue number must match PR title issue number
+
+### Rationale
+
+- Enforcement in GitHub ensures policy applies consistently even if local hooks are missing
+- Scope limited to pull requests preserves existing push-to-main CI behavior
+- Aligns with Conventional Commit intent in CONTRIBUTING.md
+
+---
+
+## Decision: Commit Message Issue Linkage (2026-04-20)
+
+**Author:** Neo (Lead)
+
+### Decision
+
+Keep commit header as standard Conventional Commit and require issue reference in single footer line: Refs #NNN, Fixes #NNN, or Closes #NNN.
+
+### Why
+
+- Header stays focused on change intent and optional component scope
+- PR title already carries issue in header form
+- Single footer issue to single branch issue creates fail-closed local check without overloading scope field
+
+### Enforcement
+
+- .githooks/commit-msg validates Conventional Commit header
+- .githooks/commit-msg requires exactly one issue footer
+- .githooks/commit-msg rejects footer/branch issue mismatches
+
+---
+
+## Decision: Branch/PR Policy Remediation Pattern (2026-04-20)
+
+**Author:** Neo (Lead)
+
+### Pattern
+
+When work is accidentally committed to main:
+1. Stash all uncommitted changes with descriptive message
+2. Create branches from origin/main (not local main)
+3. Pop stash and selectively stage files per issue
+4. Use stacked PRs when issues have dependencies
+5. Leave local main intact for squad docs
+
+### Sprint 21 Application
+
+- Stash: Sprint21-uncommitted-work-backup
+- Branch chain: issue-761 → issue-760 → issue-762
+- PR chain: #770 (base: main) → #771 (base: issue-761) → #772 (base: issue-760)
+- Merge order: #770 first, then #771 (retarget to main), then #772 (retarget to main)
+
+### Prevention
+
+This is the third violation. The directive exists in .squad/routing.md and was reinforced in prior decisions. Agents must read decisions.md before starting work.
+
+---
+
+## Decision: Open PR Review Stack Order (#770, #771, #772)
+
+**Date:** 2026-04-20  
+**Status:** ✅ COMPLETE (Review)
+
+### Merge Order: Remains #770 → #771 → #772
+
+#### PR #770
+- Status: Ready in current stack order
+
+#### PR #771
+- **Blocked:** Fresh-environment bootstrap broken; scripts\database\data-seed.sql seeds collector source rows without CreatedByEntraOid
+- **New fail-closed owner resolution cannot resolve owner on clean database**
+- **Follow-up:** After #770 merges, rebase/retarget #771 onto updated base and rerun validation before merge
+
+#### PR #772
+- **Blocked:** Cross-issue payload; changes src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json even though this PR is collector regression coverage only
+- **Follow-up:** After #771 merges, retarget #772 to new base and remove unrelated Web config drift before merge
+

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,64 +1,55 @@
 # Team Focus — Now
 
-**Last updated:** 2026-04-10  
-**Sprint:** 13 (complete) → ready for Sprint 14  
-**Status:** All Sprint 13 issues closed. Main is up to date.  
-**Next:** Awaiting Sprint 14 feature planning from jguadagno.
+**Last updated:** 2026-04-20  
+**Sprint:** 21 (active)  
+**Status:** Sprint planning complete. Ready to start collector owner work.  
+**Next:** Begin implementation of #760, #761, #762 (collector owner OID threading).
 
 ## Current Focus
 
-Epic #667 is complete. All PRs merged, all issues closed. Team is now in post-epic maintenance mode.
+**Sprint 21 — Collector Owner OID Completeness (Epic #609 Round 1)**
 
-## Open Work
+Close the remaining Round 1 ownership gaps in the Functions collector flow:
 
-- #689: In-memory caching for SocialMediaPlatformManager (enhancement, not started)
+| Issue | Title | Squad |
+|---|---|---|
+| #760 | Source collector owner OID from collector records | trinity |
+| #761 | Remove empty-owner reader scaffolding | trinity |
+| #762 | Add regression coverage for collector owner threading | tank |
 
-## Last Completed
+**Goal:** All collector-triggered persistence paths thread a real owner OID from the source/collector record — no more global scaffold or empty-string fallbacks.
 
-Epic #667 — Social Media Platform Management System — fully shipped 2026-04-10
+## Future Sprints
 
-**PRs merged (Sprint 3):**
-1. ✅ #686 — Domain/data layer (SocialMediaPlatform model + repository)
-2. ✅ #685 — API endpoints + tests (EngagementsController platform sub-resources)
-3. ✅ #687 — Web Admin UI (SocialMediaPlatforms CRUD)
-4. ✅ #688 — Engagement edit page with platform selector
+The scope-to-role migration (#763–#769) is now scheduled across dedicated sprints:
 
-**Issues closed:**
-- #667 (epic) — completed
-- #682 (cleanup tracker) — completed
-- #53, #54, #536, #537 — closed as not planned (superseded)
+| Sprint | Phase | Issues |
+|---|---|---|
+| Sprint 22 | Phase 0 — Foundation | #763, #764 |
+| Sprint 23 | Phases 1-2 — Controller + test migration | #765, #766 |
+| Sprint 24 | Phases 3-4 — Cleanup + Entra portal | #767, #768, #769 |
 
-**Build Status:** Clean. All tests passing.  
-**Branch Status:** Main up to date. All feature branches deleted.
+## Standing Work
 
-## Key Patterns Established (Epic #667)
+- #689: In-memory caching for SocialMediaPlatformManager (backlog)
 
-1. **Social platform CRUD:** Full Web → Service → API → Manager → DataStore chain with ISocialMediaPlatformManager
-2. **includeInactive propagation:** When a filter capability exists at data layer, it must thread through every layer up to the Web controller call site
-3. **Details mirrors Edit:** Any ViewModel property loaded in `Edit` GET must also be loaded in `Details` GET if the view renders it
-4. **Test patterns:** Real `IMapper` in tests (not mocked); Manager tests use `default` CancellationToken; Controller tests use `It.IsAny<CancellationToken>()`
-5. **Process:** Full `dotnet test` required before every push — no exceptions, including after rebases
+## Key Patterns (Sprint 21)
+
+1. **Owner OID threading:** Collectors load owner OID from the collector/source record and pass it through `LoadNewPosts`, `LoadAllPosts`, `LoadNewVideos`, `LoadAllVideos`.
+2. **No empty-owner persistence:** Readers must require a non-empty `CreatedByEntraOid` on persisted records.
+3. **Regression tests:** Tests must fail if implementation falls back to removed scaffolding.
 
 ## Team Composition
 
-**Epic #667 Collaborators:**
-- Switch — Web layer (PR #687, #688 fixes)
-- Neo — Code review and tech lead decisions
-- Tank — Test automation
-- Coordinator — GitHub operations and branch management
-- Scribe — Session logging and decisions
+**Sprint 21:**
+- Trinity — Collector implementation (#760, #761)
+- Tank — Test coverage (#762)
+- Neo — Review & architecture
 
 **Rotating Roles:** Squad roster available in `.squad/team.md`
 
-## Metrics
-
-- **Epic #667 PRs:** 4 (#685, #686, #687, #688)
-- **Issues Closed:** 6 (#667, #682, #53, #54, #536, #537)
-- **Branches Deleted:** 5 local + remote pruned
-- **Build Status:** Clean (0 errors)
-
 ---
 
-**Last Updated:** 2026-04-10  
-**Epic Closed:** #667 (Social Media Platform Management)  
-**Next Decision Point:** Assign #689 (caching) or begin new epic
+**Last Updated:** 2026-04-20  
+**Sprint:** 21 (Collector Owner OID)  
+**Next Decision Point:** Sprint 22 kickoff after Sprint 21 closes

--- a/.squad/skills/collector-owner-oid-resolution/SKILL.md
+++ b/.squad/skills/collector-owner-oid-resolution/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: "collector-owner-oid-resolution"
+description: "Resolve collector ownership from persisted source records and fail closed on missing owner OIDs."
+domain: "azure-functions"
+confidence: "high"
+source: "earned"
+tools:
+  - name: "rg"
+    description: "Find collector call sites, reader overloads, and owner field usage."
+    when: "When tracing ownership flow across Functions, readers, managers, data stores, and tests."
+---
+
+## Context
+
+Use this when a background collector has no authenticated user context but still needs to persist owned records. In JJGNet Broadcasting, the Round 1 fix is to resolve the owner OID from existing persisted source records and pass that OID all the way into the reader that materializes new content.
+
+## Patterns
+
+- Add a narrow `GetCollectorOwnerOidAsync` helper on the relevant manager/data-store pair.
+- Resolve the owner OID at the Function boundary before calling the reader.
+- If the owner OID is missing or blank, fail closed and stop before persistence.
+- Reader methods that materialize persistable domain models should require `ownerOid` and throw on blank values.
+- Regression coverage should stub `GetCollectorOwnerOidAsync(...)` with a distinct owner value and verify the collector passes that exact value into `reader.GetAsync(...)`.
+- Regression coverage should verify `SaveAsync(...)` receives records whose `CreatedByEntraOid` is non-empty and matches the resolved owner.
+- Keep manually skipped integration tests compiling against the owner-aware overloads so repo-wide builds stay green.
+- Keep the scope narrow: do not broaden a collector-owner fix into OAuth/token-runtime redesign unless the issue explicitly asks for it.
+
+## Examples
+
+- `src\JosephGuadagno.Broadcasting.Functions/Collectors/CollectorOwnerOidResolver.cs`
+- `src\JosephGuadagno.Broadcasting.Functions/Collectors/SyndicationFeed/LoadNewPosts.cs`
+- `src\JosephGuadagno.Broadcasting.Functions/Collectors/YouTube/LoadNewVideos.cs`
+- `src\JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs`
+- `src\JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadAllVideosTests.cs`
+- `src\JosephGuadagno.Broadcasting.SyndicationFeedReader.Tests/SyndicationFeedReaderOfflineTests.cs`
+- `src\JosephGuadagno.Broadcasting.YouTubeReader.Tests/YouTubeReaderFetchTests.cs`
+
+## Anti-Patterns
+
+- Do not fall back to a global settings-level owner scaffold once source records already carry ownership.
+- Do not allow readers to construct persistable records with `CreatedByEntraOid = string.Empty`.
+- Do not hide missing-owner conditions by silently saving data with blank ownership.
+- Do not let skipped/manual integration tests drift onto removed overloads after the owner-aware interfaces become the contract.

--- a/.squad/skills/github-pr-comment/SKILL.md
+++ b/.squad/skills/github-pr-comment/SKILL.md
@@ -1,0 +1,28 @@
+# GitHub PR Comment via gh api (Windows PowerShell)
+
+## When to use
+- You need to leave a visible PR/issue comment from the CLI.
+- A regular comment is required instead of a formal GitHub review.
+
+## Pattern
+1. Build the comment body in PowerShell.
+2. Serialize `{ body = <comment text> }` to JSON with `ConvertTo-Json`.
+3. Write that JSON to a file inside the repo (not `/tmp`).
+4. Post with `gh api repos/<owner>/<repo>/issues/<number>/comments --method POST --input <json-file>`.
+5. Delete the temporary JSON file after the request succeeds.
+
+## Example
+```powershell
+$payloadPath = '.\\gh-comment-123.json'
+@{ body = 'Neo review note: concise finding here.' } |
+  ConvertTo-Json -Compress |
+  Set-Content -Path $payloadPath -Encoding utf8
+
+gh api repos\owner\repo\issues\123\comments --method POST --input $payloadPath
+
+Remove-Item $payloadPath -Force
+```
+
+## Why
+- Avoids shell-escaping issues with multiline comment bodies on Windows.
+- Produces a normal visible PR comment, which matches squad protocol for author-owned PRs.

--- a/.squad/skills/stacked-pr-review/SKILL.md
+++ b/.squad/skills/stacked-pr-review/SKILL.md
@@ -1,0 +1,19 @@
+# Stacked PR Review
+
+## Purpose
+
+Use this checklist when reviewing dependent pull requests in a stack.
+
+## Rules
+
+1. Review each PR against its declared base, not the imagined final squashed result.
+2. Treat "downstream PR fixes upstream build/test break" as a blocking defect.
+3. Treat unrelated file drift in a PR as blocking when it violates the one-PR-per-issue rule.
+4. Call out explicit merge order and required retargeting after each merge.
+5. Check clean-environment/bootstrap behavior separately from happy-path local state.
+
+## Sprint 21 Example
+
+- #770 is the base PR and must stand alone on `main`.
+- #771 cannot remove `Settings.OwnerEntraOid` unless its own branch also updates the Functions tests that still compile against that type.
+- #772 can add regression coverage on top of #771, but it cannot carry unrelated Web scope config changes.


### PR DESCRIPTION
This PR recovers the squad's institutional knowledge that existed only on the local backup branch `backup/main-before-sync-20260420-1407`.

## What's recovered:
- Team decisions and decision history
- Agent work histories and analysis documents  
- Session logs and ceremonies records
- Squad identity and configuration documents
- Custom skill definitions (collector-owner-oid-resolution, github-pr-comment, stacked-pr-review)

## Scope
All changes are scoped to the `.squad` directory and do not affect production code or systems.

## Notes
This is a documentation/metadata recovery. No merge is required — the branch is created for record-keeping and validation.