### PR TITLE
feat(#812): add CredentialSetupDocumentationUrl to SocialMediaPlatforms

### DIFF
--- a/scripts/database/data-seed.sql
+++ b/scripts/database/data-seed.sql
@@ -97,6 +97,18 @@ IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Mast
     INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
     VALUES (N'Mastodon', N'https://mastodon.social', N'bi-mastodon', 1)
 
+-- Seed CredentialSetupDocumentationUrl for SocialMediaPlatforms (Issue #812)
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/twitter'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'Twitter'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/bluesky'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'BlueSky'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/linkedin'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'LinkedIn'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/facebook'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'Facebook'
+UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/mastodon'
+    WHERE CredentialSetupDocumentationUrl IS NULL AND Name = N'Mastodon'
+
 -- Seed the EmailTemplates table (Issue #615)
 IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.EmailTemplates WHERE Name = N'UserApproved')
     INSERT INTO JJGNet.dbo.EmailTemplates (Name, Subject, Body) VALUES (

--- a/scripts/database/table-create.sql
+++ b/scripts/database/table-create.sql
@@ -294,7 +294,8 @@ create table dbo.SocialMediaPlatforms
             unique,
     Url      nvarchar(500) null,
     Icon     nvarchar(100) null,
-    IsActive bit default 1 not null
+    IsActive bit default 1 not null,
+    CredentialSetupDocumentationUrl nvarchar(500) null
 )
 go
 

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformRequest.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformRequest.cs
@@ -19,4 +19,8 @@ public class SocialMediaPlatformRequest
     public string? Icon { get; set; }
 
     public bool IsActive { get; set; } = true;
+
+    [MaxLength(500)]
+    [Url]
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SocialMediaPlatformResponse.cs
@@ -10,4 +10,5 @@ public class SocialMediaPlatformResponse
     public string? Url { get; set; }
     public string? Icon { get; set; }
     public bool IsActive { get; set; }
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/SocialMediaPlatform.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/SocialMediaPlatform.cs
@@ -17,6 +17,8 @@ public partial class SocialMediaPlatform
 
     public bool IsActive { get; set; }
 
+    public string CredentialSetupDocumentationUrl { get; set; }
+
     public virtual ICollection<EngagementSocialMediaPlatform> EngagementSocialMediaPlatforms { get; set; } = new List<EngagementSocialMediaPlatform>();
 
     public virtual ICollection<UserPublisherSetting> UserPublisherSettings { get; set; } = new List<UserPublisherSetting>();

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/SocialMediaPlatform.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/SocialMediaPlatform.cs
@@ -37,4 +37,10 @@ public class SocialMediaPlatform
     /// Indicates if the platform is active (soft delete)
     /// </summary>
     public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// URL to the credential setup documentation for the platform
+    /// </summary>
+    [MaxLength(500)]
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Models/SocialMediaPlatformViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/SocialMediaPlatformViewModel.cs
@@ -36,4 +36,11 @@ public class SocialMediaPlatformViewModel
     /// Indicates if the platform is active (soft delete)
     /// </summary>
     public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// URL to the credential setup documentation for the platform
+    /// </summary>
+    [Url(ErrorMessage = "Please enter a valid URL")]
+    [MaxLength(500, ErrorMessage = "Credential setup documentation URL cannot exceed 500 characters")]
+    public string? CredentialSetupDocumentationUrl { get; set; }
 }


### PR DESCRIPTION
Closes #812

Adds nullable \CredentialSetupDocumentationUrl\ column to \dbo.SocialMediaPlatforms\ and propagates it through Domain, Data.Sql, API DTOs, and Web ViewModel. Seed data sets URLs for all 5 existing platforms (idempotent).