### PR TITLE
fix(#842): enforce gh api --input for Neo PR review comments

### DIFF
--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -21,6 +21,7 @@
 - Write decisions to inbox when making team-relevant choices
 - Focused, practical, gets things done
 - **PR comments**: Always use `.squad/skills/neo-pr-comment/TEMPLATE.md` for structuring reviews — two modes: Formal Review (comprehensive subsystem analysis + checklist) or Quick Finding (targeted blocker + action)
+- **GitHub comment posting**: ALWAYS write comment body to a temp JSON file and post via `gh api --input <tmpfile>`. NEVER use `gh pr review --body` or `gh pr comment --body` inline — PowerShell mangles Markdown backtick fences (``` ``` ```). Always wrap code samples in triple-backtick fences in the JSON body.
 
 ## Boundaries
 


### PR DESCRIPTION
## Problem
Neo's review comments posted via \gh pr review --body\ lose Markdown code fences because PowerShell mangles backticks. Code snippets appear as plain text.

## Fix
Updated Neo's charter (\.squad/agents/neo/charter.md\) to enforce:
- Use a temp JSON file and post via \gh api --input <tmpfile>\
- Triple-backtick fences inside the JSON body string
- Never use inline \--body\ strings on any \gh\ comment command

This mirrors the existing team directive already enforced for Scribe.

Closes #842