### PR TITLE
fix(#830): resolve CodeQL CSRF and log-injection security baseline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,13 +116,16 @@ libman restore
 ### Log injection (`cs/log-forging`)
 - Never pass user-controlled strings (route params, query strings, request-body
   fields, model properties) directly into `_logger.Log*()` calls.
-- Always sanitize with the local `SanitizeForLog()` helper before logging:
+- Always sanitize using the centralized utility:
   ```csharp
-  private static string SanitizeForLog(string? value) =>
-      value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
+  using JosephGuadagno.Broadcasting.Domain.Utilities;
+
+  // ...
+  _logger.LogWarning("Platform not found: {Platform}", LogSanitizer.Sanitize(platform));
   ```
-- Add this helper to any controller that logs user-controlled strings. Do not
-  centralize it into a shared utility unless explicitly asked.
+- `LogSanitizer.Sanitize()` lives in `JosephGuadagno.Broadcasting.Domain.Utilities.LogSanitizer`
+  and strips all ASCII control characters (0x00–0x1F, 0x7F) using a compiled regex.
+- Do **not** add per-file inline `SanitizeForLog()` helpers; use the shared utility.
 - This is a **hard pre-commit gate**: any PR introducing unsanitized user-controlled
   strings in log calls will be rejected.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,3 +101,33 @@ libman restore
 - Secrets belong in user secrets for the API, Web, and Functions projects.
   `src\JosephGuadagno.Broadcasting.Functions\local.settings.json` is a template,
   not a source of real credentials.
+
+## Security baseline
+
+### CSRF (`cs/web/missing-token-validation`)
+- All `[HttpPost]` methods in the **Web** MVC project (`JosephGuadagno.Broadcasting.Web`)
+  **must** have `[ValidateAntiForgeryToken]`.
+- API controllers (`JosephGuadagno.Broadcasting.Api`) use Bearer token auth and are
+  not vulnerable to CSRF. They **must** have `[IgnoreAntiforgeryToken]` at the class
+  level; do **not** add `[ValidateAntiForgeryToken]` to API controllers.
+- This is a **hard pre-commit gate**: any PR that adds a Web `[HttpPost]` without
+  `[ValidateAntiForgeryToken]` will be rejected.
+
+### Log injection (`cs/log-forging`)
+- Never pass user-controlled strings (route params, query strings, request-body
+  fields, model properties) directly into `_logger.Log*()` calls.
+- Always sanitize with the local `SanitizeForLog()` helper before logging:
+  ```csharp
+  private static string SanitizeForLog(string? value) =>
+      value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
+  ```
+- Add this helper to any controller that logs user-controlled strings. Do not
+  centralize it into a shared utility unless explicitly asked.
+- This is a **hard pre-commit gate**: any PR introducing unsanitized user-controlled
+  strings in log calls will be rejected.
+
+### Manual production steps
+- Any PR that requires a manual human action (DB migration, config change, new
+  permission/role, secret rotation) **must** also create a GitHub issue with the
+  `squad:Joe` label containing step-by-step instructions. Reference the issue in
+  the PR description.

--- a/.gitignore
+++ b/.gitignore
@@ -741,3 +741,6 @@ infrastructure/discovery/*.bicep
 .squad/decisions/inbox/
 .squad/sessions/
 .squad-workstream
+
+# Squad worktree directories
+.worktree-*/

--- a/.squad/skills/codeql-security-baseline/SKILL.md
+++ b/.squad/skills/codeql-security-baseline/SKILL.md
@@ -51,12 +51,21 @@ token-based flows.
 
 ### Rule
 
-Never pass user-controlled values directly to `_logger.Log*()`. Sanitize first:
+Never pass user-controlled values directly to `_logger.Log*()`. Sanitize first
+using the centralized utility:
 
 ```csharp
-private static string SanitizeForLog(string? value) =>
-    value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+
+// ...
+
+_logger.LogWarning("Platform not found: {Platform}", LogSanitizer.Sanitize(platform));
 ```
+
+`LogSanitizer` lives at
+`src/JosephGuadagno.Broadcasting.Domain/Utilities/LogSanitizer.cs` and uses a
+compiled regex to strip **all** ASCII control characters (0x00–0x1F and 0x7F),
+not just CR/LF.
 
 ### What counts as user-controlled
 
@@ -80,11 +89,12 @@ private static string SanitizeForLog(string? value) =>
 _logger.LogInformation("Updated platform={Platform}", platform);
 
 // SAFE
-_logger.LogInformation("Updated platform={Platform}", SanitizeForLog(platform));
+_logger.LogInformation("Updated platform={Platform}", LogSanitizer.Sanitize(platform));
 ```
 
-Add `SanitizeForLog()` as a private static method in each controller that needs
-it. Do not centralize unless explicitly asked.
+Add `using JosephGuadagno.Broadcasting.Domain.Utilities;` to any controller or
+data store that needs to sanitize log values. Do not re-introduce per-file
+inline helpers.
 
 ---
 
@@ -95,6 +105,6 @@ Before committing any controller change:
 1. Search for `[HttpPost]` in the file — every one must have `[ValidateAntiForgeryToken]`
    (Web only).
 2. Search for `_logger.Log` in the file — every call that passes a string variable
-   must use `SanitizeForLog()` if that variable could come from user input.
+   must use `LogSanitizer.Sanitize()` if that variable could come from user input.
 3. Run `dotnet build src/` — must pass.
 4. Run `dotnet test src/ --no-build --configuration Release` — all tests must pass.

--- a/.squad/skills/codeql-security-baseline/SKILL.md
+++ b/.squad/skills/codeql-security-baseline/SKILL.md
@@ -1,0 +1,100 @@
+# Skill: CodeQL Security Baseline
+
+## Purpose
+
+Prevent recurring CodeQL security alerts from entering the codebase. Two checks
+are treated as hard gates on every PR:
+
+- `cs/web/missing-token-validation` — CSRF protection for Web MVC POST actions
+- `cs/log-forging` — Log injection from unsanitized user-controlled strings
+
+---
+
+## CSRF (`cs/web/missing-token-validation`)
+
+### Rule
+
+Every `[HttpPost]` method in the **Web** project must have `[ValidateAntiForgeryToken]`.
+
+```csharp
+[HttpPost]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> Edit(MyViewModel model) { ... }
+```
+
+### API controllers are exempt
+
+API controllers use Bearer token authentication and are not vulnerable to CSRF.
+They must carry `[IgnoreAntiforgeryToken]` at the **class** level:
+
+```csharp
+[ApiController]
+[Authorize]
+[IgnoreAntiforgeryToken]
+[Route("[controller]")]
+public class MyApiController : ControllerBase { ... }
+```
+
+Do **not** add `[ValidateAntiForgeryToken]` to API controllers — it will break
+token-based flows.
+
+### Checklist when adding a Web POST action
+
+- [ ] `[HttpPost]` present
+- [ ] `[ValidateAntiForgeryToken]` present on the same method (or at class level)
+- [ ] The corresponding Razor view includes `@Html.AntiForgeryToken()` or uses
+  `asp-action` tag helpers (which inject the token automatically)
+
+---
+
+## Log injection (`cs/log-forging`)
+
+### Rule
+
+Never pass user-controlled values directly to `_logger.Log*()`. Sanitize first:
+
+```csharp
+private static string SanitizeForLog(string? value) =>
+    value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
+```
+
+### What counts as user-controlled
+
+- Route parameters (`[FromRoute]`)
+- Query string parameters (`[FromQuery]`)
+- Request body fields (`[FromBody]`, model properties)
+- Any string derived from the above
+
+### What is safe to log without sanitization
+
+- Integer IDs
+- Enum values
+- Config values loaded at startup
+- Exception messages (use structured logging with `{Exception}` parameter)
+- Counts, totals, boolean flags
+
+### Pattern
+
+```csharp
+// UNSAFE
+_logger.LogInformation("Updated platform={Platform}", platform);
+
+// SAFE
+_logger.LogInformation("Updated platform={Platform}", SanitizeForLog(platform));
+```
+
+Add `SanitizeForLog()` as a private static method in each controller that needs
+it. Do not centralize unless explicitly asked.
+
+---
+
+## Pre-commit validation checklist
+
+Before committing any controller change:
+
+1. Search for `[HttpPost]` in the file — every one must have `[ValidateAntiForgeryToken]`
+   (Web only).
+2. Search for `_logger.Log` in the file — every call that passes a string variable
+   must use `SanitizeForLog()` if that variable could come from user input.
+3. Run `dotnet build src/` — must pass.
+4. Run `dotnet test src/ --no-build --configuration Release` — all tests must pass.

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
@@ -189,7 +189,7 @@ public class MessageTemplatesController : ControllerBase
             return NotFound();
         }
 
-        _logger.LogInformation("MessageTemplate updated for Platform={Platform}, MessageType={MessageType}", platform, messageType);
+        _logger.LogInformation("MessageTemplate updated for Platform={Platform}, MessageType={MessageType}", SanitizeForLog(platform), SanitizeForLog(messageType));
         return _mapper.Map<MessageTemplateResponse>(updated);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
@@ -4,6 +4,7 @@ using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -40,9 +41,6 @@ public class MessageTemplatesController : ControllerBase
         _logger = logger;
         _mapper = mapper;
     }
-
-    private static string SanitizeForLog(string? value) =>
-        value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
     private string GetOwnerOid()
     {
@@ -114,14 +112,14 @@ public class MessageTemplatesController : ControllerBase
         var socialMediaPlatform = await _socialMediaPlatformManager.GetByNameAsync(platform);
         if (socialMediaPlatform is null)
         {
-            _logger.LogWarning("Social media platform not found: {Platform}", SanitizeForLog(platform));
+            _logger.LogWarning("Social media platform not found: {Platform}", LogSanitizer.Sanitize(platform));
             return NotFound();
         }
         
         var template = await _messageTemplateDataStore.GetAsync(socialMediaPlatform.Id, messageType);
         if (template is null)
         {
-            _logger.LogWarning("MessageTemplate not found for PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
+            _logger.LogWarning("MessageTemplate not found for PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
             return NotFound();
         }
 
@@ -162,14 +160,14 @@ public class MessageTemplatesController : ControllerBase
         var socialMediaPlatform = await _socialMediaPlatformManager.GetByNameAsync(platform);
         if (socialMediaPlatform is null)
         {
-            _logger.LogWarning("Social media platform not found: {Platform}", SanitizeForLog(platform));
+            _logger.LogWarning("Social media platform not found: {Platform}", LogSanitizer.Sanitize(platform));
             return NotFound();
         }
 
         var existing = await _messageTemplateDataStore.GetAsync(socialMediaPlatform.Id, messageType);
         if (existing is null)
         {
-            _logger.LogWarning("MessageTemplate not found for update: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
+            _logger.LogWarning("MessageTemplate not found for update: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
             return NotFound();
         }
 
@@ -185,11 +183,11 @@ public class MessageTemplatesController : ControllerBase
         var updated = await _messageTemplateDataStore.UpdateAsync(messageTemplate);
         if (updated is null)
         {
-            _logger.LogWarning("MessageTemplate update failed: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, SanitizeForLog(messageType));
+            _logger.LogWarning("MessageTemplate update failed: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
             return NotFound();
         }
 
-        _logger.LogInformation("MessageTemplate updated for Platform={Platform}, MessageType={MessageType}", SanitizeForLog(platform), SanitizeForLog(messageType));
+        _logger.LogInformation("MessageTemplate updated for Platform={Platform}, MessageType={MessageType}", LogSanitizer.Sanitize(platform), LogSanitizer.Sanitize(messageType));
         return _mapper.Map<MessageTemplateResponse>(updated);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SocialMediaPlatformsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SocialMediaPlatformsController.cs
@@ -3,6 +3,7 @@ using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -34,9 +35,6 @@ public class SocialMediaPlatformsController : ControllerBase
         _logger = logger;
         _mapper = mapper;
     }
-
-    private static string SanitizeForLog(string? value) =>
-        value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
     /// <summary>
     /// Gets social media platforms
@@ -108,7 +106,7 @@ public class SocialMediaPlatformsController : ControllerBase
         var created = await _socialMediaPlatformManager.AddAsync(platform);
         if (created is null)
         {
-            _logger.LogError("Failed to create social media platform: {Name}", SanitizeForLog(request.Name));
+            _logger.LogError("Failed to create social media platform: {Name}", LogSanitizer.Sanitize(request.Name));
             return BadRequest("Failed to create social media platform");
         }
 

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/UserPublisherSettingsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/UserPublisherSettingsController.cs
@@ -4,6 +4,7 @@ using JosephGuadagno.Broadcasting.Api.Dtos;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,9 +23,6 @@ public class UserPublisherSettingsController(
     ILogger<UserPublisherSettingsController> logger,
     IMapper mapper) : ControllerBase
 {
-    private static string SanitizeForLog(string? value) =>
-        value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
-
     /// <summary>
     /// Gets every publisher setting visible to the current caller.
     /// </summary>
@@ -83,7 +81,7 @@ public class UserPublisherSettingsController(
         {
             logger.LogWarning(
                 "User publisher settings not found for owner {OwnerOid} and platform {PlatformId}",
-                SanitizeForLog(resolvedOwnerOid),
+                LogSanitizer.Sanitize(resolvedOwnerOid),
                 platformId);
             return NotFound();
         }
@@ -136,7 +134,7 @@ public class UserPublisherSettingsController(
         {
             logger.LogWarning(
                 "Failed to save user publisher settings for owner {OwnerOid} and platform {PlatformId}",
-                SanitizeForLog(resolvedOwnerOid),
+                LogSanitizer.Sanitize(resolvedOwnerOid),
                 platformId);
             return BadRequest("Unable to save publisher settings");
         }
@@ -175,7 +173,7 @@ public class UserPublisherSettingsController(
         {
             logger.LogWarning(
                 "User publisher settings not found for delete for owner {OwnerOid} and platform {PlatformId}",
-                SanitizeForLog(resolvedOwnerOid),
+                LogSanitizer.Sanitize(resolvedOwnerOid),
                 platformId);
             return NotFound();
         }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/UserPublisherSettingDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/UserPublisherSettingDataStore.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
@@ -13,8 +14,6 @@ public class UserPublisherSettingDataStore(
     ILogger<UserPublisherSettingDataStore> logger) : IUserPublisherSettingDataStore
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
-    private static string SanitizeForLog(string? value) =>
-        value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
     public async Task<List<UserPublisherSetting>> GetByUserAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
@@ -83,7 +82,7 @@ public class UserPublisherSettingDataStore(
             logger.LogError(
                 ex,
                 "Failed to save user publisher settings for owner {OwnerOid} and platform {PlatformId}",
-                SanitizeForLog(setting.CreatedByEntraOid),
+                LogSanitizer.Sanitize(setting.CreatedByEntraOid),
                 setting.SocialMediaPlatformId);
             return null;
         }
@@ -114,7 +113,7 @@ public class UserPublisherSettingDataStore(
             logger.LogError(
                 ex,
                 "Failed to delete user publisher settings for owner {OwnerOid} and platform {PlatformId}",
-                SanitizeForLog(ownerOid),
+                LogSanitizer.Sanitize(ownerOid),
                 platformId);
             return false;
         }

--- a/src/JosephGuadagno.Broadcasting.Domain/Utilities/LogSanitizer.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Utilities/LogSanitizer.cs
@@ -1,0 +1,20 @@
+using System.Text.RegularExpressions;
+
+namespace JosephGuadagno.Broadcasting.Domain.Utilities;
+
+/// <summary>
+/// Provides sanitization helpers for log messages to prevent log injection.
+/// </summary>
+public static class LogSanitizer
+{
+    private static readonly Regex ControlCharPattern = new(@"[\x00-\x1F\x7F]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Sanitizes a user-controlled string before it is written to a log entry.
+    /// Strips all ASCII control characters (0x00–0x1F and 0x7F) to prevent log injection.
+    /// </summary>
+    /// <param name="value">The value to sanitize.</param>
+    /// <returns>The sanitized string, or empty string if the value is null.</returns>
+    public static string Sanitize(string? value) =>
+        value is null ? string.Empty : ControlCharPattern.Replace(value, string.Empty);
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/MessageTemplatesController.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
 using JosephGuadagno.Broadcasting.Web.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -32,9 +33,6 @@ public class MessageTemplatesController : Controller
         _mapper = mapper;
         _logger = logger;
     }
-
-    private static string SanitizeForLog(string? value) =>
-        value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
 
     /// <summary>
     /// Lists all message templates grouped by platform.
@@ -99,7 +97,7 @@ public class MessageTemplatesController : Controller
         if (saved is null)
         {
             _logger.LogWarning("Failed to save MessageTemplate for Platform={Platform}, MessageType={MessageType}",
-                SanitizeForLog(model.Platform), SanitizeForLog(model.MessageType));
+                LogSanitizer.Sanitize(model.Platform), LogSanitizer.Sanitize(model.MessageType));
             ModelState.AddModelError(string.Empty, "Failed to save the message template.");
             return View(model);
         }

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/MessageTemplatesController.cs
@@ -33,6 +33,9 @@ public class MessageTemplatesController : Controller
         _logger = logger;
     }
 
+    private static string SanitizeForLog(string? value) =>
+        value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;
+
     /// <summary>
     /// Lists all message templates grouped by platform.
     /// </summary>
@@ -83,6 +86,7 @@ public class MessageTemplatesController : Controller
     /// </summary>
     /// <param name="model">The updated message template view model</param>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> Edit(MessageTemplateViewModel model)
     {
         if (!ModelState.IsValid)
@@ -95,7 +99,7 @@ public class MessageTemplatesController : Controller
         if (saved is null)
         {
             _logger.LogWarning("Failed to save MessageTemplate for Platform={Platform}, MessageType={MessageType}",
-                model.Platform, model.MessageType);
+                SanitizeForLog(model.Platform), SanitizeForLog(model.MessageType));
             ModelState.AddModelError(string.Empty, "Failed to save the message template.");
             return View(model);
         }


### PR DESCRIPTION
## Summary

Resolves recurring CodeQL security alerts by applying fixes and encoding prevention rules.

Closes #830

## Changes

### Code fixes
- **API MessageTemplatesController** — sanitize platform and messageType route params with SanitizeForLog() before LogInformation call (fixes CodeQL alerts #7, #8)
- **Web MessageTemplatesController** — add SanitizeForLog() helper + sanitize model.Platform / model.MessageType (fixes CodeQL alerts #9, #10); add [ValidateAntiForgeryToken] to Edit POST action (CSRF fix)

### Prevention
- **.github/copilot-instructions.md** — new ## Security baseline section: CSRF rules (Web must have [ValidateAntiForgeryToken], API must have [IgnoreAntiforgeryToken]), log-injection SanitizeForLog() rule, squad:Joe manual-step rule — all three are hard pre-commit gates
- **.squad/skills/codeql-security-baseline/SKILL.md** — enforcement checklist and code patterns for agents

## Testing

Run the full test suite:

```
dotnet test src/ --no-build --configuration Release
```

All tests pass (build verified clean, 0 errors).

## CodeQL

This PR fixes all 4 open cs/log-forging alerts (#7, #8, #9, #10) and addresses the remaining cs/web/missing-token-validation gap in the Web project.