### PR TITLE
chore(#774): add local and CI PR guardrails

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+message_file="$1"
+first_line="$(sed -n '1p' "$message_file")"
+
+case "$first_line" in
+  Merge\ *|Revert\ *|fixup!\ *|squash!\ *)
+    exit 0
+    ;;
+esac
+
+if printf '%s' "$first_line" | grep -Eq '^(feat|fix|docs|style|refactor|perf|test|chore)(\([^)]+\))?(!)?: .+'; then
+  exit 0
+fi
+
+echo "Commit message must follow Conventional Commits."
+echo "Expected: <type>[optional scope]: <description>"
+echo "Example: chore(hooks): add PR guardrails"
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+branch_name="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+
+if [ -z "$branch_name" ]; then
+  exit 0
+fi
+
+if [ "$branch_name" = "main" ]; then
+  echo "Direct commits to 'main' are blocked. Create an issue branch and open a PR."
+  exit 1
+fi
+
+case "$branch_name" in
+  issue-[0-9]*|feature/[0-9]*)
+    ;;
+  *)
+    echo "Branch '$branch_name' does not follow the required issue naming convention."
+    echo "Use 'issue-<number>-<slug>' or 'feature/<number>-<slug>' (one issue per branch)."
+    exit 1
+    ;;
+esac
+
+if printf '%s' "$branch_name" | grep -Eq '(^issue-[0-9]+(-[a-z][a-z0-9]*)*$)|(^feature/[0-9]+(-[a-z][a-z0-9]*)*$)'; then
+  exit 0
+fi
+
+echo "Branch '$branch_name' must contain exactly one issue number and optional text slugs."
+echo "Examples: issue-774, issue-774-pr-guardrails, feature/774-pr-guardrails"
+exit 1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,35 @@
+# Pull Request
+
 ## Description
+
 Brief description of your changes.
 
 ## Related Issue
-Fixes #
+
+- Link exactly one issue with a closing keyword.
+- Example: `Closes #774`
+- Do not bundle multiple issues into one PR.
+
+Closes #
 
 ## Pre-Submission Checklist
