### PR TITLE
feat(#809,#811): display resolved source item name in Schedules views

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -587,4 +587,307 @@ public class SchedulesControllerTests
         result.Result.Should().BeOfType<NotFoundResult>();
         _scheduledItemManagerMock.Verify(m => m.GetScheduledItemsByCalendarMonthAsync(2025, 1, It.IsAny<int>(), It.IsAny<int>()), Times.Once);
     }
+
+    // ── SourceItemDisplayName resolution (issues #809 / #811) ───────────────
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithEngagementItem_PopulatesEngagementName()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.Engagements,
+            ItemPrimaryKey = 5,
+            Message = "NDC Oslo talk!",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _engagementManagerMock
+            .Setup(m => m.GetAsync(5))
+            .ReturnsAsync(new Engagement { Id = 5, Name = "NDC Oslo" });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().Be("NDC Oslo");
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithEngagementItem_WhenEngagementNotFound_SourceItemDisplayNameIsNull()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.Engagements,
+            ItemPrimaryKey = 5,
+            Message = "Missing engagement",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _engagementManagerMock
+            .Setup(m => m.GetAsync(5))
+            .ReturnsAsync((Engagement?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithTalkItem_WhenEngagementExists_PopulatesCombinedName()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.Talks,
+            ItemPrimaryKey = 10,
+            Message = "Clean Architecture at NDC!",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _engagementManagerMock
+            .Setup(m => m.GetTalkAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Talk { Id = 10, Name = "Clean Architecture", EngagementId = 5 });
+        _engagementManagerMock
+            .Setup(m => m.GetAsync(5))
+            .ReturnsAsync(new Engagement { Id = 5, Name = "NDC Oslo" });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().Be("NDC Oslo - Clean Architecture");
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithTalkItem_WhenEngagementNotFound_PopulatesTalkNameOnly()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.Talks,
+            ItemPrimaryKey = 10,
+            Message = "Talk without parent engagement",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _engagementManagerMock
+            .Setup(m => m.GetTalkAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Talk { Id = 10, Name = "Clean Architecture", EngagementId = 5 });
+        _engagementManagerMock
+            .Setup(m => m.GetAsync(5))
+            .ReturnsAsync((Engagement?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().Be("Clean Architecture");
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithTalkItem_WhenTalkNotFound_SourceItemDisplayNameIsNull()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.Talks,
+            ItemPrimaryKey = 99,
+            Message = "Talk not in DB",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _engagementManagerMock
+            .Setup(m => m.GetTalkAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Talk?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithSyndicationFeedSourceItem_PopulatesFeedTitle()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.SyndicationFeedSources,
+            ItemPrimaryKey = 7,
+            Message = "New blog post!",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _syndicationFeedSourceManagerMock
+            .Setup(m => m.GetAsync(7))
+            .ReturnsAsync(new SyndicationFeedSource
+            {
+                Id = 7,
+                Title = "Joseph's Blog",
+                FeedIdentifier = "josephguadagno-blog",
+                Author = "Joseph Guadagno",
+                Url = "https://josephguadagno.net/feed.rss",
+                CreatedByEntraOid = "test-oid",
+                PublicationDate = DateTimeOffset.UtcNow,
+                AddedOn = DateTimeOffset.UtcNow,
+                LastUpdatedOn = DateTimeOffset.UtcNow
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().Be("Joseph's Blog");
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WithYouTubeSourceItem_PopulatesYouTubeTitle()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.YouTubeSources,
+            ItemPrimaryKey = 3,
+            Message = "New YouTube video!",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _youTubeSourceManagerMock
+            .Setup(m => m.GetAsync(3))
+            .ReturnsAsync(new YouTubeSource
+            {
+                Id = 3,
+                Title = "JosephGuadagno",
+                VideoId = "abc123",
+                Author = "Joseph Guadagno",
+                Url = "https://youtube.com/watch?v=abc123",
+                CreatedByEntraOid = "test-oid",
+                PublicationDate = DateTimeOffset.UtcNow,
+                AddedOn = DateTimeOffset.UtcNow,
+                LastUpdatedOn = DateTimeOffset.UtcNow
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetScheduledItemsAsync();
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().Be("JosephGuadagno");
+    }
+
+    [Fact]
+    public async Task GetScheduledItemsAsync_WhenResolutionThrows_SourceItemDisplayNameIsNullAndNoException()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 1,
+            ItemType = Domain.Enums.ScheduledItemType.SyndicationFeedSources,
+            ItemPrimaryKey = 99,
+            Message = "Item with broken lookup",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<ScheduledItem> { Items = [item], TotalCount = 1 });
+        _syndicationFeedSourceManagerMock
+            .Setup(m => m.GetAsync(99))
+            .ThrowsAsync(new Exception("DB error"));
+
+        var sut = CreateSut();
+
+        // Act
+        var act = async () => await sut.GetScheduledItemsAsync();
+
+        // Assert — must complete without throwing; display name must be null
+        await act.Should().NotThrowAsync();
+        var result = await sut.GetScheduledItemsAsync();
+        result.Value.Should().NotBeNull();
+        result.Value!.Items[0].SourceItemDisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetScheduledItemAsync_WithEngagementItem_PopulatesSourceItemDisplayName()
+    {
+        // Arrange
+        var item = new ScheduledItem
+        {
+            Id = 5,
+            ItemType = Domain.Enums.ScheduledItemType.Engagements,
+            ItemPrimaryKey = 5,
+            Message = "Engagement item",
+            SendOnDateTime = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedByEntraOid = "owner-oid-12345"
+        };
+        _scheduledItemManagerMock
+            .Setup(m => m.GetAsync(5))
+            .ReturnsAsync(item);
+        _engagementManagerMock
+            .Setup(m => m.GetAsync(5))
+            .ReturnsAsync(new Engagement { Id = 5, Name = "NDC Oslo" });
+
+        var sut = CreateSut(ownerOid: "owner-oid-12345");
+
+        // Act
+        var result = await sut.GetScheduledItemAsync(5);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<Api.Dtos.ScheduledItemResponse>().Subject;
+        response.SourceItemDisplayName.Should().Be("NDC Oslo");
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/SchedulesControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Security.Claims;
 using AutoMapper;
 using FluentAssertions;
@@ -617,7 +618,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().Be("NDC Oslo");
+        result.Value!.Items.First().SourceItemDisplayName.Should().Be("NDC Oslo");
     }
 
     [Fact]
@@ -647,7 +648,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().BeNull();
+        result.Value!.Items.First().SourceItemDisplayName.Should().BeNull();
     }
 
     [Fact]
@@ -680,7 +681,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().Be("NDC Oslo - Clean Architecture");
+        result.Value!.Items.First().SourceItemDisplayName.Should().Be("NDC Oslo - Clean Architecture");
     }
 
     [Fact]
@@ -713,7 +714,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().Be("Clean Architecture");
+        result.Value!.Items.First().SourceItemDisplayName.Should().Be("Clean Architecture");
     }
 
     [Fact]
@@ -743,7 +744,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().BeNull();
+        result.Value!.Items.First().SourceItemDisplayName.Should().BeNull();
     }
 
     [Fact]
@@ -784,7 +785,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().Be("Joseph's Blog");
+        result.Value!.Items.First().SourceItemDisplayName.Should().Be("Joseph's Blog");
     }
 
     [Fact]
@@ -825,7 +826,7 @@ public class SchedulesControllerTests
 
         // Assert
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().Be("JosephGuadagno");
+        result.Value!.Items.First().SourceItemDisplayName.Should().Be("JosephGuadagno");
     }
 
     [Fact]
@@ -857,7 +858,7 @@ public class SchedulesControllerTests
         await act.Should().NotThrowAsync();
         var result = await sut.GetScheduledItemsAsync();
         result.Value.Should().NotBeNull();
-        result.Value!.Items[0].SourceItemDisplayName.Should().BeNull();
+        result.Value!.Items.First().SourceItemDisplayName.Should().BeNull();
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SchedulesController.cs
@@ -93,6 +93,10 @@ public class SchedulesController: ControllerBase
         }
 
         var items = _mapper.Map<List<ScheduledItemResponse>>(result.Items);
