### PR TITLE
fix(#784): add retry-safe collector saves for Azure SQL

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/DbContextTransactionExtensionsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/DbContextTransactionExtensionsTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Moq;
+using Xunit;
+
+namespace JosephGuadagno.Broadcasting.Data.Sql.Tests;
+
+public class DbContextTransactionExtensionsTests
+{
+    [Fact]
+    public async Task ExecuteInTransactionIfSupportedAsync_UsesExecutionStrategyToOwnTransaction()
+    {
+        var options = new DbContextOptionsBuilder<BroadcastingContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new BroadcastingContext(options);
+        var executionStrategy = new TrackingExecutionStrategy(context);
+        var transaction = new Mock<IDbContextTransaction>();
+        var transactionStartedInsideStrategy = false;
+        var operationExecutedInsideStrategy = false;
+
+        await DbContextTransactionExtensions.ExecuteInTransactionIfSupportedAsync(
+            executionStrategy,
+            ct =>
+            {
+                transactionStartedInsideStrategy = executionStrategy.IsExecuting;
+                return Task.FromResult(transaction.Object);
+            },
+            ct =>
+            {
+                operationExecutedInsideStrategy = executionStrategy.IsExecuting;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.True(transactionStartedInsideStrategy);
+        Assert.True(operationExecutedInsideStrategy);
+        Assert.Equal(1, executionStrategy.ExecuteAsyncCallCount);
+        transaction.Verify(t => t.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteInTransactionIfSupportedAsync_InMemoryProvider_RunsWithoutTransaction()
+    {
+        var options = new DbContextOptionsBuilder<BroadcastingContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new BroadcastingContext(options);
+        var operationCalled = false;
+
+        await context.ExecuteInTransactionIfSupportedAsync(
+            () =>
+            {
+                operationCalled = true;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.True(operationCalled);
+    }
+
+    private sealed class TrackingExecutionStrategy(DbContext dbContext) : IExecutionStrategy
+    {
+        public int ExecuteAsyncCallCount { get; private set; }
+
+        public bool IsExecuting { get; private set; }
+
+        public bool RetriesOnFailure => true;
+
+        public TResult Execute<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, TResult> operation,
+            Func<DbContext, TState, ExecutionResult<TResult>>? verifySucceeded)
+        {
+            IsExecuting = true;
+            try
+            {
+                return operation(dbContext, state);
+            }
+            finally
+            {
+                IsExecuting = false;
+            }
+        }
+
+        public async Task<TResult> ExecuteAsync<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>>? verifySucceeded,
+            CancellationToken cancellationToken = default)
+        {
+            ExecuteAsyncCallCount++;
+            IsExecuting = true;
+            try
+            {
+                return await operation(dbContext, state, cancellationToken);
+            }
+            finally
+            {
+                IsExecuting = false;
+            }
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/DbContextTransactionExtensionsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/DbContextTransactionExtensionsTests.cs
@@ -40,6 +40,42 @@ public class DbContextTransactionExtensionsTests
     }
 
     [Fact]
+    public async Task ExecuteInTransactionIfSupportedAsync_RetriesOperationAndReturnsResult()
+    {
+        var options = new DbContextOptionsBuilder<BroadcastingContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new BroadcastingContext(options);
+        var executionStrategy = new RetryingExecutionStrategy(context);
+        var firstTransaction = new Mock<IDbContextTransaction>();
+        var secondTransaction = new Mock<IDbContextTransaction>();
+        var transactions = new Queue<IDbContextTransaction>([firstTransaction.Object, secondTransaction.Object]);
+        var operationAttempts = 0;
+
+        var result = await DbContextTransactionExtensions.ExecuteInTransactionIfSupportedAsync(
+            executionStrategy,
+            _ => Task.FromResult(transactions.Dequeue()),
+            _ =>
+            {
+                operationAttempts++;
+
+                if (operationAttempts == 1)
+                {
+                    throw new InvalidOperationException("Transient failure");
+                }
+
+                return Task.FromResult(42);
+            },
+            CancellationToken.None);
+
+        Assert.Equal(42, result);
+        Assert.Equal(2, operationAttempts);
+        Assert.Equal(2, executionStrategy.Attempts);
+        firstTransaction.Verify(t => t.CommitAsync(It.IsAny<CancellationToken>()), Times.Never);
+        secondTransaction.Verify(t => t.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task ExecuteInTransactionIfSupportedAsync_InMemoryProvider_RunsWithoutTransaction()
     {
         var options = new DbContextOptionsBuilder<BroadcastingContext>()
@@ -98,6 +134,38 @@ public class DbContextTransactionExtensionsTests
             finally
             {
                 IsExecuting = false;
+            }
+        }
+    }
+
+    private sealed class RetryingExecutionStrategy(DbContext dbContext) : IExecutionStrategy
+    {
+        public int Attempts { get; private set; }
+
+        public bool RetriesOnFailure => true;
+
+        public TResult Execute<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, TResult> operation,
+            Func<DbContext, TState, ExecutionResult<TResult>>? verifySucceeded)
+            => throw new NotSupportedException();
+
+        public async Task<TResult> ExecuteAsync<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>>? verifySucceeded,
+            CancellationToken cancellationToken = default)
+        {
+            Attempts++;
+
+            try
+            {
+                return await operation(dbContext, state, cancellationToken);
+            }
+            catch (InvalidOperationException) when (Attempts == 1)
+            {
+                Attempts++;
+                return await operation(dbContext, state, cancellationToken);
             }
         }
     }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/DbContextTransactionExtensions.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/DbContextTransactionExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace JosephGuadagno.Broadcasting.Data.Sql;
+
+internal static class DbContextTransactionExtensions
+{
+    public static Task ExecuteInTransactionIfSupportedAsync(
+        this BroadcastingContext context,
+        Func<Task> operation,
+        CancellationToken cancellationToken)
+    {
+        if (context.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
+        {
+            return operation();
+        }
+
+        return ExecuteInTransactionIfSupportedAsync(
+            context.Database.CreateExecutionStrategy(),
+            ct => context.Database.BeginTransactionAsync(ct),
+            ct => operation(),
+            cancellationToken);
+    }
+
+    internal static Task ExecuteInTransactionIfSupportedAsync(
+        IExecutionStrategy executionStrategy,
+        Func<CancellationToken, Task<IDbContextTransaction>> beginTransactionAsync,
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        return executionStrategy.ExecuteAsync<object?, bool>(
+            null,
+            async (_, _, ct) =>
+            {
+                await using var transaction = await beginTransactionAsync(ct);
+                await operation(ct);
+                await transaction.CommitAsync(ct);
+                return true;
+            },
+            null,
+            cancellationToken);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/DbContextTransactionExtensions.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/DbContextTransactionExtensions.cs
@@ -9,16 +9,36 @@ internal static class DbContextTransactionExtensions
         this BroadcastingContext context,
         Func<Task> operation,
         CancellationToken cancellationToken)
+        => context.ExecuteInTransactionIfSupportedAsync(
+            _ => operation(),
+            cancellationToken);
+
+    public static Task ExecuteInTransactionIfSupportedAsync(
+        this BroadcastingContext context,
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+        => context.ExecuteInTransactionIfSupportedAsync(
+            async ct =>
+            {
+                await operation(ct);
+                return true;
+            },
+            cancellationToken);
+
+    public static Task<TResult> ExecuteInTransactionIfSupportedAsync<TResult>(
+        this BroadcastingContext context,
+        Func<CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken)
     {
         if (context.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
         {
-            return operation();
+            return operation(cancellationToken);
         }
 
         return ExecuteInTransactionIfSupportedAsync(
             context.Database.CreateExecutionStrategy(),
             ct => context.Database.BeginTransactionAsync(ct),
-            ct => operation(),
+            operation,
             cancellationToken);
     }
 
@@ -27,15 +47,30 @@ internal static class DbContextTransactionExtensions
         Func<CancellationToken, Task<IDbContextTransaction>> beginTransactionAsync,
         Func<CancellationToken, Task> operation,
         CancellationToken cancellationToken)
+        => ExecuteInTransactionIfSupportedAsync(
+            executionStrategy,
+            beginTransactionAsync,
+            async ct =>
+            {
+                await operation(ct);
+                return true;
+            },
+            cancellationToken);
+
+    internal static Task<TResult> ExecuteInTransactionIfSupportedAsync<TResult>(
+        IExecutionStrategy executionStrategy,
+        Func<CancellationToken, Task<IDbContextTransaction>> beginTransactionAsync,
+        Func<CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken)
     {
-        return executionStrategy.ExecuteAsync<object?, bool>(
+        return executionStrategy.ExecuteAsync<object?, TResult>(
             null,
             async (_, _, ct) =>
             {
                 await using var transaction = await beginTransactionAsync(ct);
-                await operation(ct);
+                var result = await operation(ct);
                 await transaction.CommitAsync(ct);
-                return true;
+                return result;
             },
             null,
             cancellationToken);

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Properties/AssemblyInfo.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("JosephGuadagno.Broadcasting.Data.Sql.Tests")]

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
@@ -34,7 +34,7 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
             broadcastingContext.Entry(dbSyndicationFeedSource).State =
                 dbSyndicationFeedSource.Id == 0 ? EntityState.Added : EntityState.Modified;
 
-            await ExecuteWithOptionalTransactionAsync(async () =>
+            await broadcastingContext.ExecuteInTransactionIfSupportedAsync(async () =>
             {
                 await broadcastingContext.SaveChangesAsync(cancellationToken);
                 await SyncSourceTagsAsync(dbSyndicationFeedSource.Id, entity.Tags, cancellationToken);
@@ -228,19 +228,6 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
         }
 
         return dbSyndicationFeedSource is null ? null : mapper.Map<Domain.Models.SyndicationFeedSource>(dbSyndicationFeedSource);
-    }
-
-    private async Task ExecuteWithOptionalTransactionAsync(Func<Task> operation, CancellationToken cancellationToken)
-    {
-        if (broadcastingContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
-        {
-            await operation();
-            return;
-        }
-
-        await using var tx = await broadcastingContext.Database.BeginTransactionAsync(cancellationToken);
-        await operation();
-        await tx.CommitAsync(cancellationToken);
     }
 
     private async Task SyncSourceTagsAsync(int sourceId, IList<string> tags, CancellationToken cancellationToken)

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/SyndicationFeedSourceDataStore.cs
@@ -30,18 +30,20 @@ public class SyndicationFeedSourceDataStore(BroadcastingContext broadcastingCont
     {
         try
         {
-            var dbSyndicationFeedSource = mapper.Map<Models.SyndicationFeedSource>(entity);
-            broadcastingContext.Entry(dbSyndicationFeedSource).State =
-                dbSyndicationFeedSource.Id == 0 ? EntityState.Added : EntityState.Modified;
-
-            await broadcastingContext.ExecuteInTransactionIfSupportedAsync(async () =>
+            var sourceId = await broadcastingContext.ExecuteInTransactionIfSupportedAsync(async ct =>
             {
-                await broadcastingContext.SaveChangesAsync(cancellationToken);
-                await SyncSourceTagsAsync(dbSyndicationFeedSource.Id, entity.Tags, cancellationToken);
+                var dbSyndicationFeedSource = mapper.Map<Models.SyndicationFeedSource>(entity);
+                broadcastingContext.Entry(dbSyndicationFeedSource).State =
+                    dbSyndicationFeedSource.Id == 0 ? EntityState.Added : EntityState.Modified;
+
+                await broadcastingContext.SaveChangesAsync(ct);
+                await SyncSourceTagsAsync(dbSyndicationFeedSource.Id, entity.Tags, ct);
+
+                return dbSyndicationFeedSource.Id;
             }, cancellationToken);
 
             var saved = await broadcastingContext.SyndicationFeedSources
-                .FirstOrDefaultAsync(s => s.Id == dbSyndicationFeedSource.Id, cancellationToken);
+                .FirstOrDefaultAsync(s => s.Id == sourceId, cancellationToken);
 
             if (saved is not null)
             {

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
@@ -33,7 +33,7 @@ public class YouTubeSourceDataStore(BroadcastingContext broadcastingContext, IMa
             broadcastingContext.Entry(dbYouTubeSource).State =
                 dbYouTubeSource.Id == 0 ? EntityState.Added : EntityState.Modified;
 
-            await ExecuteWithOptionalTransactionAsync(async () =>
+            await broadcastingContext.ExecuteInTransactionIfSupportedAsync(async () =>
             {
                 await broadcastingContext.SaveChangesAsync(cancellationToken);
                 await SyncSourceTagsAsync(dbYouTubeSource.Id, entity.Tags, cancellationToken);
@@ -164,19 +164,6 @@ public class YouTubeSourceDataStore(BroadcastingContext broadcastingContext, IMa
             .FirstOrDefaultAsync(cancellationToken);
 
         return string.IsNullOrWhiteSpace(ownerOid) ? null : ownerOid;
-    }
-
-    private async Task ExecuteWithOptionalTransactionAsync(Func<Task> operation, CancellationToken cancellationToken)
-    {
-        if (broadcastingContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
-        {
-            await operation();
-            return;
-        }
-
-        await using var tx = await broadcastingContext.Database.BeginTransactionAsync(cancellationToken);
-        await operation();
-        await tx.CommitAsync(cancellationToken);
     }
 
     private async Task SyncSourceTagsAsync(int sourceId, IList<string> tags, CancellationToken cancellationToken)

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/YouTubeSourceDataStore.cs
@@ -29,18 +29,20 @@ public class YouTubeSourceDataStore(BroadcastingContext broadcastingContext, IMa
     {
         try
         {
-            var dbYouTubeSource = mapper.Map<Models.YouTubeSource>(entity);
-            broadcastingContext.Entry(dbYouTubeSource).State =
-                dbYouTubeSource.Id == 0 ? EntityState.Added : EntityState.Modified;
-
-            await broadcastingContext.ExecuteInTransactionIfSupportedAsync(async () =>
+            var sourceId = await broadcastingContext.ExecuteInTransactionIfSupportedAsync(async ct =>
             {
-                await broadcastingContext.SaveChangesAsync(cancellationToken);
-                await SyncSourceTagsAsync(dbYouTubeSource.Id, entity.Tags, cancellationToken);
+                var dbYouTubeSource = mapper.Map<Models.YouTubeSource>(entity);
+                broadcastingContext.Entry(dbYouTubeSource).State =
+                    dbYouTubeSource.Id == 0 ? EntityState.Added : EntityState.Modified;
+
+                await broadcastingContext.SaveChangesAsync(ct);
+                await SyncSourceTagsAsync(dbYouTubeSource.Id, entity.Tags, ct);
+
+                return dbYouTubeSource.Id;
             }, cancellationToken);
 
             var saved = await broadcastingContext.YouTubeSources
-                .FirstOrDefaultAsync(y => y.Id == dbYouTubeSource.Id, cancellationToken);
+                .FirstOrDefaultAsync(y => y.Id == sourceId, cancellationToken);
 
             if (saved is not null)
             {

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/Collectors/LoadNewPostsTests.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
-using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Functions.Collectors.SyndicationFeed;
 using JosephGuadagno.Broadcasting.Functions.Interfaces;
@@ -277,6 +277,48 @@ public class LoadNewPostsTests
         // Assert
         _urlShortener.Verify(u => u.GetShortenedUrlAsync(item.Url, "short.example.com"), Times.Once);
         _feedSourceManager.Verify(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p => p.ShortenedUrl == "https://short.example.com/abc")), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_ContinuesWhenSaveThrowsExecutionStrategyTransactionError()
+    {
+        // Arrange
+        var failedItem = CreateFeedSource("transaction-failure");
+        var successfulItem = CreateFeedSource("transaction-success");
+        var savedItem = CreateFeedSource("transaction-success");
+        savedItem.Id = 77;
+
+        SetupFeedCheck();
+        _feedCheckManager.Setup(f => f.SaveAsync(It.IsAny<FeedCheck>()))
+            .ReturnsAsync(OperationResult<FeedCheck>.Success(new FeedCheck()));
+        _feedReader.Setup(r => r.GetAsync(OwnerEntraOid, It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new List<SyndicationFeedSource> { failedItem, successfulItem });
+        _feedSourceManager.Setup(m => m.GetByFeedIdentifierAsync("transaction-failure"))
+            .ReturnsAsync((SyndicationFeedSource?)null);
+        _feedSourceManager.Setup(m => m.GetByFeedIdentifierAsync("transaction-success"))
+            .ReturnsAsync((SyndicationFeedSource?)null);
+        _urlShortener.Setup(u => u.GetShortenedUrlAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("https://short.example.com/txn");
+        _feedSourceManager.Setup(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p => p.FeedIdentifier == "transaction-failure")))
+            .ThrowsAsync(new InvalidOperationException("The configured execution strategy 'SqlServerRetryingExecutionStrategy' does not support user-initiated transactions."));
+        _feedSourceManager.Setup(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p => p.FeedIdentifier == "transaction-success")))
+            .ReturnsAsync(OperationResult<SyndicationFeedSource>.Success(savedItem));
+
+        // Act
+        var result = await _sut.RunAsync(null!);
+
+        // Assert
+        _feedSourceManager.Verify(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p => p.FeedIdentifier == "transaction-failure")), Times.Exactly(4));
+        _feedSourceManager.Verify(m => m.SaveAsync(It.Is<SyndicationFeedSource>(p => p.FeedIdentifier == "transaction-success")), Times.Once);
+        _eventPublisher.Verify(
+            e => e.PublishSyndicationFeedEventsAsync(
+                It.IsAny<string>(),
+                It.Is<IReadOnlyCollection<SyndicationFeedSource>>(items =>
+                    items.Count == 1 && items.Single().FeedIdentifier == "transaction-success")),
+            Times.Once);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("Loaded 1 of 2 post(s)", okResult.Value!.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- run the collector save path inside the EF Core execution strategy so Azure SQL retries can safely wrap the transaction
- share the retry-safe transaction helper across feed and YouTube source data stores
- add regression coverage for the retry helper and the collector path that saves new posts

## Testing
- dotnet restore .\src\
- dotnet build .\src\ --no-restore --configuration Release
- dotnet test .\src\ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"

Closes #784