### PR TITLE
fix(#834): resolve remaining CSRF token validation CodeQL alerts

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/SchedulesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/SchedulesController.cs
@@ -138,6 +138,7 @@ public class SchedulesController : Controller
     /// <param name="scheduledItemViewModel">The <see cref="ScheduledItemViewModel"/></param>
     /// <returns>Upon success, redirects to the <see cref="Details"/> page. Upon failure, reloads the page.</returns>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> Edit(ScheduledItemViewModel scheduledItemViewModel)
     {
         // Defence-in-depth: re-verify ownership before saving (issue #742)
@@ -246,6 +247,7 @@ public class SchedulesController : Controller
     /// <param name="scheduledItemViewModel">The <see cref="ScheduledItemViewModel"/> to be added</param>
     /// <returns>Upon success, redirects to the <see cref="Details"/>. Upon failure, reloads the page</returns>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public async Task<RedirectToActionResult> Add(ScheduledItemViewModel scheduledItemViewModel)
     {
         var scheduledItemToAdd = _mapper.Map<Domain.Models.ScheduledItem>(scheduledItemViewModel);

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/TalksController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/TalksController.cs
@@ -94,6 +94,7 @@ public class TalksController : Controller
     /// <param name="talkViewModel">The <see cref="TalkViewModel"/> to edit</param>
     /// <returns>Upon success, redirected to the <see cref="Details"/>. Upon failure, the view will be reloaded</returns>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     [Route("{talkId:int}")]
     public async Task<IActionResult> Edit(TalkViewModel talkViewModel)
     {
@@ -221,6 +222,7 @@ public class TalksController : Controller
     /// <param name="talkViewModel">The <see cref="TalkViewModel"/></param>
     /// <returns>Upon success, redirects to the <see cref="Details"/> page. Upon failure, reloads the page.</returns>
     [HttpPost]
+    [ValidateAntiForgeryToken]
     [Route("")]
     public async Task<RedirectToActionResult> Add(TalkViewModel talkViewModel)
     {


### PR DESCRIPTION
## Description

This PR resolves all 8 remaining CodeQL CSRF alerts across 4 controllers by implementing appropriate CSRF protection based on controller type.

## Related Issue

Closes #834

## Changes Made

### API Controllers (No Changes Required)
Both API controllers already had [IgnoreAntiforgeryToken] at the class level:
- ✅ **SchedulesController** (API) - Alert #13
- ✅ **EngagementsController** (API) - Alerts #27, #37, #38

API controllers use Bearer token authentication and are not vulnerable to CSRF attacks. The existing [IgnoreAntiforgeryToken] attribute correctly excludes them from CSRF validation.

### Web Controllers (Added ValidateAntiForgeryToken)
Added [ValidateAntiForgeryToken] to POST actions that were missing it:

#### SchedulesController (Web)
- ✅ **Edit** POST action - Alert #20
- ✅ **Add** POST action - Alert #30
- DeleteConfirmed already had the attribute

#### TalksController (Web)  
- ✅ **Edit** POST action - Alert #18
- ✅ **Add** POST action - Alert #31
- DeleteConfirmed already had the attribute

All corresponding Razor views use sp-action tag helpers which automatically inject anti-forgery tokens when the controller action has [ValidateAntiForgeryToken].

## Pre-Submission Checklist

- [x] My branch name follows the issue convention (`issue-834-csrf-fixes`)
- [x] My PR title follows `<type>(#<issue>): <summary>` and matches the linked issue above
- [x] I ran `dotnet restore .\src\`
- [x] I ran `dotnet build .\src\ --no-restore --configuration Release`
- [x] I ran `dotnet test .\src\ --no-build --verbosity normal --configuration Release --filter "FullyQualifiedName!~SyndicationFeedReader"`
- [x] Zero test failures — I have not included known failures in this PR
- [x] This PR contains changes for exactly one issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Process/infrastructure change

## Additional Context

**Security Impact:** This fix ensures all state-changing Web MVC actions are protected against CSRF attacks. API endpoints remain correctly excluded from CSRF validation as they use Bearer token authentication.

**Testing:** All 978 tests passed successfully (41 skipped by design).