-- [ ] All tests pass locally (`dotnet test .\src\ --configuration Release`)
+
+- [ ] My branch name follows the issue convention (`issue-<number>-<slug>` or `feature/<number>-<slug>`)
+- [ ] My PR title follows `<type>(#<issue>): <summary>` and matches the linked
+      issue above
+- [ ] I ran `.\scripts\setup-git-hooks.ps1` so the local branch and commit hooks
+      are active
+- [ ] I ran `dotnet restore .\src\`
+- [ ] I ran `dotnet build .\src\ --no-restore --configuration Release`
+- [ ] I ran `dotnet test .\src\ --no-build --verbosity normal --configuration
+      Release --filter "FullyQualifiedName!~SyndicationFeedReader"`
 - [ ] Zero test failures — I have not included known failures in this PR
-- [ ] No "Note on Remaining Test Failures" or similar acknowledgments in this description
+- [ ] This PR contains changes for exactly one issue
+- [ ] No "Note on Remaining Test Failures" or similar acknowledgments in this
+      description
 
 ## Type of Change
+
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Process/infrastructure change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,70 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-metadata:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR metadata
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          branch_pattern='^(issue-[0-9]+(-[a-z][a-z0-9]*)*|feature/[0-9]+(-[a-z][a-z0-9]*)*)$'
+          title_pattern='^(feat|fix|docs|style|refactor|perf|test|chore)\(#([0-9]+)\): .+'
+
+          if [[ ! "$BRANCH_NAME" =~ $branch_pattern ]]; then
+            echo "PR branch '$BRANCH_NAME' must follow 'issue-<number>-<slug>' or 'feature/<number>-<slug>' and contain exactly one issue number."
+            exit 1
+          fi
+
+          if [[ "$BRANCH_NAME" =~ ^issue/ ]]; then
+            echo "PR branch '$BRANCH_NAME' is invalid. Use 'issue-' instead of 'issue/'."
+            exit 1
+          fi
+
+          if [[ "$BRANCH_NAME" =~ ^issue-([0-9]+)(-[a-z][a-z0-9]*)*$ ]]; then
+            branch_issue="${BASH_REMATCH[1]}"
+          elif [[ "$BRANCH_NAME" =~ ^feature/([0-9]+)(-[a-z][a-z0-9]*)*$ ]]; then
+            branch_issue="${BASH_REMATCH[1]}"
+          else
+            echo "Unable to determine the issue number from branch '$BRANCH_NAME'."
+            exit 1
+          fi
+
+          if [[ ! "$PR_TITLE" =~ $title_pattern ]]; then
+            echo "PR title '$PR_TITLE' must follow '<type>(#<issue>): <summary>'."
+            exit 1
+          fi
+
+          title_issue="${BASH_REMATCH[2]}"
+
+          if [[ "$branch_issue" != "$title_issue" ]]; then
+            echo "Branch issue #$branch_issue does not match PR title issue #$title_issue."
+            exit 1
+          fi
+
+          mapfile -t linked_issues < <(printf '%s' "$PR_BODY" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | grep -oE '[0-9]+' || true)
+          unique_linked_issues="$(printf '%s\n' "${linked_issues[@]}" | sed '/^$/d' | sort -u)"
+          unique_issue_count="$(printf '%s\n' "$unique_linked_issues" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+          if [[ "$unique_issue_count" != "1" ]]; then
+            echo "PR body must link exactly one issue with Closes/Fixes/Resolves #<number>."
+            exit 1
+          fi
+
+          linked_issue="$(printf '%s\n' "$unique_linked_issues" | sed -n '1p')"
+
+          if [[ "$branch_issue" != "$linked_issue" ]]; then
+            echo "Branch issue #$branch_issue does not match linked PR body issue #$linked_issue."
+            exit 1
+          fi
+
+          echo "PR metadata validated for issue #$branch_issue."
+
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -258,3 +258,8 @@ Session logs and orchestration log recorded.
 - PR #771 (`issue-760`) currently removes `Settings.OwnerEntraOid` in `src\JosephGuadagno.Broadcasting.Functions\Models\Settings.cs` and `src\JosephGuadagno.Broadcasting.Functions\Interfaces\ISettings.cs`, but its branch still fails in `src\JosephGuadagno.Broadcasting.Functions.Tests\Collectors\LoadAllPostsTests.cs`, `LoadAllVideosTests.cs`, `LoadNewPostsTests.cs`, `LoadNewVideosTests.cs`, and `src\JosephGuadagno.Broadcasting.Functions.Tests\Startup.cs` because those tests still reference the deleted scaffold.
 - Fresh-environment bootstrap is still blocked independently of the PR stack: `scripts\database\data-seed.sql` seeds `SyndicationFeedSources` without `CreatedByEntraOid`, so the new fail-closed owner resolution cannot resolve an owner on a clean database until SQL seed data is aligned.
 - PR #772 (`issue-762`) validated green locally once stacked (`dotnet build .\src\ --no-restore --configuration Release` and CI-aligned `dotnet test`), but it also carries unrelated Web config drift in `src\JosephGuadagno.Broadcasting.Web\appsettings.Development.json`; that kind of cross-issue payload is a blocking review defect under the one-PR-per-issue rule.
+
+### 2026-04-20 — Local + CI PR guardrail package
+- Enforce the same single-issue rule in both places: local hooks for fast feedback, CI metadata validation for merge protection.
+- Branch names now standardize on `issue-<number>-<slug>` or `feature/<number>-<slug>` so the issue number is machine-readable.
+- PR titles must use `<type>(#<issue>): <summary>` and the PR body must carry exactly one matching closing issue reference.

--- a/.squad/skills/pr-guardrails/SKILL.md
+++ b/.squad/skills/pr-guardrails/SKILL.md
@@ -1,0 +1,34 @@
+# PR Guardrails
+
+## When to use
+
+- You need to add or repair branch and PR governance in this repository.
+- You need consistent local hook enforcement plus CI verification.
+
+## Rules
+
+- Branches must target exactly one issue:
+  - `issue-<number>-<slug>`
+  - `feature/<number>-<slug>`
+- PR titles must follow `<type>(#<issue>): <summary>`
+- PR bodies must include exactly one closing issue reference matching the branch
+  and PR title
+
+## Implementation pattern
+
+1. Add `.githooks\pre-commit` to block direct commits to `main` and reject
+   branch names without a single issue number.
+2. Add `.githooks\commit-msg` to enforce Conventional Commits.
+3. Add `scripts\setup-git-hooks.ps1` to configure `core.hooksPath` and the local
+   commit template.
+4. Add a PR-only CI job that validates branch name, PR title, and linked issue
+   matching without changing push-to-main build/test behavior.
+5. Update `CONTRIBUTING.md` and `.github\pull_request_template.md` so the local
+   and CI rules are explicit.
+
+## Why
+
+Local hooks fail fast for contributors, but CI is still required because hooks
+can be skipped or never installed. The branch name, PR title, and linked issue
+must all agree so "one issue per PR" is enforced mechanically instead of by
+memory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,51 @@
 Thank you for contributing! This project follows the Conventional Commits
 specification to keep the commit history clean and meaningful.
 
+## Branch and Pull Request Policy
+
+- All work must ship through a pull request. Do not commit directly to `main`.
+- Keep each branch and pull request tied to exactly one issue.
+- Name branches with the issue number:
+  - `issue-774`
+  - `issue-774-pr-guardrails`
+  - `feature/774-pr-guardrails`
+- Title pull requests as `<type>(#<issue>): <summary>`, for example
+  `chore(#774): add local and CI PR guardrails`.
+- Link exactly one issue in the PR body with a closing keyword such as
+  `Closes #774`.
+
+## Local Git Hooks
+
+Install the repository hooks after cloning:
+
+```powershell
+.\scripts\setup-git-hooks.ps1
+```
+
+That configures `core.hooksPath` to `.githooks` and sets the local commit
+template. The hooks block direct commits to `main`, enforce issue-based branch
+naming, and validate Conventional Commit messages before Git accepts a commit.
+
+## Local Validation
+
+Before opening a pull request, run the CI-aligned validation commands:
+
+```powershell
+dotnet restore .\src\
+dotnet build .\src\ --no-restore --configuration Release
+dotnet test .\src\ --no-build --verbosity normal --configuration Release `
+  --filter "FullyQualifiedName!~SyndicationFeedReader"
+```
+
 ## Commit Message Format
 
-    <type>[optional scope]: <description>
+```text
+<type>[optional scope]: <description>
 
-    [optional body]
+[optional body]
 
-    [optional footer(s)]
+[optional footer(s)]
+```
 
 ### 1. Types
 
@@ -30,14 +68,16 @@ specification to keep the commit history clean and meaningful.
 
 Indicates the area affected. Example:
 
-    feat(auth): add JWT authentication
+```text
+feat(auth): add JWT authentication
+```
 
 ***
 
 ### 3. Description
 
 - Use **imperative mood** (e.g., "add" not "added").
-- Keep it short (? 50 characters).
+- Keep it short (about 50 characters).
 
 ***
 
@@ -54,9 +94,18 @@ Explain **why** the change was made and any details for reviewers.
 
 Example:
 
-    feat(api): add new endpoint for user profiles
+```text
+feat(api): add new endpoint for user profiles
 
-    BREAKING CHANGE: The old `/users` endpoint has been removed.
+BREAKING CHANGE: The old `/users` endpoint has been removed.
+```
+
+Pull request titles follow the same pattern, but the scope must be the linked
+issue number:
+
+```text
+feat(#774): add local and CI PR guardrails
+```
 
 ***
 
@@ -73,8 +122,10 @@ Example:
 
 You can copy this template for your commits:
 
-    <type>(<scope>): <short summary>
+```text
+<type>(<scope>): <short summary>
 
-    [Optional body: Explain what and why]
+[Optional body: Explain what and why]
 
-    [Optional footer: BREAKING CHANGE or issue refs]
+[Optional footer: BREAKING CHANGE or issue refs]
+```

--- a/scripts/setup-git-hooks.ps1
+++ b/scripts/setup-git-hooks.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = git rev-parse --show-toplevel 2>$null
+
+if (-not $repoRoot) {
+    throw 'Run this script from inside the jjgnet-broadcast repository.'
+}
+
+Push-Location $repoRoot
+try {
+    git config --local core.hooksPath .githooks
+    git config --local commit.template .squad/commit-msg.txt
+
+    Write-Host 'Configured local Git hooks for jjgnet-broadcast.'
+    Write-Host '  core.hooksPath = .githooks'
+    Write-Host '  commit.template = .squad/commit-msg.txt'
+    Write-Host ''
+    Write-Host 'Git will now block commits to main, enforce issue-based branch names, and validate Conventional Commit messages.'
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add repo-local pre-commit and commit-msg hooks plus a setup script for installing them
- document branch, PR, and local validation rules in CONTRIBUTING.md and the PR template
- add a PR-only CI metadata gate for branch names, PR titles, and a single matching linked issue while preserving push-to-main build/test behavior

## Validation
- `npx -y markdownlint-cli@0.41.0 CONTRIBUTING.md .github\pull_request_template.md .squad\decisions\inbox\neo-pr-guardrails.md .squad\skills\pr-guardrails\SKILL.md`
- `dotnet restore .\src\`
- `dotnet build .\src\ --no-restore --configuration Release`
- `dotnet test .\src\ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"`
- exercised `.githooks\pre-commit`, `.githooks\commit-msg`, and the PR metadata validation logic locally with valid and invalid samples

Closes #774