+        foreach (var item in items)
+        {
+            item.SourceItemDisplayName = await ResolveDisplayNameAsync(item.ItemType, item.ItemPrimaryKey);
+        }
         
         return new PagedResponse<ScheduledItemResponse>
         {
@@ -130,7 +134,9 @@ public class SchedulesController: ControllerBase
             return Forbid();
         }
 
-        return Ok(_mapper.Map<ScheduledItemResponse>(item));
+        var response = _mapper.Map<ScheduledItemResponse>(item);
+        response.SourceItemDisplayName = await ResolveDisplayNameAsync(response.ItemType, response.ItemPrimaryKey);
+        return Ok(response);
     }
 
     /// <summary>
@@ -277,6 +283,10 @@ public class SchedulesController: ControllerBase
         }
 
         var items = _mapper.Map<List<ScheduledItemResponse>>(result.Items);
+        foreach (var item in items)
+        {
+            item.SourceItemDisplayName = await ResolveDisplayNameAsync(item.ItemType, item.ItemPrimaryKey);
+        }
         
         return new PagedResponse<ScheduledItemResponse>
         {
@@ -314,6 +324,10 @@ public class SchedulesController: ControllerBase
         }
 
         var items = _mapper.Map<List<ScheduledItemResponse>>(result.Items);
