### PR TITLE
fix(#779): remove stale engagement DTO fields

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/MappingProfiles/ApiBroadcastingProfileTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/MappingProfiles/ApiBroadcastingProfileTests.cs
@@ -1,0 +1,86 @@
+using AutoMapper;
+using FluentAssertions;
+using JosephGuadagno.Broadcasting.Api.Dtos;
+using JosephGuadagno.Broadcasting.Api.MappingProfiles;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Api.Tests.MappingProfiles;
+
+public class ApiBroadcastingProfileTests
+{
+    private static readonly string[] RemovedEngagementFields =
+    [
+        nameof(EngagementContract.BlueSkyHandle),
+        nameof(EngagementContract.ConferenceHashtag),
+        nameof(EngagementContract.ConferenceTwitterHandle)
+    ];
+
+    private static readonly IMapper Mapper = new MapperConfiguration(
+        cfg => cfg.AddProfile<ApiBroadcastingProfile>(),
+        new LoggerFactory())
+        .CreateMapper();
+
+    [Theory]
+    [InlineData(typeof(EngagementRequest))]
+    [InlineData(typeof(EngagementResponse))]
+    public void EngagementDtos_WhenInspectingPublicProperties_ShouldNotExposeRemovedSocialFields(Type dtoType)
+    {
+        var propertyNames = dtoType.GetProperties().Select(property => property.Name);
+
+        propertyNames.Should().NotContain(RemovedEngagementFields);
+    }
+
+    [Fact]
+    public void ApiBroadcastingProfile_WhenMappingEngagementRequest_ShouldPopulateSupportedDomainFields()
+    {
+        var request = new EngagementRequest
+        {
+            Name = "SpringOne",
+            Url = "https://springone.example.com",
+            StartDateTime = DateTimeOffset.Parse("2026-09-14T09:00:00+00:00"),
+            EndDateTime = DateTimeOffset.Parse("2026-09-16T17:00:00+00:00"),
+            TimeZoneId = "UTC",
+            Comments = "Bring backup batteries."
+        };
+
+        var result = Mapper.Map<Engagement>(request);
+
+        result.Name.Should().Be(request.Name);
+        result.Url.Should().Be(request.Url);
+        result.StartDateTime.Should().Be(request.StartDateTime);
+        result.EndDateTime.Should().Be(request.EndDateTime);
+        result.TimeZoneId.Should().Be(request.TimeZoneId);
+        result.Comments.Should().Be(request.Comments);
+    }
+
+    [Fact]
+    public void ApiBroadcastingProfile_WhenMappingEngagementResponse_ShouldPopulateSupportedDtoFields()
+    {
+        var engagement = new Engagement
+        {
+            Id = 42,
+            Name = "SpringOne",
+            Url = "https://springone.example.com",
+            StartDateTime = DateTimeOffset.Parse("2026-09-14T09:00:00+00:00"),
+            EndDateTime = DateTimeOffset.Parse("2026-09-16T17:00:00+00:00"),
+            TimeZoneId = "UTC",
+            Comments = "Bring backup batteries.",
+            CreatedOn = DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+            LastUpdatedOn = DateTimeOffset.Parse("2026-01-15T00:00:00+00:00")
+        };
+
+        var result = Mapper.Map<EngagementResponse>(engagement);
+
+        result.Should().BeEquivalentTo(engagement, options => options
+            .ExcludingMissingMembers()
+            .Excluding(response => response.Talks));
+    }
+
+    private sealed class EngagementContract
+    {
+        public string? BlueSkyHandle { get; init; }
+        public string? ConferenceHashtag { get; init; }
+        public string? ConferenceTwitterHandle { get; init; }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/EngagementRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/EngagementRequest.cs
@@ -24,10 +24,4 @@ public class EngagementRequest
     public string TimeZoneId { get; set; } = string.Empty;
 
     public string? Comments { get; set; }
-
-    public string? BlueSkyHandle { get; set; }
-
-    public string? ConferenceHashtag { get; set; }
-
-    public string? ConferenceTwitterHandle { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/EngagementResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/EngagementResponse.cs
@@ -12,9 +12,6 @@ public class EngagementResponse
     public DateTimeOffset EndDateTime { get; set; }
     public string TimeZoneId { get; set; } = string.Empty;
     public string? Comments { get; set; }
-    public string? BlueSkyHandle { get; set; }
-    public string? ConferenceHashtag { get; set; }
-    public string? ConferenceTwitterHandle { get; set; }
     public List<TalkResponse>? Talks { get; set; }
     public DateTimeOffset CreatedOn { get; set; }
     public DateTimeOffset LastUpdatedOn { get; set; }


### PR DESCRIPTION
## Summary
- recover the accidental main edits for issue #779 into a dedicated branch
- remove the stale engagement social fields from the API request/response DTOs
- add focused API mapping regression coverage for the isolated cleanup

## Notes
This PR was recovered from accidental local edits made on main. It intentionally contains only the isolated #779 engagement DTO cleanup and excludes unrelated .squad or other local work.

Closes #779