### PR TITLE
feat(#802): allow Dependabot PRs to bypass branch naming validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Dependabot PRs use `dependabot/{ecosystem}/{package}` naming — bypass all metadata checks.
+          if [[ "$BRANCH_NAME" =~ ^dependabot/ ]]; then
+            echo "Dependabot PR detected on branch '$BRANCH_NAME' — skipping branch/title metadata validation."
+            exit 0
+          fi
+
           branch_pattern='^(issue-[0-9]+(-[a-z][a-z0-9]*)*|feature/[0-9]+(-[a-z][a-z0-9]*)*)$'
           title_pattern='^(feat|fix|docs|style|refactor|perf|test|chore)\(#([0-9]+)\): .+'
 


### PR DESCRIPTION
## Summary

Adds a `dependabot/*` exception to the branch naming validation in the `pr-metadata` CI job so Dependabot dependency-update PRs are not rejected by the metadata checks.

Non-Dependabot PRs are unaffected and continue to require the existing `issue-<n>-<slug>` / `feature/<n>-<slug>` naming convention.

> **Note:** If GitHub branch protection rules also enforce branch naming patterns directly (outside of the CI workflow), those rules will need to be updated in the GitHub UI to add a `dependabot/**` exception.

Closes #802