+        foreach (var item in items)
+        {
+            item.SourceItemDisplayName = await ResolveDisplayNameAsync(item.ItemType, item.ItemPrimaryKey);
+        }
         
         return new PagedResponse<ScheduledItemResponse>
         {
@@ -353,6 +367,10 @@ public class SchedulesController: ControllerBase
         }
 
         var items = _mapper.Map<List<ScheduledItemResponse>>(result.Items);
+        foreach (var item in items)
+        {
+            item.SourceItemDisplayName = await ResolveDisplayNameAsync(item.ItemType, item.ItemPrimaryKey);
+        }
         
         return new PagedResponse<ScheduledItemResponse>
         {
@@ -364,7 +382,7 @@ public class SchedulesController: ControllerBase
     }
 
     /// <summary>
-    /// Gets a list of orphaned scheduled items (items whose source no longer exists)
+    /// Gets a list of orphaned scheduled items(items whose source no longer exists)
     /// </summary>
     /// <param name="page">The page number (default: 1)</param>
     /// <param name="pageSize">The page size (default: 25)</param>
@@ -390,6 +408,10 @@ public class SchedulesController: ControllerBase
         }
 
         var items = _mapper.Map<List<ScheduledItemResponse>>(result.Items);
+        foreach (var item in items)
+        {
+            item.SourceItemDisplayName = await ResolveDisplayNameAsync(item.ItemType, item.ItemPrimaryKey);
+        }
         
         return new PagedResponse<ScheduledItemResponse>
         {
@@ -401,7 +423,7 @@ public class SchedulesController: ControllerBase
     }
 
     /// <summary>
-    /// Validates that a source item exists for the given type and primary key.
+    /// Validates that a source item existsfor the given type and primary key.
     /// Used by the Web project's AJAX validation.
     /// </summary>
     /// <param name="itemType">The type of item (Engagements, Talks, SyndicationFeedSources, YouTubeSources)</param>
@@ -515,5 +537,60 @@ public class SchedulesController: ControllerBase
             ItemTitle = source.Title,
             ItemDetails = source.Author
         });
