### PR TITLE
feat(#808): redesign ScheduledItemValidationService to call API

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -17,6 +17,9 @@ namespace JosephGuadagno.Broadcasting.Api.Tests.Controllers;
 public class SchedulesControllerTests
 {
     private readonly Mock<IScheduledItemManager> _scheduledItemManagerMock;
+    private readonly Mock<IEngagementManager> _engagementManagerMock;
+    private readonly Mock<ISyndicationFeedSourceManager> _syndicationFeedSourceManagerMock;
+    private readonly Mock<IYouTubeSourceManager> _youTubeSourceManagerMock;
     private readonly Mock<ILogger<SchedulesController>> _loggerMock;
 
     // Use the assembly-wide shared mapper to avoid AutoMapper profile-registry races
@@ -26,6 +29,9 @@ public class SchedulesControllerTests
     public SchedulesControllerTests()
     {
         _scheduledItemManagerMock = new Mock<IScheduledItemManager>();
+        _engagementManagerMock = new Mock<IEngagementManager>();
+        _syndicationFeedSourceManagerMock = new Mock<ISyndicationFeedSourceManager>();
+        _youTubeSourceManagerMock = new Mock<IYouTubeSourceManager>();
         _loggerMock = new Mock<ILogger<SchedulesController>>();
     }
 
@@ -35,7 +41,13 @@ public class SchedulesControllerTests
 
     private SchedulesController CreateSut(string ownerOid = "owner-oid-12345", bool isSiteAdmin = false)
     {
-        var controller = new SchedulesController(_scheduledItemManagerMock.Object, _loggerMock.Object, _mapper)
+        var controller = new SchedulesController(
+            _scheduledItemManagerMock.Object,
+            _engagementManagerMock.Object,
+            _syndicationFeedSourceManagerMock.Object,
+            _youTubeSourceManagerMock.Object,
+            _loggerMock.Object,
+            _mapper)
         {
             ControllerContext = ApiControllerTestHelpers.CreateControllerContext(ownerOid, isSiteAdmin),
             ProblemDetailsFactory = new TestProblemDetailsFactory()

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using AutoMapper;
 using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Enums;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -20,6 +21,9 @@ namespace JosephGuadagno.Broadcasting.Api.Controllers;
 public class SchedulesController: ControllerBase
 {
     private readonly IScheduledItemManager _scheduledItemManager;
+    private readonly IEngagementManager _engagementManager;
+    private readonly ISyndicationFeedSourceManager _syndicationFeedSourceManager;
+    private readonly IYouTubeSourceManager _youTubeSourceManager;
     private readonly ILogger<SchedulesController> _logger;
     private readonly IMapper _mapper;
 
@@ -27,11 +31,23 @@ public class SchedulesController: ControllerBase
     /// The constructor
     /// </summary>
     /// <param name="scheduledItemManager">The scheduled item manager</param>
+    /// <param name="engagementManager">The engagement manager</param>
+    /// <param name="syndicationFeedSourceManager">The syndication feed source manager</param>
+    /// <param name="youTubeSourceManager">The YouTube source manager</param>
     /// <param name="logger">The logger to use</param>
     /// <param name="mapper">The AutoMapper instance</param>
-    public SchedulesController(IScheduledItemManager scheduledItemManager, ILogger<SchedulesController> logger, IMapper mapper)
+    public SchedulesController(
+        IScheduledItemManager scheduledItemManager,
+        IEngagementManager engagementManager,
+        ISyndicationFeedSourceManager syndicationFeedSourceManager,
+        IYouTubeSourceManager youTubeSourceManager,
+        ILogger<SchedulesController> logger,
+        IMapper mapper)
     {
         _scheduledItemManager = scheduledItemManager;
+        _engagementManager = engagementManager;
+        _syndicationFeedSourceManager = syndicationFeedSourceManager;
+        _youTubeSourceManager = youTubeSourceManager;
         _logger = logger;
         _mapper = mapper;
     }
@@ -382,5 +398,122 @@ public class SchedulesController: ControllerBase
             PageSize = pageSize,
             TotalCount = result.TotalCount
         };
+    }
+
+    /// <summary>
+    /// Validates that a source item exists for the given type and primary key.
+    /// Used by the Web project's AJAX validation.
+    /// </summary>
+    /// <param name="itemType">The type of item (Engagements, Talks, SyndicationFeedSources, YouTubeSources)</param>
+    /// <param name="itemPrimaryKey">The primary key of the item to validate</param>
+    /// <returns>A <see cref="SourceItemValidationResponse"/> with validation status and item details</returns>
+    /// <response code="200">Upon success, returns validation result (IsValid may be false when item not found)</response>
+    /// <response code="400">If the parameters are invalid</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet("validate-source-item")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SourceItemValidationResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<SourceItemValidationResponse>> ValidateSourceItemAsync(
+        [FromQuery] ScheduledItemType itemType,
+        [FromQuery] int itemPrimaryKey)
+    {
+        if (itemPrimaryKey <= 0)
+        {
+            return BadRequest("itemPrimaryKey must be greater than 0");
+        }
+
+        try
+        {
+            return itemType switch
+            {
+                ScheduledItemType.Engagements => await ValidateEngagementAsync(itemPrimaryKey),
+                ScheduledItemType.Talks => await ValidateTalkAsync(itemPrimaryKey),
+                ScheduledItemType.SyndicationFeedSources => await ValidateSyndicationFeedSourceAsync(itemPrimaryKey),
+                ScheduledItemType.YouTubeSources => await ValidateYouTubeSourceAsync(itemPrimaryKey),
+                _ => BadRequest($"Unknown item type: {itemType}")
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating source item type={ItemType} key={ItemPrimaryKey}",
+                itemType, itemPrimaryKey);
+            return Ok(new SourceItemValidationResponse
+            {
+                IsValid = false,
+                ErrorMessage = "An error occurred while validating the item"
+            });
+        }
+    }
+
+    private async Task<ActionResult<SourceItemValidationResponse>> ValidateEngagementAsync(int id)
+    {
+        var engagement = await _engagementManager.GetAsync(id);
+        if (engagement is null)
+        {
+            return Ok(new SourceItemValidationResponse { IsValid = false, ErrorMessage = "Item not found" });
+        }
+
+        return Ok(new SourceItemValidationResponse
+        {
+            IsValid = true,
+            ItemTitle = engagement.Name,
+            ItemDetails = $"{engagement.StartDateTime:d} – {engagement.EndDateTime:d}"
+        });
+    }
+
+    private async Task<ActionResult<SourceItemValidationResponse>> ValidateTalkAsync(int talkId)
+    {
+        var talk = await _engagementManager.GetTalkAsync(talkId);
+        if (talk is null)
+        {
+            return Ok(new SourceItemValidationResponse { IsValid = false, ErrorMessage = "Item not found" });
+        }
+
+        Engagement? engagement = null;
+        if (talk.EngagementId > 0)
+        {
+            engagement = await _engagementManager.GetAsync(talk.EngagementId);
+        }
+
+        return Ok(new SourceItemValidationResponse
+        {
+            IsValid = true,
+            ItemTitle = talk.Name,
+            ItemDetails = engagement is not null ? engagement.Name : null
+        });
+    }
+
+    private async Task<ActionResult<SourceItemValidationResponse>> ValidateSyndicationFeedSourceAsync(int id)
+    {
+        var source = await _syndicationFeedSourceManager.GetAsync(id);
+        if (source is null)
+        {
+            return Ok(new SourceItemValidationResponse { IsValid = false, ErrorMessage = "Item not found" });
+        }
+
+        return Ok(new SourceItemValidationResponse
+        {
+            IsValid = true,
+            ItemTitle = source.Title,
+            ItemDetails = source.Author
+        });
+    }
+
+    private async Task<ActionResult<SourceItemValidationResponse>> ValidateYouTubeSourceAsync(int id)
+    {
+        var source = await _youTubeSourceManager.GetAsync(id);
+        if (source is null)
+        {
+            return Ok(new SourceItemValidationResponse { IsValid = false, ErrorMessage = "Item not found" });
+        }
+
+        return Ok(new SourceItemValidationResponse
+        {
+            IsValid = true,
+            ItemTitle = source.Title,
+            ItemDetails = source.Author
+        });
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/SourceItemValidationResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/SourceItemValidationResponse.cs
@@ -1,0 +1,27 @@
+namespace JosephGuadagno.Broadcasting.Api.Dtos;
+
+/// <summary>
+/// Response for the source item validation endpoint
+/// </summary>
+public class SourceItemValidationResponse
+{
+    /// <summary>
+    /// Whether the source item exists and is valid
+    /// </summary>
+    public bool IsValid { get; set; }
+
+    /// <summary>
+    /// The title or name of the source item, if found
+    /// </summary>
+    public string? ItemTitle { get; set; }
+
+    /// <summary>
+    /// Additional item details (type-specific), if found
+    /// </summary>
+    public string? ItemDetails { get; set; }
+
+    /// <summary>
+    /// Error message when the item is not found or a lookup error occurred
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Api/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Program.cs
@@ -229,6 +229,14 @@ void ConfigureRepositories(IServiceCollection services)
     
     services.TryAddScoped<IEngagementSocialMediaPlatformDataStore, EngagementSocialMediaPlatformDataStore>();
 
+    // SyndicationFeedSource
+    services.TryAddScoped<ISyndicationFeedSourceDataStore, SyndicationFeedSourceDataStore>();
+    services.TryAddScoped<ISyndicationFeedSourceManager, SyndicationFeedSourceManager>();
+
+    // YouTubeSource
+    services.TryAddScoped<IYouTubeSourceDataStore, YouTubeSourceDataStore>();
+    services.TryAddScoped<IYouTubeSourceManager, YouTubeSourceManager>();
+
     // RBAC Phase 1
     services.TryAddScoped<IApplicationUserDataStore, ApplicationUserDataStore>();
     services.TryAddScoped<IRoleDataStore, RoleDataStore>();

--- a/src/JosephGuadagno.Broadcasting.Web/Services/ScheduledItemValidationService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/ScheduledItemValidationService.cs
@@ -2,25 +2,49 @@ using JosephGuadagno.Broadcasting.Domain.Enums;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
 using JosephGuadagno.Broadcasting.Web.Models;
 
+using Microsoft.Identity.Abstractions;
+
 namespace JosephGuadagno.Broadcasting.Web.Services;
 
 /// <summary>
-/// Stub implementation of <see cref="IScheduledItemValidationService"/>.
-/// Source-item validation requires a dedicated API endpoint that does not yet exist.
-/// See: https://github.com/jguadagno/jjgnet-broadcast/issues (ScheduledItemValidationService redesign)
+/// Calls the API to validate that a scheduled item's source record exists.
 /// </summary>
-public class ScheduledItemValidationService : IScheduledItemValidationService
+public class ScheduledItemValidationService(
+    IDownstreamApi apiClient,
+    ILogger<ScheduledItemValidationService> logger) : IScheduledItemValidationService
 {
+    private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
+    private const string ValidateSourceItemUrl = "/Schedules/validate-source-item";
+
     /// <inheritdoc />
-    public Task<ScheduledItemLookupResult> ValidateItemAsync(
+    public async Task<ScheduledItemLookupResult> ValidateItemAsync(
         ScheduledItemType itemType,
         int itemPrimaryKey,
         CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(new ScheduledItemLookupResult
+        try
         {
-            IsValid = false,
-            ErrorMessage = "Source item validation is not yet available. Please verify the item ID manually."
-        });
+            var response = await apiClient.GetForUserAsync<ScheduledItemLookupResult>(ApiServiceName, options =>
+            {
+                options.RelativePath = $"{ValidateSourceItemUrl}?itemType={itemType}&itemPrimaryKey={itemPrimaryKey}";
+            });
+
+            return response ?? new ScheduledItemLookupResult
+            {
+                IsValid = false,
+                ErrorMessage = "Validation service returned no response"
+            };
+        }
+        catch (Exception ex)
+        {
+            var sanitized = ex.Message.Replace("\r", string.Empty).Replace("\n", string.Empty);
+            logger.LogError(ex, "Error validating source item type={ItemType} key={ItemPrimaryKey}: {Message}",
+                itemType, itemPrimaryKey, sanitized);
+            return new ScheduledItemLookupResult
+            {
+                IsValid = false,
+                ErrorMessage = "An error occurred while validating the item"
+            };
+        }
     }
 }


### PR DESCRIPTION
Closes #808

Replaces the stub ScheduledItemValidationService with a proper implementation that calls a new GET /schedules/validate-source-item endpoint on the API. Eliminates the architectural violation of injecting DB managers into the Web project.