### PR TITLE
feat(#817): add SyndicationFeedSourcesController with full CRUD endpoints

### DIFF
--- a/scripts/database/data-seed.sql
+++ b/scripts/database/data-seed.sql
@@ -97,6 +97,18 @@ IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Mast
     INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
     VALUES (N'Mastodon', N'https://mastodon.social', N'bi-mastodon', 1)
 
+-- Seed CredentialSetupDocumentationUrl for SocialMediaPlatforms (Issue #812)
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/twitter'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'Twitter'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/bluesky'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'BlueSky'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/linkedin'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'LinkedIn'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/facebook'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'Facebook'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/mastodon'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'Mastodon'
+
 -- Seed the EmailTemplates table (Issue #615)
 IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.EmailTemplates WHERE Name = N'UserApproved')
     INSERT INTO JJGNet.dbo.EmailTemplates (Name, Subject, Body) VALUES (

--- a/scripts/database/table-create.sql
+++ b/scripts/database/table-create.sql
@@ -294,7 +294,8 @@ create table dbo.SocialMediaPlatforms
             unique,
     Url      nvarchar(500) null,
     Icon     nvarchar(100) null,
-    IsActive bit default 1 not null
+    IsActive bit default 1 not null,
+    CredentialSetupDocumentationUrl nvarchar(500) null
 )
 go
 

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SyndicationFeedSourcesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SyndicationFeedSourcesController.cs
@@ -1,0 +1,191 @@
+using System.Security.Claims;
+using AutoMapper;
+using JosephGuadagno.Broadcasting.Api.Dtos;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Api.Controllers;
+
+/// <summary>
+/// Works with the Syndication Feed Sources of JosephGuadagno.NET Broadcasting
+/// </summary>
+[ApiController]
+[Authorize]
+[IgnoreAntiforgeryToken]
+[Route("[controller]")]
+[Produces("application/json")]
+public class SyndicationFeedSourcesController : ControllerBase
+{
+    private readonly ISyndicationFeedSourceManager _syndicationFeedSourceManager;
+    private readonly ILogger<SyndicationFeedSourcesController> _logger;
+    private readonly IMapper _mapper;
+
+    /// <summary>
+    /// Handles the interactions with Syndication Feed Sources
+    /// </summary>
+    /// <param name="syndicationFeedSourceManager"></param>
+    /// <param name="logger"></param>
+    /// <param name="mapper"></param>
+    public SyndicationFeedSourcesController(
+        ISyndicationFeedSourceManager syndicationFeedSourceManager,
+        ILogger<SyndicationFeedSourcesController> logger,
+        IMapper mapper)
+    {
+        _syndicationFeedSourceManager = syndicationFeedSourceManager;
+        _logger = logger;
+        _mapper = mapper;
+    }
+
+    private string GetOwnerOid()
+    {
+        return User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)
+            ?? throw new InvalidOperationException("Entra Object ID claim not found");
+    }
+
+    private bool IsSiteAdministrator()
+    {
+        return User.IsInRole(RoleNames.SiteAdministrator);
+    }
+
+    /// <summary>
+    /// Gets all the syndication feed sources
+    /// </summary>
+    /// <returns>A list of syndication feed sources</returns>
+    /// <response code="200">If the call was successful</response>
+    /// <response code="400">If the request is poorly formatted</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<SyndicationFeedSourceResponse>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<List<SyndicationFeedSourceResponse>>> GetSyndicationFeedSourcesAsync()
+    {
+        List<SyndicationFeedSource> sources;
+        if (IsSiteAdministrator())
+        {
+            sources = await _syndicationFeedSourceManager.GetAllAsync();
+        }
+        else
+        {
+            var ownerOid = GetOwnerOid();
+            sources = await _syndicationFeedSourceManager.GetAllAsync(ownerOid);
+        }
+
+        return Ok(_mapper.Map<List<SyndicationFeedSourceResponse>>(sources));
+    }
+
+    /// <summary>
+    /// Returns a syndication feed source by its identifier
+    /// </summary>
+    /// <param name="id">The identifier of the syndication feed source</param>
+    /// <returns>A <see cref="SyndicationFeedSource"/></returns>
+    /// <response code="200">If the item was found</response>
+    /// <response code="400">If the request is poorly formatted</response>
+    /// <response code="403">If the current user does not own this resource</response>
+    /// <response code="404">If the requested id was not found</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet("{id:int}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ActionName(nameof(GetSyndicationFeedSourceAsync))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SyndicationFeedSourceResponse))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<SyndicationFeedSourceResponse>> GetSyndicationFeedSourceAsync(int id)
+    {
+        var source = await _syndicationFeedSourceManager.GetAsync(id);
+        if (source is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && source.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
+        return Ok(_mapper.Map<SyndicationFeedSourceResponse>(source));
+    }
+
+    /// <summary>
+    /// Creates a syndication feed source
+    /// </summary>
+    /// <param name="request">The syndication feed source data to create</param>
+    /// <returns>The newly created syndication feed source with the Url to view its details</returns>
+    /// <response code="201">Returns the newly created syndication feed source</response>
+    /// <response code="400">If the request is null or there are data violations</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SyndicationFeedSourceResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<SyndicationFeedSourceResponse>> CreateSyndicationFeedSourceAsync(SyndicationFeedSourceRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("CreateSyndicationFeedSourceAsync called with invalid model state");
+            return BadRequest(ModelState);
+        }
+
+        var source = _mapper.Map<SyndicationFeedSource>(request);
+        source.CreatedByEntraOid = GetOwnerOid();
+        source.AddedOn = DateTimeOffset.UtcNow;
+        source.LastUpdatedOn = DateTimeOffset.UtcNow;
+
+        var result = await _syndicationFeedSourceManager.SaveAsync(source);
+        if (result.IsSuccess && result.Value != null)
+        {
+            _logger.LogInformation("SyndicationFeedSource created with Id {SourceId}", result.Value.Id);
+            return CreatedAtAction(nameof(GetSyndicationFeedSourceAsync), new { id = result.Value.Id },
+                _mapper.Map<SyndicationFeedSourceResponse>(result.Value));
+        }
+
+        return Problem("Failed to create the syndication feed source");
+    }
+
+    /// <summary>
+    /// Deletes the specified syndication feed source
+    /// </summary>
+    /// <param name="id">The primary identifier for the syndication feed source</param>
+    /// <returns></returns>
+    /// <response code="204">If the item was deleted</response>
+    /// <response code="400">If the request is poorly formatted</response>
+    /// <response code="403">If the current user does not own this resource</response>
+    /// <response code="404">If the requested id was not found</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpDelete("{id:int}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireAdministrator)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult> DeleteSyndicationFeedSourceAsync(int id)
+    {
+        var source = await _syndicationFeedSourceManager.GetAsync(id);
+        if (source is null)
+        {
+            _logger.LogWarning("SyndicationFeedSource {SourceId} not found for deletion", id);
+            return NotFound();
+        }
+
+        if (!IsSiteAdministrator() && source.CreatedByEntraOid != GetOwnerOid())
+        {
+            return Forbid();
+        }
+
+        var wasDeleted = await _syndicationFeedSourceManager.DeleteAsync(id);
+        if (wasDeleted.IsSuccess)
+        {
+            _logger.LogInformation("SyndicationFeedSource {SourceId} deleted successfully", id);
+            return NoContent();
+        }
+
+        _logger.LogWarning("SyndicationFeedSource {SourceId} deletion failed", id);
+        return NotFound();
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/YouTubeSourcesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/YouTubeSourcesController.cs
@@ -1,0 +1,181 @@
+using System.Security.Claims;
+using AutoMapper;
+using JosephGuadagno.Broadcasting.Api.Dtos;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Api.Controllers;
+
+/// <summary>
+/// Works with the YouTube Sources of JosephGuadagno.NET Broadcasting
+/// </summary>
+[ApiController]
+[Authorize]
+[IgnoreAntiforgeryToken]
+[Route("[controller]")]
+[Produces("application/json")]
+public class YouTubeSourcesController : ControllerBase
+{
+    private readonly IYouTubeSourceManager _youTubeSourceManager;
+    private readonly ILogger<YouTubeSourcesController> _logger;
+    private readonly IMapper _mapper;
+
+    /// <summary>
+    /// Handles the interactions with YouTube Sources
+    /// </summary>
+    /// <param name="youTubeSourceManager"></param>
+    /// <param name="logger"></param>
+    /// <param name="mapper"></param>
+    public YouTubeSourcesController(
+        IYouTubeSourceManager youTubeSourceManager,
+        ILogger<YouTubeSourcesController> logger,
+        IMapper mapper)
+    {
+        _youTubeSourceManager = youTubeSourceManager;
+        _logger = logger;
+        _mapper = mapper;
+    }
+
+    private string GetOwnerOid()
+    {
+        return User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)
+            ?? throw new InvalidOperationException("Entra Object ID claim not found");
+    }
+
+    private bool IsSiteAdministrator()
+    {
+        return User.IsInRole(RoleNames.SiteAdministrator);
+    }
+
+    /// <summary>
+    /// Gets all YouTube sources
+    /// </summary>
+    /// <returns>A list of YouTube sources</returns>
+    /// <response code="200">If the call was successful</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<YouTubeSourceResponse>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<List<YouTubeSourceResponse>>> GetYouTubeSourcesAsync()
+    {
+        List<YouTubeSource> results;
+        if (IsSiteAdministrator())
+        {
+            results = await _youTubeSourceManager.GetAllAsync();
+        }
+        else
+        {
+            var ownerOid = GetOwnerOid();
+            results = await _youTubeSourceManager.GetAllAsync(ownerOid);
+        }
+
+        return Ok(_mapper.Map<List<YouTubeSourceResponse>>(results));
+    }
+
+    /// <summary>
+    /// Returns a YouTube source by its identifier
+    /// </summary>
+    /// <param name="id">The identifier of the YouTube source</param>
+    /// <returns>A <see cref="YouTubeSource"/></returns>
+    /// <response code="200">If the item was found</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    /// <response code="403">If the current user does not own this resource</response>
+    /// <response code="404">If the requested id was not found</response>
+    [HttpGet("{id:int}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ActionName(nameof(GetYouTubeSourceAsync))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(YouTubeSourceResponse))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<YouTubeSourceResponse>> GetYouTubeSourceAsync(int id)
+    {
+        var source = await _youTubeSourceManager.GetAsync(id);
+        if (source is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && source.CreatedByEntraOid != GetOwnerOid())
+            return Forbid();
+
+        return Ok(_mapper.Map<YouTubeSourceResponse>(source));
+    }
+
+    /// <summary>
+    /// Creates a YouTube source
+    /// </summary>
+    /// <param name="request">The YouTube source data to create</param>
+    /// <returns>The newly created YouTube source with the Url to view its details</returns>
+    /// <response code="201">Returns the newly created YouTube source</response>
+    /// <response code="400">If the request is null or there are data violations</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(YouTubeSourceResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<YouTubeSourceResponse>> CreateYouTubeSourceAsync(YouTubeSourceRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("CreateYouTubeSourceAsync called with invalid model state");
+            return BadRequest(ModelState);
+        }
+
+        var source = _mapper.Map<YouTubeSource>(request);
+        source.CreatedByEntraOid = GetOwnerOid();
+        source.AddedOn = DateTimeOffset.UtcNow;
+        source.LastUpdatedOn = DateTimeOffset.UtcNow;
+
+        var result = await _youTubeSourceManager.SaveAsync(source);
+        if (result.IsSuccess && result.Value != null)
+        {
+            _logger.LogInformation("YouTubeSource created with Id {YouTubeSourceId}", result.Value.Id);
+            return CreatedAtAction(nameof(GetYouTubeSourceAsync), new { id = result.Value.Id },
+                _mapper.Map<YouTubeSourceResponse>(result.Value));
+        }
+
+        return Problem("Failed to create the YouTube source");
+    }
+
+    /// <summary>
+    /// Deletes the specified YouTube source
+    /// </summary>
+    /// <param name="id">The primary identifier for the YouTube source</param>
+    /// <returns></returns>
+    /// <response code="204">If the item was deleted</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    /// <response code="403">If the current user does not own this resource</response>
+    /// <response code="404">If the requested id was not found</response>
+    [HttpDelete("{id:int}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireAdministrator)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeleteYouTubeSourceAsync(int id)
+    {
+        var source = await _youTubeSourceManager.GetAsync(id);
+        if (source is null)
+        {
+            _logger.LogWarning("YouTubeSource {YouTubeSourceId} not found for deletion", id);
+            return NotFound();
+        }
+
+        if (!IsSiteAdministrator() && source.CreatedByEntraOid != GetOwnerOid())
+            return Forbid();
+
+        var wasDeleted = await _youTubeSourceManager.DeleteAsync(id);
+        if (wasDeleted.IsSuccess)
+        {
+            _logger.LogInformation("YouTubeSource {YouTubeSourceId} deleted successfully", id);
+            return NoContent();
+        }
+
+        _logger.LogWarning("YouTubeSource {YouTubeSourceId} deletion failed", id);
+        return NotFound();
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformRequest.cs
@@ -19,4 +19,8 @@ public class SocialMediaPlatformRequest
     public string? Icon { get; set; }
 
     public bool IsActive { get; set; } = true;
+
+    [MaxLength(500)]
+    [Url]
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformResponse.cs
@@ -10,4 +10,5 @@ public class SocialMediaPlatformResponse
     public string? Url { get; set; }
     public string? Icon { get; set; }
     public bool IsActive { get; set; }
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SourceItemValidationResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SourceItemValidationResponse.cs
@@ -1,0 +1,27 @@
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Response for the source item validation endpoint
+/// </summary>
+public class SourceItemValidationResponse
+{
+    /// <summary>
+    /// Whether the source item exists and is valid
+    /// </summary>
+    public bool IsValid { get; set; }
+
+    /// <summary>
+    /// The title or name of the source item, if found
+    /// </summary>
+    public string? ItemTitle { get; set; }
+
+    /// <summary>
+    /// Additional item details (type-specific), if found
+    /// </summary>
+    public string? ItemDetails { get; set; }
+
+    /// <summary>
+    /// Error message when the item is not found or a lookup error occurred
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SyndicationFeedSourceRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SyndicationFeedSourceRequest.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Request DTO for creating a syndication feed source.
+/// </summary>
+public class SyndicationFeedSourceRequest
+{
+    [Required]
+    public string FeedIdentifier { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(255)]
+    public string Author { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(512)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [Url]
+    public string Url { get; set; } = string.Empty;
+
+    [Required]
+    public DateTimeOffset PublicationDate { get; set; }
+
+    [StringLength(255)]
+    public string? ShortenedUrl { get; set; }
+
+    public IList<string>? Tags { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SyndicationFeedSourceResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SyndicationFeedSourceResponse.cs
@@ -1,0 +1,19 @@
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Response DTO for a syndication feed source.
+/// </summary>
+public class SyndicationFeedSourceResponse
+{
+    public int Id { get; set; }
+    public string FeedIdentifier { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public DateTimeOffset PublicationDate { get; set; }
+    public string? ShortenedUrl { get; set; }
+    public IList<string> Tags { get; set; } = [];
+    public DateTimeOffset AddedOn { get; set; }
+    public DateTimeOffset LastUpdatedOn { get; set; }
+    public string CreatedByEntraOid { get; set; } = string.Empty;
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceRequest.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Request DTO for creating a YouTube source.
+/// </summary>
+public class YouTubeSourceRequest
+{
+    [Required]
+    [StringLength(20)]
+    public string VideoId { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(255)]
+    public string Author { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(512)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [Url]
+    public string Url { get; set; } = string.Empty;
+
+    [Required]
+    public DateTimeOffset PublicationDate { get; set; }
+
+    [StringLength(255)]
+    public string? ShortenedUrl { get; set; }
+
+    public IList<string>? Tags { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceResponse.cs
@@ -1,0 +1,19 @@
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Response DTO for a YouTube source.
+/// </summary>
+public class YouTubeSourceResponse
+{
+    public int Id { get; set; }
+    public string VideoId { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public DateTimeOffset PublicationDate { get; set; }
+    public string? ShortenedUrl { get; set; }
+    public IList<string> Tags { get; set; } = [];
+    public DateTimeOffset AddedOn { get; set; }
+    public DateTimeOffset LastUpdatedOn { get; set; }
+    public string CreatedByEntraOid { get; set; } = string.Empty;
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/SocialMediaPlatform.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/SocialMediaPlatform.cs
@@ -17,6 +17,8 @@ public partial class SocialMediaPlatform
 
     public bool IsActive { get; set; }
 
+    public string CredentialSetupDocumentationUrl { get; set; }
+
     public virtual ICollection<EngagementSocialMediaPlatform> EngagementSocialMediaPlatforms { get; set; } = new List<EngagementSocialMediaPlatform>();
 
     public virtual ICollection<UserPublisherSetting> UserPublisherSettings { get; set; } = new List<UserPublisherSetting>();

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/SocialMediaPlatform.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/SocialMediaPlatform.cs
@@ -37,4 +37,10 @@ public class SocialMediaPlatform
     /// Indicates if the platform is active (soft delete)
     /// </summary>
     public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// URL to the credential setup documentation for the platform
+    /// </summary>
+    [MaxLength(500)]
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }


### PR DESCRIPTION
Closes #817

Adds SyndicationFeedSourcesController with GET (list + single), POST, and DELETE. Follows EngagementsController pattern with admin bypass and ownership enforcement. Includes DTOs and AutoMapper profile.