### PR TITLE
chore(#807): remove SyndicationFeedReader filter from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,8 +21,7 @@ Closes #
       are active
 - [ ] I ran `dotnet restore .\src\`
 - [ ] I ran `dotnet build .\src\ --no-restore --configuration Release`
-- [ ] I ran `dotnet test .\src\ --no-build --verbosity normal --configuration
-      Release --filter "FullyQualifiedName!~SyndicationFeedReader"`
+- [ ] I ran `dotnet test .\src\ --no-build --verbosity normal --configuration Release`
 - [ ] Zero test failures — I have not included known failures in this PR
 - [ ] This PR contains changes for exactly one issue
 - [ ] No "Note on Remaining Test Failures" or similar acknowledgments in this


### PR DESCRIPTION
## Description

Removes the unnecessary --filter "FullyQualifiedName!~SyndicationFeedReader" flag from the PR checklist test step. The preceding dotnet test command already runs all tests — the filter was redundant and confusing.

## Related Issue

Closes #807

## Type of Change

- [x] Process/infrastructure change
