### PR TITLE
feat(#689): add IMemoryCache caching to SocialMediaPlatformManager

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Program.cs
@@ -73,6 +73,8 @@ builder.Services.AddAutoMapper(config =>
     config.AddProfile<JosephGuadagno.Broadcasting.Api.MappingProfiles.ApiBroadcastingProfile>();
 }, typeof(Program));
 
+builder.Services.AddMemoryCache();
+
 ConfigureApplication(builder.Services);
 
 // ASP.NET Core API stuff

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/JosephGuadagno.Broadcasting.Managers.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/JosephGuadagno.Broadcasting.Managers.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="JosephGuadagno.AzureHelpers.Storage" Version="1.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/SocialMediaPlatformManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/SocialMediaPlatformManagerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Moq;
 
 namespace JosephGuadagno.Broadcasting.Managers.Tests;
@@ -8,12 +9,14 @@ namespace JosephGuadagno.Broadcasting.Managers.Tests;
 public class SocialMediaPlatformManagerTests
 {
     private readonly Mock<ISocialMediaPlatformDataStore> _dataStore;
+    private readonly IMemoryCache _cache;
     private readonly SocialMediaPlatformManager _sut;
 
     public SocialMediaPlatformManagerTests()
     {
         _dataStore = new Mock<ISocialMediaPlatformDataStore>();
-        _sut = new SocialMediaPlatformManager(_dataStore.Object);
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _sut = new SocialMediaPlatformManager(_dataStore.Object, _cache);
     }
 
     // ── GetAllAsync ───────────────────────────────────────────────────────────
@@ -74,6 +77,50 @@ public class SocialMediaPlatformManagerTests
         _dataStore.Verify(d => d.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task GetAllAsync_OnCacheHit_ShouldReturnCachedResultWithoutCallingDataStore()
+    {
+        // Arrange
+        var platforms = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true }
+        };
+        _dataStore
+            .Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platforms);
+
+        // Act — first call populates the cache
+        await _sut.GetAllAsync();
+        // second call should be served from cache
+        var result = await _sut.GetAllAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(platforms);
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_OnCacheMiss_ShouldCallDataStoreAndPopulateCache()
+    {
+        // Arrange
+        var platforms = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true }
+        };
+        _dataStore
+            .Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platforms);
+
+        // Act — cache is empty, so data store must be called
+        var result = await _sut.GetAllAsync();
+
+        // Assert — data store was called and cache is now populated
+        result.Should().BeEquivalentTo(platforms);
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Once);
+        _cache.TryGetValue("SocialMediaPlatforms_All", out List<SocialMediaPlatform>? cached);
+        cached.Should().BeEquivalentTo(platforms);
+    }
+
     // ── GetAllIncludingInactiveAsync ──────────────────────────────────────────
 
     [Fact]
@@ -115,6 +162,28 @@ public class SocialMediaPlatformManagerTests
         _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task GetAllIncludingInactiveAsync_OnCacheHit_ShouldNotCallDataStore()