+    }
+
+    // ── Display-name resolution ───────────────────────────────────────────────
+
+    private async Task<string?> ResolveDisplayNameAsync(ScheduledItemType itemType, int itemPrimaryKey)
+    {
+        try
+        {
+            return itemType switch
+            {
+                ScheduledItemType.Engagements => await ResolveEngagementNameAsync(itemPrimaryKey),
+                ScheduledItemType.Talks => await ResolveTalkNameAsync(itemPrimaryKey),
+                ScheduledItemType.SyndicationFeedSources => await ResolveSyndicationFeedSourceNameAsync(itemPrimaryKey),
+                ScheduledItemType.YouTubeSources => await ResolveYouTubeSourceNameAsync(itemPrimaryKey),
+                _ => null
+            };
+        }
+        catch
+        {
+            // Name resolution failure must never break the list response
+            return null;
+        }
+    }
+
+    private async Task<string?> ResolveEngagementNameAsync(int id)
+    {
+        var engagement = await _engagementManager.GetAsync(id);
+        return engagement?.Name;
+    }
+
+    private async Task<string?> ResolveTalkNameAsync(int talkId)
+    {
+        var talk = await _engagementManager.GetTalkAsync(talkId);
+        if (talk is null) return null;
+
+        if (talk.EngagementId > 0)
+        {
+            var engagement = await _engagementManager.GetAsync(talk.EngagementId);
+            if (engagement is not null)
+                return $"{engagement.Name} - {talk.Name}";
+        }
+
+        return talk.Name;
+    }
+
+    private async Task<string?> ResolveSyndicationFeedSourceNameAsync(int id)
+    {
+        var source = await _syndicationFeedSourceManager.GetAsync(id);
+        return source?.Title;
+    }
+
+    private async Task<string?> ResolveYouTubeSourceNameAsync(int id)
+    {
+        var source = await _youTubeSourceManager.GetAsync(id);
+        return source?.Title;
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/Dtos/ScheduledItemResponse.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Dtos/ScheduledItemResponse.cs
@@ -18,4 +18,5 @@ public class ScheduledItemResponse
     public DateTimeOffset SendOnDateTime { get; set; }
     public string? Platform { get; set; }
     public string? MessageType { get; set; }
+    public string? SourceItemDisplayName { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Api/MappingProfiles/ApiBroadcastingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/MappingProfiles/ApiBroadcastingProfile.cs
@@ -44,7 +44,8 @@ public class ApiBroadcastingProfile : Profile
         CreateMap<ScheduledItemRequest, ScheduledItem>()
             .ForMember(d => d.Id, o => o.Ignore())
             .ForMember(d => d.MessageSent, o => o.Ignore())
-            .ForMember(d => d.MessageSentOn, o => o.Ignore());
+            .ForMember(d => d.MessageSentOn, o => o.Ignore())
+            .ForMember(d => d.SourceItemDisplayName, o => o.Ignore());
 
         CreateMap<MessageTemplateRequest, MessageTemplate>()
             .ForMember(d => d.SocialMediaPlatformId, o => o.Ignore())

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/MappingProfiles/BroadcastingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/MappingProfiles/BroadcastingProfile.cs
@@ -13,7 +13,10 @@ public class BroadcastingProfile: Profile
         CreateMap<Models.ScheduledItem, Domain.Models.ScheduledItem>()
             .ForMember(
                 destination => destination.ItemType,
-                options => options.MapFrom(source => Enum.Parse<ScheduledItemType>(source.ItemTableName)));
+                options => options.MapFrom(source => Enum.Parse<ScheduledItemType>(source.ItemTableName)))
+            .ForMember(
+                destination => destination.SourceItemDisplayName,
+                options => options.Ignore());
         CreateMap<Models.FeedCheck, Domain.Models.FeedCheck>().ReverseMap();
         CreateMap<Models.MessageTemplate, Domain.Models.MessageTemplate>().ReverseMap();
         CreateMap<Models.TokenRefresh, Domain.Models.TokenRefresh>().ReverseMap();

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/ScheduledItem.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/ScheduledItem.cs
@@ -75,6 +75,11 @@ public class ScheduledItem
     /// </summary>
     public string? CreatedByEntraOid { get; set; }
 
+    /// <summary>
+    /// Resolved display name for the source item. Populated by the API on read; not persisted.
+    /// </summary>
+    public string? SourceItemDisplayName { get; set; }
+
     public Dictionary<string, string> ToDictionary()
     {
         return new Dictionary<string, string>

--- a/src/JosephGuadagno.Broadcasting.Web/Models/ScheduledItemViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/ScheduledItemViewModel.cs
@@ -84,6 +84,11 @@ public class ScheduledItemViewModel
     public string? MessageType { get; set; }
 
     /// <summary>
+    /// Resolved human-readable name for the source item (Engagement name, Talk name, feed title, etc.)
+    /// </summary>
+    public string? SourceItemDisplayName { get; set; }
+
+    /// <summary>
     /// Returns a Dictionary&lt;string, string&gt; representation of the properties
     /// </summary>
     /// <returns></returns>

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Schedules/Details.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Schedules/Details.cshtml
@@ -7,10 +7,12 @@
 <dl class="row">
     <dt class="col-sm-3">Id</dt>
     <dt class="col-sm-9">@Model.Id</dt>
-    <dt class="col-sm-3">Table</dt>
+    <dt class="col-sm-3">Type</dt>
     <dt class="col-sm-9">@Model.ItemTableName</dt>
     <dt class="col-sm-3">Primary Key</dt>
     <dt class="col-sm-9">@Model.ItemPrimaryKey</dt>
+    <dt class="col-sm-3">Source Item</dt>
+    <dt class="col-sm-9">@(Model.SourceItemDisplayName ?? "–")</dt>
     <dt class="col-sm-3">Scheduled on</dt>
     <dt class="col-sm-9"><local-time value="@Model.SendOnDateTime" /></dt>
     <dt class="col-sm-3">Message</dt>

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Schedules/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Schedules/Index.cshtml
@@ -17,8 +17,7 @@
     <table class="table table-striped">
         <thead class="thead-dark">
         <tr>
-            <th scope="col">Table Name</th>
-            <th scope="col">Key</th>
+            <th scope="col">Source Item</th>
             <th scope="col">Schedule Send DateTime</th>
             <th scope="col">Was Sent</th>
             <th scope="col">&nbsp;</th>
@@ -29,8 +28,7 @@
         {
             <tr>
 
-                <td>@scheduledItem.ItemTableName</td>
-                <td>@scheduledItem.ItemPrimaryKey</td>
+                <td>@(scheduledItem.SourceItemDisplayName ?? $"{scheduledItem.ItemTableName} #{scheduledItem.ItemPrimaryKey}")</td>
                 <td><local-time value="@scheduledItem.SendOnDateTime" /></td>
                 <td>@if (scheduledItem.MessageSent)
                     {


### PR DESCRIPTION
## Summary

Resolves **#809** and **#811**.

Both issues require the same server-side mechanism: resolving a human-readable display name for each scheduled item's source item and propagating it through the response pipeline.

## Changes

### Domain
- `Models/ScheduledItem.cs`: Added nullable `SourceItemDisplayName` property (non-persisted, resolved display value)

### API
- `Dtos/ScheduledItemResponse.cs`: Added `SourceItemDisplayName` to the response DTO
- `Controllers/SchedulesController.cs`: Added `ResolveDisplayNameAsync` dispatch helper + 4 type-specific private resolvers; populates `SourceItemDisplayName` on all GET endpoints (list and single-item). Resolution failures are caught and return null (never breaks the list response)
- `MappingProfiles/ApiBroadcastingProfile.cs`: Added explicit Ignore() for `SourceItemDisplayName` on the request-to-domain map

### Data.Sql
- `MappingProfiles/BroadcastingProfile.cs`: Added explicit Ignore() for `SourceItemDisplayName` on the SQL entity-to-domain map (no DB column)

### Web
- `Models/ScheduledItemViewModel.cs`: Added `SourceItemDisplayName` property
- `Views/Schedules/Index.cshtml` (#809): Merged 'Table Name' and 'Key' columns into a single **Source Item** column showing the resolved display name; fallback: "TypeName #KeyValue" for orphaned items
- `Views/Schedules/Details.cshtml` (#811): Relabelled 'Table' to 'Type'; added 'Source Item' row after 'Primary Key' with em-dash fallback for orphaned items

### Tests
- `Controllers/SchedulesControllerTests.cs`: 9 new unit tests covering all 4 item types, null-safety, engagement-missing fallback for talks, and graceful degradation when manager throws

## Test results
- Build: 0 errors
- Tests: 165 passed (23 in SchedulesControllerTests, including 9 new)

## AutoMapper note
Two `AssertConfigurationIsValid()` test suites (API mapping tests and Data.Sql mapping tests) caught that `SourceItemDisplayName` needed explicit Ignore() entries on two existing maps. Both were added and confirmed green.
