### PR TITLE
fix(#831): sanitize user-controlled strings in log calls

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/SocialMediaPlatformsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/SocialMediaPlatformsController.cs
@@ -110,7 +110,7 @@ public class SocialMediaPlatformsController : ControllerBase
             return BadRequest("Failed to create social media platform");
         }
 
-        _logger.LogInformation("Created social media platform with ID {Id}: {Name}", created.Id, created.Name);
+        _logger.LogInformation("Created social media platform with ID {Id}: {Name}", created.Id, LogSanitizer.Sanitize(created.Name));
         var response = _mapper.Map<SocialMediaPlatformResponse>(created);
         return CreatedAtAction(nameof(GetAsync), new { id = created.Id }, response);
     }
@@ -148,7 +148,7 @@ public class SocialMediaPlatformsController : ControllerBase
             return NotFound();
         }
 
-        _logger.LogInformation("Updated social media platform with ID {Id}: {Name}", id, updated.Name);
+        _logger.LogInformation("Updated social media platform with ID {Id}: {Name}", id, LogSanitizer.Sanitize(updated.Name));
         return Ok(_mapper.Map<SocialMediaPlatformResponse>(updated));
     }
 


### PR DESCRIPTION
Closes #831

## Summary
Applies LogSanitizer.Sanitize() to the remaining unsanitized user-controlled string arguments passed to logger calls.

The MessageTemplatesController fixes (Api + Web) were already applied in PR #833 (fix #830). This PR completes #831 by fixing the 2 remaining alerts in Api/Controllers/SocialMediaPlatformsController.cs:
- CreateAsync: created.Name -> LogSanitizer.Sanitize(created.Name)
- UpdateAsync: updated.Name -> LogSanitizer.Sanitize(updated.Name)

Both created.Name and updated.Name trace back through the manager/data layer to request.Name (user-controlled via [FromBody]), making them log-forging vectors per CodeQL data-flow analysis.

Uses the centralized JosephGuadagno.Broadcasting.Domain.Utilities.LogSanitizer -- no per-file helpers added. The using directive was already present in the file.

## Scan Results
Broader scan of all API and Web controller logger calls confirmed no other unsanitized user-controlled strings (all other logged values are integers, enum values, or hardcoded strings).

## Testing
All existing tests pass. No behavioral changes -- sanitization only affects log output.