+    {
+        // Arrange
+        var platforms = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true },
+            new SocialMediaPlatform { Id = 2, Name = "MySpace", IsActive = false }
+        };
+        _dataStore
+            .Setup(d => d.GetAllAsync(true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platforms);
+
+        // Act — first call populates the cache; second should be a cache hit
+        await _sut.GetAllIncludingInactiveAsync();
+        var result = await _sut.GetAllIncludingInactiveAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(platforms);
+        _dataStore.Verify(d => d.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     // ── GetByIdAsync ──────────────────────────────────────────────────────────
 
     [Fact]
@@ -150,6 +219,59 @@ public class SocialMediaPlatformManagerTests
         // Assert
         result.Should().BeNull();
         _dataStore.Verify(d => d.GetAsync(99, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_OnCacheHit_ShouldReturnCachedResultWithoutCallingDataStore()
+    {
+        // Arrange
+        var platform = new SocialMediaPlatform { Id = 5, Name = "LinkedIn", IsActive = true };
+        _dataStore
+            .Setup(d => d.GetAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platform);
+
+        // Act — first call populates the cache; second should be a cache hit
+        await _sut.GetByIdAsync(5);
+        var result = await _sut.GetByIdAsync(5);
+
+        // Assert
+        result.Should().BeEquivalentTo(platform);
+        _dataStore.Verify(d => d.GetAsync(5, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_OnCacheMiss_ShouldCallDataStoreAndPopulateCache()
+    {
+        // Arrange
+        var platform = new SocialMediaPlatform { Id = 7, Name = "Mastodon", IsActive = true };
+        _dataStore
+            .Setup(d => d.GetAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platform);
+
+        // Act
+        var result = await _sut.GetByIdAsync(7);
+
+        // Assert — data store was called and entry is now in cache
+        result.Should().BeEquivalentTo(platform);
+        _dataStore.Verify(d => d.GetAsync(7, It.IsAny<CancellationToken>()), Times.Once);
+        _cache.TryGetValue("SocialMediaPlatform_7", out SocialMediaPlatform? cached);
+        cached.Should().BeEquivalentTo(platform);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenPlatformDoesNotExist_ShouldNotCacheNullResult()
+    {
+        // Arrange
+        _dataStore
+            .Setup(d => d.GetAsync(99, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SocialMediaPlatform?)null);
+
+        // Act — call twice; data store should be hit both times since null is not cached
+        await _sut.GetByIdAsync(99);
+        await _sut.GetByIdAsync(99);
+
+        // Assert
+        _dataStore.Verify(d => d.GetAsync(99, It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     // ── GetByNameAsync ────────────────────────────────────────────────────────
@@ -244,6 +366,34 @@ public class SocialMediaPlatformManagerTests
         _dataStore.Verify(d => d.AddAsync(platform, cts.Token), Times.Once);
     }
 
+    [Fact]
+    public async Task AddAsync_ShouldInvalidateListCaches()
+    {
+        // Arrange — pre-populate the list cache
+        var existing = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 1, Name = "Twitter", IsActive = true }
+        };
+        _dataStore
+            .Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        await _sut.GetAllAsync(); // populates cache
+
+        var input = new SocialMediaPlatform { Name = "Mastodon" };
+        _dataStore
+            .Setup(d => d.AddAsync(input, default))
+            .ReturnsAsync(new SocialMediaPlatform { Id = 10, Name = "Mastodon" });
+
+        // Act
+        await _sut.AddAsync(input);
+
+        // Assert — cache is invalidated; next GetAllAsync hits data store again
+        _dataStore.Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SocialMediaPlatform>());
+        await _sut.GetAllAsync();
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
     // ── UpdateAsync ───────────────────────────────────────────────────────────
 
     [Fact]
@@ -300,6 +450,35 @@ public class SocialMediaPlatformManagerTests
         _dataStore.Verify(d => d.UpdateAsync(platform, cts.Token), Times.Once);
     }
 
+    [Fact]
+    public async Task UpdateAsync_ShouldInvalidateListCachesAndByIdCache()
+    {
+        // Arrange — pre-populate list and by-id caches
+        var platformList = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 3, Name = "BlueSky", IsActive = true }
+        };
+        var platform = new SocialMediaPlatform { Id = 3, Name = "BlueSky", IsActive = true };
+        _dataStore.Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>())).ReturnsAsync(platformList);
+        _dataStore.Setup(d => d.GetAsync(3, It.IsAny<CancellationToken>())).ReturnsAsync(platform);
+        await _sut.GetAllAsync();
+        await _sut.GetByIdAsync(3);
+
+        var updated = new SocialMediaPlatform { Id = 3, Name = "BlueSky Updated" };
+        _dataStore.Setup(d => d.UpdateAsync(It.IsAny<SocialMediaPlatform>(), default)).ReturnsAsync(updated);
+
+        // Act
+        await _sut.UpdateAsync(updated);
+
+        // Assert — subsequent reads hit data store again (caches cleared)
+        _dataStore.Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>())).ReturnsAsync(new List<SocialMediaPlatform>());
+        _dataStore.Setup(d => d.GetAsync(3, It.IsAny<CancellationToken>())).ReturnsAsync(updated);
+        await _sut.GetAllAsync();
+        await _sut.GetByIdAsync(3);
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _dataStore.Verify(d => d.GetAsync(3, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
     // ── DeleteAsync ───────────────────────────────────────────────────────────
 
     [Fact]
@@ -348,5 +527,33 @@ public class SocialMediaPlatformManagerTests
 
         // Assert
         _dataStore.Verify(d => d.DeleteAsync(1, cts.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldInvalidateListCachesAndByIdCache()
+    {
+        // Arrange — pre-populate list and by-id caches
+        var platformList = new List<SocialMediaPlatform>
+        {
+            new SocialMediaPlatform { Id = 4, Name = "Threads", IsActive = true }
+        };
+        var platform = new SocialMediaPlatform { Id = 4, Name = "Threads", IsActive = true };
+        _dataStore.Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>())).ReturnsAsync(platformList);
+        _dataStore.Setup(d => d.GetAsync(4, It.IsAny<CancellationToken>())).ReturnsAsync(platform);
+        await _sut.GetAllAsync();
+        await _sut.GetByIdAsync(4);
+
+        _dataStore.Setup(d => d.DeleteAsync(4, default)).ReturnsAsync(true);
+
+        // Act
+        await _sut.DeleteAsync(4);
+
+        // Assert — subsequent reads hit data store again (caches cleared)
+        _dataStore.Setup(d => d.GetAllAsync(false, It.IsAny<CancellationToken>())).ReturnsAsync(new List<SocialMediaPlatform>());
+        _dataStore.Setup(d => d.GetAsync(4, It.IsAny<CancellationToken>())).ReturnsAsync((SocialMediaPlatform?)null);
+        await _sut.GetAllAsync();
+        await _sut.GetByIdAsync(4);
+        _dataStore.Verify(d => d.GetAllAsync(false, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _dataStore.Verify(d => d.GetAsync(4, It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/SocialMediaPlatformManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/SocialMediaPlatformManager.cs
@@ -4,31 +4,60 @@ using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers;
 
 public class SocialMediaPlatformManager : ISocialMediaPlatformManager
 {
     private readonly ISocialMediaPlatformDataStore _dataStore;
+    private readonly IMemoryCache _cache;
 
-    public SocialMediaPlatformManager(ISocialMediaPlatformDataStore dataStore)
+    private const string CacheKeyAllActive = "SocialMediaPlatforms_All";
+    private const string CacheKeyAllIncludingInactive = "SocialMediaPlatforms_AllIncludingInactive";
+    private static string CacheKeyById(int id) => $"SocialMediaPlatform_{id}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public SocialMediaPlatformManager(ISocialMediaPlatformDataStore dataStore, IMemoryCache cache)
     {
         _dataStore = dataStore;
+        _cache = cache;
     }
 
     public async Task<List<SocialMediaPlatform>> GetAllAsync(bool includeInactive = false, CancellationToken cancellationToken = default)
     {
-        return await _dataStore.GetAllAsync(includeInactive: includeInactive, cancellationToken);
+        var cacheKey = includeInactive ? CacheKeyAllIncludingInactive : CacheKeyAllActive;
+        if (_cache.TryGetValue(cacheKey, out List<SocialMediaPlatform>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _dataStore.GetAllAsync(includeInactive: includeInactive, cancellationToken);
+        _cache.Set(cacheKey, result, CacheOptions);
+        return result;
     }
 
     public async Task<List<SocialMediaPlatform>> GetAllIncludingInactiveAsync(CancellationToken cancellationToken = default)
     {
-        return await _dataStore.GetAllAsync(includeInactive: true, cancellationToken);
+        return await GetAllAsync(includeInactive: true, cancellationToken);
     }
 
     public async Task<SocialMediaPlatform?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
     {
-        return await _dataStore.GetAsync(id, cancellationToken);
+        var cacheKey = CacheKeyById(id);
+        if (_cache.TryGetValue(cacheKey, out SocialMediaPlatform? cached))
+        {
+            return cached;
+        }
+
+        var result = await _dataStore.GetAsync(id, cancellationToken);
+        if (result is not null)
+        {
+            _cache.Set(cacheKey, result, CacheOptions);
+        }
+        return result;
     }
 
     public async Task<SocialMediaPlatform?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
@@ -38,17 +67,31 @@ public class SocialMediaPlatformManager : ISocialMediaPlatformManager
 
     public async Task<SocialMediaPlatform?> AddAsync(SocialMediaPlatform platform, CancellationToken cancellationToken = default)
     {
-        return await _dataStore.AddAsync(platform, cancellationToken);
+        var result = await _dataStore.AddAsync(platform, cancellationToken);
+        InvalidateListCaches();
+        return result;
     }
 
     public async Task<SocialMediaPlatform?> UpdateAsync(SocialMediaPlatform platform, CancellationToken cancellationToken = default)
     {
-        return await _dataStore.UpdateAsync(platform, cancellationToken);
+        var result = await _dataStore.UpdateAsync(platform, cancellationToken);
+        InvalidateListCaches();
+        _cache.Remove(CacheKeyById(platform.Id));
+        return result;
     }
 
     public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
-        return await _dataStore.DeleteAsync(id, cancellationToken);
+        var result = await _dataStore.DeleteAsync(id, cancellationToken);
+        InvalidateListCaches();
+        _cache.Remove(CacheKeyById(id));
+        return result;
+    }
+
+    private void InvalidateListCaches()
+    {
+        _cache.Remove(CacheKeyAllActive);
+        _cache.Remove(CacheKeyAllIncludingInactive);
     }
 }
 

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -249,6 +249,7 @@ void ConfigureTelemetryAndLogging(IServiceCollection services, string logPath, s
 void ConfigureApplication(IServiceCollection services)
 {
     services.AddHttpClient();
+    services.AddMemoryCache();
     
     // Register BroadcastingContext via transitive dependency (Managers ΓåÆ Data.Sql)
     // Note: BroadcastingContext type is fully qualified to avoid needing "using Data.Sql"


### PR DESCRIPTION
## Summary

Implements in-memory caching for SocialMediaPlatformManager as described in issue #689.

## Changes

### SocialMediaPlatformManager.cs
- Injected IMemoryCache via constructor
- GetAllAsync and GetByIdAsync read from cache on hit; populate cache on miss (5-minute absolute expiry)
- AddAsync, UpdateAsync, DeleteAsync invalidate list caches (SocialMediaPlatforms_All + SocialMediaPlatforms_AllIncludingInactive) and the by-id entry where applicable

### SocialMediaPlatformManagerTests.cs
- Updated constructor to inject real MemoryCache instance
- Added cache-hit tests (second call does NOT call data store)
- Added cache-miss tests (first call populates cache and calls data store)
- Added write-operation cache invalidation tests for AddAsync, UpdateAsync, DeleteAsync

### Program.cs (Api + Web)
- Added `builder.Services.AddMemoryCache()` / `services.AddMemoryCache()`

### JosephGuadagno.Broadcasting.Managers.Tests.csproj
- Added Microsoft.Extensions.Caching.Memory 10.0.7 package reference

## Testing

All tests pass:

```
dotnet test .\src\ --no-build --configuration Release
```

Closes #689