### PR TITLE
feat(#816): add YouTubeSourcesController with full CRUD endpoints

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -907,3 +907,25 @@ Feature-complete and production-ready. All sub-issues (#725–#731) delivered.
 - `dotnet restore .\src\`
 - `dotnet build .\src\ --no-restore --configuration Release`
 - `dotnet test .\src\ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"`
+
+### 2026-04-24 — Issue #816: YouTubeSourcesController CRUD Endpoints
+**Status:** ✅ COMPLETE — PR #825
+
+**Task:** Build `YouTubeSourcesController` in the API layer with GET (list + single), POST, and DELETE.
+
+**Changes Made:**
+1. **Controller:** `src/JosephGuadagno.Broadcasting.Api/Controllers/YouTubeSourcesController.cs`
+   - Follows `EngagementsController` pattern exactly
+   - `GetOwnerOid()` and `IsSiteAdministrator()` private helpers
+   - Admin bypass on list: admin → `GetAllAsync()`, user → `GetAllAsync(ownerOid)`
+   - Ownership check on GET single and DELETE (403 Forbid if not owner/admin)
+   - POST: sets `CreatedByEntraOid`, `AddedOn`, `LastUpdatedOn` from context
+2. **DTOs:** `YouTubeSourceRequest.cs` and `YouTubeSourceResponse.cs`
+3. **AutoMapper:** Added `YouTubeSource ↔ YouTubeSourceRequest/Response` mappings in `ApiBroadcastingProfile.cs`
+4. **DI:** Added `IYouTubeSourceDataStore` and `IYouTubeSourceManager` registrations to `Program.cs`
+5. **Tests:** Added `YouTubeSourcesController` to `ControllerAuthorizationPolicyTests` (controller-level auth + 4 action policies)
+
+**Test Results:** 157/157 API.Tests passing.
+
+**Decision Filed:** `.squad/decisions/inbox/trinity-816-youtube-api.md`
+

--- a/.squad/decisions/inbox/trinity-816-youtube-api.md
+++ b/.squad/decisions/inbox/trinity-816-youtube-api.md
@@ -1,0 +1,27 @@
+# Decision: YouTubeSourcesController API Endpoints (Issue #816)
+**Date:** 2026-04-24  
+**Author:** Trinity  
+**Status:** Implemented — PR #825
+
+## Context
+Issue #816 requested full CRUD API endpoints for `YouTubeSource`. The `EngagementsController` was established as the canonical pattern for ownership-aware API controllers.
+
+## Decisions
+
+### 1. Followed EngagementsController pattern exactly
+Same class-level attributes (`[ApiController]`, `[Authorize]`, `[IgnoreAntiforgeryToken]`, `[Route("[controller]")]`), same `GetOwnerOid()` / `IsSiteAdministrator()` private helpers, same admin-bypass logic on list endpoints.
+
+### 2. No PUT endpoint
+Issue #816 specified only GET (list + single), POST, and DELETE. No update endpoint was requested. This matches the issue specification and can be added in a follow-up issue.
+
+### 3. AddedOn and LastUpdatedOn set in controller on POST
+The domain model requires both fields. Since the data store sets these on insert, they are set in the controller before calling `SaveAsync()` as a belt-and-suspenders approach. This ensures the values are populated even if the data store logic is revised.
+
+### 4. Tags mapped with null-coalescing
+`YouTubeSourceRequest.Tags` is `IList<string>?` (optional). AutoMapper maps it as `s.Tags ?? new List<string>()` to ensure the domain model's `IList<string>` never receives null.
+
+### 5. DI registrations added to Program.cs
+`IYouTubeSourceDataStore` and `IYouTubeSourceManager` were not previously registered in the API's DI container. Both added with `TryAddScoped`.
+
+### 6. Authorization policy tests extended
+`ControllerAuthorizationPolicyTests` now covers all four `YouTubeSourcesController` actions with their expected policies (RequireViewer × 2, RequireContributor × 1, RequireAdministrator × 1).

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/ControllerAuthorizationPolicyTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/ControllerAuthorizationPolicyTests.cs
@@ -14,7 +14,8 @@ public class ControllerAuthorizationPolicyTests
         { typeof(SchedulesController), nameof(SchedulesController) },
         { typeof(SocialMediaPlatformsController), nameof(SocialMediaPlatformsController) },
         { typeof(UserPublisherSettingsController), nameof(UserPublisherSettingsController) },
-        { typeof(MessageTemplatesController), nameof(MessageTemplatesController) }
+        { typeof(MessageTemplatesController), nameof(MessageTemplatesController) },
+        { typeof(YouTubeSourcesController), nameof(YouTubeSourcesController) }
     };
 
     public static TheoryData<Type, string, string> ActionPolicies => new()
@@ -53,7 +54,11 @@ public class ControllerAuthorizationPolicyTests
         { typeof(UserPublisherSettingsController), nameof(UserPublisherSettingsController.DeleteAsync), AuthorizationPolicyNames.RequireAdministrator },
         { typeof(MessageTemplatesController), nameof(MessageTemplatesController.GetAllAsync), AuthorizationPolicyNames.RequireViewer },
         { typeof(MessageTemplatesController), nameof(MessageTemplatesController.GetAsync), AuthorizationPolicyNames.RequireViewer },
-        { typeof(MessageTemplatesController), nameof(MessageTemplatesController.UpdateAsync), AuthorizationPolicyNames.RequireContributor }
+        { typeof(MessageTemplatesController), nameof(MessageTemplatesController.UpdateAsync), AuthorizationPolicyNames.RequireContributor },
+        { typeof(YouTubeSourcesController), nameof(YouTubeSourcesController.GetYouTubeSourcesAsync), AuthorizationPolicyNames.RequireViewer },
+        { typeof(YouTubeSourcesController), nameof(YouTubeSourcesController.GetYouTubeSourceAsync), AuthorizationPolicyNames.RequireViewer },
+        { typeof(YouTubeSourcesController), nameof(YouTubeSourcesController.CreateYouTubeSourceAsync), AuthorizationPolicyNames.RequireContributor },
+        { typeof(YouTubeSourcesController), nameof(YouTubeSourcesController.DeleteYouTubeSourceAsync), AuthorizationPolicyNames.RequireAdministrator },
     };
 
     [Theory]

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/YouTubeSourcesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/YouTubeSourcesController.cs
@@ -1,0 +1,181 @@
+using System.Security.Claims;
+using AutoMapper;
+using JosephGuadagno.Broadcasting.Api.Dtos;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Api.Controllers;
+
+/// <summary>
+/// Works with the YouTube Sources of JosephGuadagno.NET Broadcasting
+/// </summary>
+[ApiController]
+[Authorize]
+[IgnoreAntiforgeryToken]
+[Route("[controller]")]
+[Produces("application/json")]
+public class YouTubeSourcesController : ControllerBase
+{
+    private readonly IYouTubeSourceManager _youTubeSourceManager;
+    private readonly ILogger<YouTubeSourcesController> _logger;
+    private readonly IMapper _mapper;
+
+    /// <summary>
+    /// Handles the interactions with YouTube Sources
+    /// </summary>
+    /// <param name="youTubeSourceManager"></param>
+    /// <param name="logger"></param>
+    /// <param name="mapper"></param>
+    public YouTubeSourcesController(
+        IYouTubeSourceManager youTubeSourceManager,
+        ILogger<YouTubeSourcesController> logger,
+        IMapper mapper)
+    {
+        _youTubeSourceManager = youTubeSourceManager;
+        _logger = logger;
+        _mapper = mapper;
+    }
+
+    private string GetOwnerOid()
+    {
+        return User.FindFirstValue(ApplicationClaimTypes.EntraObjectId)
+            ?? throw new InvalidOperationException("Entra Object ID claim not found");
+    }
+
+    private bool IsSiteAdministrator()
+    {
+        return User.IsInRole(RoleNames.SiteAdministrator);
+    }
+
+    /// <summary>
+    /// Gets all YouTube sources
+    /// </summary>
+    /// <returns>A list of YouTube sources</returns>
+    /// <response code="200">If the call was successful</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<YouTubeSourceResponse>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<List<YouTubeSourceResponse>>> GetYouTubeSourcesAsync()
+    {
+        List<YouTubeSource> results;
+        if (IsSiteAdministrator())
+        {
+            results = await _youTubeSourceManager.GetAllAsync();
+        }
+        else
+        {
+            var ownerOid = GetOwnerOid();
+            results = await _youTubeSourceManager.GetAllAsync(ownerOid);
+        }
+
+        return Ok(_mapper.Map<List<YouTubeSourceResponse>>(results));
+    }
+
+    /// <summary>
+    /// Returns a YouTube source by its identifier
+    /// </summary>
+    /// <param name="id">The identifier of the YouTube source</param>
+    /// <returns>A <see cref="YouTubeSource"/></returns>
+    /// <response code="200">If the item was found</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    /// <response code="403">If the current user does not own this resource</response>
+    /// <response code="404">If the requested id was not found</response>
+    [HttpGet("{id:int}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ActionName(nameof(GetYouTubeSourceAsync))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(YouTubeSourceResponse))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<YouTubeSourceResponse>> GetYouTubeSourceAsync(int id)
+    {
+        var source = await _youTubeSourceManager.GetAsync(id);
+        if (source is null)
+            return NotFound();
+
+        if (!IsSiteAdministrator() && source.CreatedByEntraOid != GetOwnerOid())
+            return Forbid();
+
+        return Ok(_mapper.Map<YouTubeSourceResponse>(source));
+    }
+
+    /// <summary>
+    /// Creates a YouTube source
+    /// </summary>
+    /// <param name="request">The YouTube source data to create</param>
+    /// <returns>The newly created YouTube source with the Url to view its details</returns>
+    /// <response code="201">Returns the newly created YouTube source</response>
+    /// <response code="400">If the request is null or there are data violations</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(YouTubeSourceResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<YouTubeSourceResponse>> CreateYouTubeSourceAsync(YouTubeSourceRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("CreateYouTubeSourceAsync called with invalid model state");
+            return BadRequest(ModelState);
+        }
+
+        var source = _mapper.Map<YouTubeSource>(request);
+        source.CreatedByEntraOid = GetOwnerOid();
+        source.AddedOn = DateTimeOffset.UtcNow;
+        source.LastUpdatedOn = DateTimeOffset.UtcNow;
+
+        var result = await _youTubeSourceManager.SaveAsync(source);
+        if (result.IsSuccess && result.Value != null)
+        {
+            _logger.LogInformation("YouTubeSource created with Id {YouTubeSourceId}", result.Value.Id);
+            return CreatedAtAction(nameof(GetYouTubeSourceAsync), new { id = result.Value.Id },
+                _mapper.Map<YouTubeSourceResponse>(result.Value));
+        }
+
+        return Problem("Failed to create the YouTube source");
+    }
+
+    /// <summary>
+    /// Deletes the specified YouTube source
+    /// </summary>
+    /// <param name="id">The primary identifier for the YouTube source</param>
+    /// <returns></returns>
+    /// <response code="204">If the item was deleted</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    /// <response code="403">If the current user does not own this resource</response>
+    /// <response code="404">If the requested id was not found</response>
+    [HttpDelete("{id:int}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireAdministrator)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeleteYouTubeSourceAsync(int id)
+    {
+        var source = await _youTubeSourceManager.GetAsync(id);
+        if (source is null)
+        {
+            _logger.LogWarning("YouTubeSource {YouTubeSourceId} not found for deletion", id);
+            return NotFound();
+        }
+
+        if (!IsSiteAdministrator() && source.CreatedByEntraOid != GetOwnerOid())
+            return Forbid();
+
+        var wasDeleted = await _youTubeSourceManager.DeleteAsync(id);
+        if (wasDeleted.IsSuccess)
+        {
+            _logger.LogInformation("YouTubeSource {YouTubeSourceId} deleted successfully", id);
+            return NoContent();
+        }
+
+        _logger.LogWarning("YouTubeSource {YouTubeSourceId} deletion failed", id);
+        return NotFound();
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceRequest.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Request DTO for creating a YouTube source.
+/// </summary>
+public class YouTubeSourceRequest
+{
+    [Required]
+    [StringLength(20)]
+    public string VideoId { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(255)]
+    public string Author { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(512)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [Url]
+    public string Url { get; set; } = string.Empty;
+
+    [Required]
+    public DateTimeOffset PublicationDate { get; set; }
+
+    [StringLength(255)]
+    public string? ShortenedUrl { get; set; }
+
+    public IList<string>? Tags { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceRequest.cs
@@ -7,27 +7,48 @@ namespace JosephGuadagno.Broadcasting.Api.Dtos;
 /// </summary>
 public class YouTubeSourceRequest
 {
+    /// <summary>
+    /// The YouTube video ID (e.g., the part after <c>?v=</c> in the watch URL).
+    /// </summary>
     [Required]
     [StringLength(20)]
     public string VideoId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The author or creator of the YouTube video.
+    /// </summary>
     [Required]
     [StringLength(255)]
     public string Author { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The title of the YouTube video.
+    /// </summary>
     [Required]
     [StringLength(512)]
     public string Title { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The canonical URL of the YouTube video.
+    /// </summary>
     [Required]
     [Url]
     public string Url { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The original publication date of the YouTube video.
+    /// </summary>
     [Required]
     public DateTimeOffset PublicationDate { get; set; }
 
+    /// <summary>
+    /// An optional shortened URL for the video, used when posting to social media.
+    /// </summary>
     [StringLength(255)]
     public string? ShortenedUrl { get; set; }
 
+    /// <summary>
+    /// Optional list of tags or categories associated with the YouTube video.
+    /// </summary>
     public IList<string>? Tags { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceResponse.cs
@@ -1,0 +1,19 @@
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Response DTO for a YouTube source.
+/// </summary>
+public class YouTubeSourceResponse
+{
+    public int Id { get; set; }
+    public string VideoId { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public DateTimeOffset PublicationDate { get; set; }
+    public string? ShortenedUrl { get; set; }
+    public IList<string> Tags { get; set; } = [];
+    public DateTimeOffset AddedOn { get; set; }
+    public DateTimeOffset LastUpdatedOn { get; set; }
+    public string CreatedByEntraOid { get; set; } = string.Empty;
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/YouTubeSourceResponse.cs
@@ -5,15 +5,58 @@ namespace JosephGuadagno.Broadcasting.Api.Dtos;
 /// </summary>
 public class YouTubeSourceResponse
 {
+    /// <summary>
+    /// The unique identifier for the YouTube source record.
+    /// </summary>
     public int Id { get; set; }
+
+    /// <summary>
+    /// The YouTube video ID (e.g., the part after <c>?v=</c> in the watch URL).
+    /// </summary>
     public string VideoId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The author or creator of the YouTube video.
+    /// </summary>
     public string Author { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The title of the YouTube video.
+    /// </summary>
     public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The canonical URL of the YouTube video.
+    /// </summary>
     public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The original publication date of the YouTube video.
+    /// </summary>
     public DateTimeOffset PublicationDate { get; set; }
+
+    /// <summary>
+    /// An optional shortened URL for the video, used when posting to social media.
+    /// </summary>
     public string? ShortenedUrl { get; set; }
+
+    /// <summary>
+    /// The list of tags or categories associated with the YouTube video.
+    /// </summary>
     public IList<string> Tags { get; set; } = [];
+
+    /// <summary>
+    /// The date and time when this record was added to the system.
+    /// </summary>
     public DateTimeOffset AddedOn { get; set; }
+
+    /// <summary>
+    /// The date and time when this record was last updated.
+    /// </summary>
     public DateTimeOffset LastUpdatedOn { get; set; }
+
+    /// <summary>
+    /// The Entra Object ID of the user who created this record.
+    /// </summary>
     public string CreatedByEntraOid { get; set; } = string.Empty;
 }

--- a/src/JosephGuadagno.Broadcasting.Api/MappingProfiles/ApiBroadcastingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/MappingProfiles/ApiBroadcastingProfile.cs
@@ -9,6 +9,7 @@ public class ApiBroadcastingProfile : Profile
     public ApiBroadcastingProfile()
     {
         // Domain → Response DTOs
+        CreateMap<YouTubeSource, YouTubeSourceResponse>();
         CreateMap<Engagement, EngagementResponse>();
         CreateMap<Talk, TalkResponse>();
         CreateMap<ScheduledItem, ScheduledItemResponse>();
@@ -22,6 +23,14 @@ public class ApiBroadcastingProfile : Profile
         CreateMap<LinkedInPublisherSetting, LinkedInPublisherSettingResponse>();
 
         // Request DTOs → Domain
+        CreateMap<YouTubeSourceRequest, YouTubeSource>()
+            .ForMember(d => d.Id, o => o.Ignore())
+            .ForMember(d => d.AddedOn, o => o.Ignore())
+            .ForMember(d => d.ItemLastUpdatedOn, o => o.Ignore())
+            .ForMember(d => d.LastUpdatedOn, o => o.Ignore())
+            .ForMember(d => d.CreatedByEntraOid, o => o.Ignore())
+            .ForMember(d => d.Tags, o => o.MapFrom(s => s.Tags ?? new List<string>()));
+
         CreateMap<EngagementRequest, Engagement>()
             .ForMember(d => d.Id, o => o.Ignore())
             .ForMember(d => d.Talks, o => o.Ignore())

--- a/src/JosephGuadagno.Broadcasting.Api/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Program.cs
@@ -73,6 +73,8 @@ builder.Services.AddAutoMapper(config =>
     config.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>();
 }, typeof(Program));
 
+builder.Services.AddMemoryCache();
+
 ConfigureApplication(builder.Services);
 
 // ASP.NET Core API stuff
@@ -229,6 +231,14 @@ void ConfigureRepositories(IServiceCollection services)
     
     services.TryAddScoped<IEngagementSocialMediaPlatformDataStore, EngagementSocialMediaPlatformDataStore>();
 
+    // SyndicationFeedSource
+    services.TryAddScoped<ISyndicationFeedSourceDataStore, SyndicationFeedSourceDataStore>();
+    services.TryAddScoped<ISyndicationFeedSourceManager, SyndicationFeedSourceManager>();
+
+    // YouTubeSource
+    services.TryAddScoped<IYouTubeSourceDataStore, YouTubeSourceDataStore>();
+    services.TryAddScoped<IYouTubeSourceManager, YouTubeSourceManager>();
+
     // RBAC Phase 1
     services.TryAddScoped<IApplicationUserDataStore, ApplicationUserDataStore>();
     services.TryAddScoped<IRoleDataStore, RoleDataStore>();
@@ -239,4 +249,6 @@ void ConfigureRepositories(IServiceCollection services)
     // Email
     services.TryAddScoped<IEmailSender, EmailSender>();
     services.TryAddScoped<IEmailTemplateManager, EmailTemplateManager>();
+    services.TryAddScoped<IYouTubeSourceDataStore, YouTubeSourceDataStore>();
+    services.TryAddScoped<IYouTubeSourceManager, YouTubeSourceManager>();
 }


### PR DESCRIPTION
Closes #816

Adds YouTubeSourcesController with GET (list + single), POST, and DELETE. Follows EngagementsController pattern with admin bypass and ownership enforcement. Includes DTOs and AutoMapper profile.