### PR TITLE
docs(#780): add missing API XML docs

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/UserPublisherSettingsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/UserPublisherSettingsController.cs
@@ -10,6 +10,9 @@ using Microsoft.Identity.Web.Resource;
 
 namespace JosephGuadagno.Broadcasting.Api.Controllers;
 
+/// <summary>
+/// Manages per-user publisher settings for each social media platform.
+/// </summary>
 [ApiController]
 [Authorize]
 [IgnoreAntiforgeryToken]
@@ -23,6 +26,16 @@ public class UserPublisherSettingsController(
     private static string SanitizeForLog(string? value) =>
         value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
+    /// <summary>
+    /// Gets every publisher setting visible to the current caller.
+    /// </summary>
+    /// <param name="ownerOid">
+    /// Optional Entra object ID to query. Non-admin callers can only query their own settings.
+    /// </param>
+    /// <returns>A list of publisher settings for the resolved owner.</returns>
+    /// <response code="200">Returns the publisher settings for the resolved owner.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller is not allowed to query the requested owner.</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<UserPublisherSettingResponse>))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -41,6 +54,18 @@ public class UserPublisherSettingsController(
         return Ok(mapper.Map<List<UserPublisherSettingResponse>>(settings));
     }
 
+    /// <summary>
+    /// Gets the publisher settings for a single social media platform.
+    /// </summary>
+    /// <param name="platformId">The social media platform identifier.</param>
+    /// <param name="ownerOid">
+    /// Optional Entra object ID to query. Non-admin callers can only query their own settings.
+    /// </param>
+    /// <returns>The publisher settings for the requested platform.</returns>
+    /// <response code="200">Returns the publisher settings for the platform.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller is not allowed to query the requested owner.</response>
+    /// <response code="404">No publisher settings exist for the resolved owner and platform.</response>
     [HttpGet("{platformId:int}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UserPublisherSettingResponse))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -69,6 +94,19 @@ public class UserPublisherSettingsController(
         return Ok(mapper.Map<UserPublisherSettingResponse>(setting));
     }
 
+    /// <summary>
+    /// Creates or updates the publisher settings for a social media platform.
+    /// </summary>
+    /// <param name="platformId">The social media platform identifier.</param>
+    /// <param name="ownerOid">
+    /// Optional Entra object ID to target. Non-admin callers can only save their own settings.
+    /// </param>
+    /// <param name="request">The publisher settings payload to save.</param>
+    /// <returns>The saved publisher settings.</returns>
+    /// <response code="200">Returns the saved publisher settings.</response>
+    /// <response code="400">The request payload was invalid or the settings could not be saved.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller is not allowed to save settings for the requested owner.</response>
     [HttpPut("{platformId:int}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UserPublisherSettingResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -110,6 +148,18 @@ public class UserPublisherSettingsController(
         return Ok(mapper.Map<UserPublisherSettingResponse>(saved));
     }
 
+    /// <summary>
+    /// Deletes the publisher settings for a social media platform.
+    /// </summary>
+    /// <param name="platformId">The social media platform identifier.</param>
+    /// <param name="ownerOid">
+    /// Optional Entra object ID to target. Non-admin callers can only delete their own settings.
+    /// </param>
+    /// <returns>No content when the delete succeeds.</returns>
+    /// <response code="204">The publisher settings were deleted.</response>
+    /// <response code="401">The caller is not authenticated.</response>
+    /// <response code="403">The caller is not allowed to delete settings for the requested owner.</response>
+    /// <response code="404">No publisher settings exist for the resolved owner and platform.</response>
     [HttpDelete("{platformId:int}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/UserPublisherSettingRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/UserPublisherSettingRequest.cs
@@ -1,60 +1,141 @@
 namespace JosephGuadagno.Broadcasting.Api.Dtos;
 
+/// <summary>
+/// Request DTO for creating or updating a user's publisher settings for a platform.
+/// </summary>
 public class UserPublisherSettingRequest
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether publishing is enabled for the platform.
+    /// </summary>
     public bool IsEnabled { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Bluesky-specific settings.
+    /// </summary>
     public BlueskyPublisherSettingRequest? Bluesky { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Twitter-specific settings.
+    /// </summary>
     public TwitterPublisherSettingRequest? Twitter { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook-specific settings.
+    /// </summary>
     public FacebookPublisherSettingRequest? Facebook { get; set; }
 
+    /// <summary>
+    /// Gets or sets the LinkedIn-specific settings.
+    /// </summary>
     public LinkedInPublisherSettingRequest? LinkedIn { get; set; }
 }
 
+/// <summary>
+/// Request DTO for Bluesky publisher settings.
+/// </summary>
 public class BlueskyPublisherSettingRequest
 {
+    /// <summary>
+    /// Gets or sets the Bluesky account user name.
+    /// </summary>
     public string? UserName { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Bluesky app password.
+    /// </summary>
     public string? AppPassword { get; set; }
 }
 
+/// <summary>
+/// Request DTO for Twitter publisher settings.
+/// </summary>
 public class TwitterPublisherSettingRequest
 {
+    /// <summary>
+    /// Gets or sets the Twitter consumer key.
+    /// </summary>
     public string? ConsumerKey { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Twitter consumer secret.
+    /// </summary>
     public string? ConsumerSecret { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Twitter access token.
+    /// </summary>
     public string? AccessToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Twitter access token secret.
+    /// </summary>
     public string? AccessTokenSecret { get; set; }
 }
 
+/// <summary>
+/// Request DTO for Facebook publisher settings.
+/// </summary>
 public class FacebookPublisherSettingRequest
 {
+    /// <summary>
+    /// Gets or sets the Facebook page identifier.
+    /// </summary>
     public string? PageId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook application identifier.
+    /// </summary>
     public string? AppId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook page access token.
+    /// </summary>
     public string? PageAccessToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook application secret.
+    /// </summary>
     public string? AppSecret { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook client token.
+    /// </summary>
     public string? ClientToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook short-lived access token.
+    /// </summary>
     public string? ShortLivedAccessToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook long-lived access token.
+    /// </summary>
     public string? LongLivedAccessToken { get; set; }
 }
 
+/// <summary>
+/// Request DTO for LinkedIn publisher settings.
+/// </summary>
 public class LinkedInPublisherSettingRequest
 {
+    /// <summary>
+    /// Gets or sets the LinkedIn author identifier.
+    /// </summary>
     public string? AuthorId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the LinkedIn client identifier.
+    /// </summary>
     public string? ClientId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the LinkedIn client secret.
+    /// </summary>
     public string? ClientSecret { get; set; }
 
+    /// <summary>
+    /// Gets or sets the LinkedIn access token.
+    /// </summary>
     public string? AccessToken { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/UserPublisherSettingResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/UserPublisherSettingResponse.cs
@@ -1,72 +1,171 @@
 namespace JosephGuadagno.Broadcasting.Api.Dtos;
 
+/// <summary>
+/// Response DTO for a user's publisher settings for a platform.
+/// </summary>
 public class UserPublisherSettingResponse
 {
+    /// <summary>
+    /// Gets or sets the publisher setting identifier.
+    /// </summary>
     public int Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Entra object ID of the owner who created the settings.
+    /// </summary>
     public string CreatedByEntraOid { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the social media platform identifier.
+    /// </summary>
     public int SocialMediaPlatformId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the social media platform metadata.
+    /// </summary>
     public SocialMediaPlatformResponse? SocialMediaPlatform { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether publishing is enabled for the platform.
+    /// </summary>
     public bool IsEnabled { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Bluesky-specific settings metadata.
+    /// </summary>
     public BlueskyPublisherSettingResponse? Bluesky { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Twitter-specific settings metadata.
+    /// </summary>
     public TwitterPublisherSettingResponse? Twitter { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook-specific settings metadata.
+    /// </summary>
     public FacebookPublisherSettingResponse? Facebook { get; set; }
 
+    /// <summary>
+    /// Gets or sets the LinkedIn-specific settings metadata.
+    /// </summary>
     public LinkedInPublisherSettingResponse? LinkedIn { get; set; }
 
+    /// <summary>
+    /// Gets or sets when the publisher settings were created.
+    /// </summary>
     public DateTimeOffset CreatedOn { get; set; }
 
+    /// <summary>
+    /// Gets or sets when the publisher settings were last updated.
+    /// </summary>
     public DateTimeOffset LastUpdatedOn { get; set; }
 }
 
+/// <summary>
+/// Response DTO for Bluesky publisher settings.
+/// </summary>
 public class BlueskyPublisherSettingResponse
 {
+    /// <summary>
+    /// Gets or sets the Bluesky account user name.
+    /// </summary>
     public string? UserName { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether an app password is configured.
+    /// </summary>
     public bool HasAppPassword { get; set; }
 }
 
+/// <summary>
+/// Response DTO for Twitter publisher settings.
+/// </summary>
 public class TwitterPublisherSettingResponse
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether a consumer key is configured.
+    /// </summary>
     public bool HasConsumerKey { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a consumer secret is configured.
+    /// </summary>
     public bool HasConsumerSecret { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether an access token is configured.
+    /// </summary>
     public bool HasAccessToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether an access token secret is configured.
+    /// </summary>
     public bool HasAccessTokenSecret { get; set; }
 }
 
+/// <summary>
+/// Response DTO for Facebook publisher settings.
+/// </summary>
 public class FacebookPublisherSettingResponse
 {
+    /// <summary>
+    /// Gets or sets the Facebook page identifier.
+    /// </summary>
     public string? PageId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Facebook application identifier.
+    /// </summary>
     public string? AppId { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a page access token is configured.
+    /// </summary>
     public bool HasPageAccessToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether an app secret is configured.
+    /// </summary>
     public bool HasAppSecret { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a client token is configured.
+    /// </summary>
     public bool HasClientToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a short-lived access token is configured.
+    /// </summary>
     public bool HasShortLivedAccessToken { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a long-lived access token is configured.
+    /// </summary>
     public bool HasLongLivedAccessToken { get; set; }
 }
 
+/// <summary>
+/// Response DTO for LinkedIn publisher settings.
+/// </summary>
 public class LinkedInPublisherSettingResponse
 {
+    /// <summary>
+    /// Gets or sets the LinkedIn author identifier.
+    /// </summary>
     public string? AuthorId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the LinkedIn client identifier.
+    /// </summary>
     public string? ClientId { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a client secret is configured.
+    /// </summary>
     public bool HasClientSecret { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether an access token is configured.
+    /// </summary>
     public bool HasAccessToken { get; set; }
 }


### PR DESCRIPTION
## Summary
- add XML documentation for the UserPublisherSettings API endpoints
- document the request and response DTOs used by the user publisher settings API
- keep the change scoped to OpenAPI/API documentation only

## Validation
- dotnet build .\src\ --no-restore --configuration Release
- dotnet test .\src\ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"

Closes #780