### PR TITLE
feat(#777): replace shared LinkedIn Key Vault OAuth with per-user UserOAuthTokens table

### DIFF
--- a/.squad/agents/cypher/charter.md
+++ b/.squad/agents/cypher/charter.md
@@ -48,6 +48,14 @@ Before starting work, read `.squad/decisions.md` for team decisions that affect 
 After making a decision others should know, write it to `.squad/decisions/inbox/cypher-{brief-slug}.md`.
 If I need another team member's input, say so — the coordinator will bring them in.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 I don't write features. I make sure everything that gets written actually ships — reliably, repeatably, forever.

--- a/.squad/agents/ghost/charter.md
+++ b/.squad/agents/ghost/charter.md
@@ -60,6 +60,14 @@ Before starting work, run `git rev-parse --show-toplevel` to find the repo root,
 Before starting work, read `.squad/decisions.md` for team decisions that affect me.
 After making a decision others should know, write it to `.squad/decisions/inbox/ghost-{brief-slug}.md`.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 The surface you can't see is the one that gets you. Locks every door, checks every token, and never assumes trust.

--- a/.squad/agents/link/charter.md
+++ b/.squad/agents/link/charter.md
@@ -58,6 +58,14 @@ Before starting work, run `git rev-parse --show-toplevel` to find the repo root,
 Before starting work, read `.squad/decisions.md` for team decisions that affect me.
 After making a decision others should know, write it to `.squad/decisions/inbox/link-{brief-slug}.md`.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 Keeps the pipes running. If the infrastructure drifts, Link finds it before production does.

--- a/.squad/agents/morpheus/charter.md
+++ b/.squad/agents/morpheus/charter.md
@@ -31,6 +31,14 @@
 
 **If I review others' work:** On rejection, I may require a different agent to revise (not the original author) or request a new specialist be spawned. The Coordinator enforces this.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Model
 
 - **Preferred:** auto

--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -35,6 +35,14 @@
 
 **Directive violations are BLOCKING.** Any violation of an established team directive (canonical OIDs, required helpers, naming conventions, etc.) found during review must be marked as a blocking defect — not a minor observation, not deferred to a follow-up issue. The PR cannot be approved until the violation is corrected. Never use phrases like "minor observation" or "could be improved" for directive violations.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Model
 
 - **Preferred:** auto

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -434,6 +434,25 @@ Both `YouTubeSourcesController` and `SyndicationFeedSourcesController` are **com
 
 Joseph's brief says "no admin-bypass logic in Web layer — API handles it." However the existing `EngagementsController` does have Web-layer ownership redirects. Issue bodies (#818/#819) follow the existing defense-in-depth pattern to stay consistent with EngagementsController. If Joseph prefers the simpler pattern (no Web-layer check), Switch should remove the ownership redirect logic from Details and Delete actions. Flag for review before implementation.
 
+---
+
+## 2026-04-24 — PR #854 Review Checklist Gap (raised by Joseph)
+
+**Status:** ✅ Documented — follow-up comment posted
+
+### Missed Checks
+
+During the PR #854 review, two directive violations were not caught by Neo's initial pass. Joseph identified them post-review:
+
+1. **AutoMapper requirement not verified** — New `UserOAuthToken` classes used direct property mapping instead of AutoMapper profiles in `Data.Sql/MappingProfiles/`. Review checklist must explicitly verify that any new entity/domain pair has a corresponding `MappingProfile` registered.
+
+2. **XML documentation comments not verified** — All seven new public files lacked `/// <summary>` XML doc comments. Review checklist must include a scan of all new public types and members for XML doc coverage.
+
+### Checklist Additions (effective immediately)
+
+- [ ] For every new domain model + EF entity pair: confirm an AutoMapper profile exists in `Data.Sql/MappingProfiles/` and is registered.
+- [ ] For every new public type and public member: confirm `/// <summary>` (and `/// <param>`, `/// <returns>`, `/// <exception>` where applicable) XML doc comments are present.
+
 ### Learnings
 
 - **Source infrastructure completeness:** Data layer, managers, and domain models for YouTubeSource/SyndicationFeedSource are fully built. Only API surface and Web UI are missing.
@@ -581,3 +600,40 @@ LinkedIn OAuth requires the user to interactively visit the site and complete th
 - **Scope boundary:** The notification Function is a follow-up issue (consumer of #777 infrastructure), not part of #777. #777 delivers the token storage/retrieval substrate; the notification Function adds the proactive alerting UX on top. Merging both would over-scope an already broad issue.
 
 - **`IEmailSender` is queue-based:** `EmailSender.QueueEmail()` enqueues to `Constants.Queues.SendEmail` (Azure Storage Queue, Base64-encoded). The email delivery Function picks this up. This is the correct pattern for Functions-triggered email — do not call Azure Communication Services directly from within a timer Function.
+
+
+---
+
+## 2026-04-24 — PR #854 Review: Issue #777 Per-User OAuth Token Runtime
+
+**Status:** ❌ BLOCKED (2 blocking issues)
+**PR:** #854 | **Branch:** `issue-777-per-user-oauth-token-runtime` | **Author:** Trinity
+
+### Outcome
+
+PR blocked. All security and architecture checks passed. Two required artifacts are missing.
+
+### Blocking Issues Found
+
+1. **Missing cross-user isolation test** — `UserOAuthTokenDataStoreTests.cs` (required by arch spec §6) is absent. No test verifies `GetByUserAndPlatformAsync("user-a", 3)` returns null when only user-b has a token. `UserOAuthTokenManagerTests.cs` also absent. The isolation is structurally correct in code but unverified by tests.
+
+2. **No GitHub issue for Key Vault secret retirement** — PR description says "should be created" but doesn't reference an existing issue. Security baseline directive requires a `squad:Joe`-labeled issue with step-by-step instructions to exist before merge. Direct violation.
+
+### What Was Clean
+
+- All 4 Functions: `ILinkedInApplicationSettings` removed, `IUserOAuthTokenManager` injected, null token → `LogWarning` + `return null` (no fallback). All log calls use `LogSanitizer.Sanitize()` on OIDs.
+- `LinkedInController`: state validation preserved in `Callback()`, `LogSanitizer.Sanitize(ownerOid)` in the success log, no raw token in any logger call, `IKeyVault` fully removed.
+- `UserOAuthTokenDataStore`: all reads double-filter on `CreatedByEntraOid == ownerOid && SocialMediaPlatformId == platformId`.
+- Table schema, unique constraint, expiry index, and constant `SocialMediaPlatformIds.LinkedIn = 3` all match spec.
+- `GetExpiringAsync` present on interface (confirmed prep for #852).
+- `SavedTokenInfo` uses `MaskedAccessToken`/`HasToken`/`ExpiresOn` — no raw token in views.
+
+### FYI Item Noted
+
+`AuthorId` was removed from `linkedInPost` in all 4 Functions. If LinkedIn API v2 requires an explicit author URN in the post body, posts will fail at runtime. `UserPublisherSettings.Settings` contains `AuthorId` per user if needed.
+
+### Patterns to Remember
+
+- **Test suite completeness check:** When arch spec lists required new test files, verify ALL listed files are present in the diff. `UserOAuthTokenDataStoreTests.cs` and `UserOAuthTokenManagerTests.cs` were explicitly required but missing.
+- **Manual step pre-check:** Always scan PR description for "should be created" / "follow-up" language around production steps. These must be issues already created with `squad:Joe` label, not promised futures.
+- **Cross-user isolation test pattern:** For any new per-user data store, the minimum test is: seed token for user-B, query as user-A, assert null result.

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -503,3 +503,81 @@ Reviewed 3 PRs in parallel:
 ### Learnings
 
 Sprint 26 demonstrates efficient parallel review and merge when agents follow established conventions and pre-commit gates. All 3 issues closed cleanly with no rework.
+
+---
+
+## 2026-04-24 — Architecture: Issue #777 Per-User OAuth/Token Runtime
+
+**Status:** ✅ COMPLETE (Architecture Review)  
+**Artifact:** `.squad/decisions/inbox/neo-777-oauth-arch.md`
+
+### Findings
+
+**LinkedInController today (broken):**
+- Hard-coded Key Vault secret names: `jjg-net-linkedin-access-token` / `jjg-net-linkedin-refresh-token`
+- All users share one token; no user identity in OAuth flow
+- `IKeyVault` dependency must be removed entirely from this controller
+
+**UserPublisherSettings (Sprint 20, partial):**
+- Already stores per-user LinkedIn `AccessToken` in the `Settings` JSONB dict alongside `ClientId`, `AuthorId`, `ClientSecret`
+- Gap: no `RefreshToken`, no `AccessTokenExpiry`; OAuth callback still writes to Key Vault (not this table)
+- Two storage locations in conflict
+
+**Functions (broken):**
+- All four LinkedIn Functions use `ILinkedInApplicationSettings.AccessToken` — a singleton from app config
+- `ScheduledItems.CreatedByEntraOid` exists; the routing key is available but not used
+
+### Architecture Decision
+
+New `UserOAuthTokens` table (NOT an extension of `UserPublisherSettings.Settings`):
+- `UserPublisherSettings` = static config (ClientId, AuthorId, ClientSecret) — user-configured
+- `UserOAuthTokens` = live OAuth tokens (AccessToken, RefreshToken, expiry) — OAuth-issued, auto-managed
+- Expiry is a first-class column (`AccessTokenExpiresAt datetimeoffset`) with an index — required for future background refresh Functions
+
+### Key File Paths (Architecture Surface)
+
+- `src\JosephGuadagno.Broadcasting.Web\Controllers\LinkedInController.cs` — full refactor
+- `src\JosephGuadagno.Broadcasting.Domain\Interfaces\IUserOAuthTokenDataStore.cs` — new
+- `src\JosephGuadagno.Broadcasting.Domain\Interfaces\IUserOAuthTokenManager.cs` — new
+- `src\JosephGuadagno.Broadcasting.Domain\Models\UserOAuthToken.cs` — new
+- `src\JosephGuadagno.Broadcasting.Data.Sql\UserOAuthTokenDataStore.cs` — new
+- `src\JosephGuadagno.Broadcasting.Managers\UserOAuthTokenManager.cs` — new
+- `scripts\database\migrations\2026-04-24-user-oauth-tokens.sql` — new
+- `scripts\database\table-create.sql` — append DDL for fresh-env AppHost replay
+- Functions: `ProcessScheduledItemFired`, `ProcessNewSyndicationDataFired`, `ProcessNewYouTubeDataFired`, `ProcessNewRandomPost` — inject `IUserOAuthTokenManager`
+
+### Constants Note
+
+Add `SocialMediaPlatformIds.LinkedIn = 3` constant in `JosephGuadagno.Broadcasting.Domain.Constants` to avoid magic numbers in Functions.
+
+
+### Security Anchor
+
+- Token fallback to shared Key Vault on `null` per-user lookup is FORBIDDEN — would silently re-introduce the shared secret pattern
+- `AccessToken` / `RefreshToken` must never appear in log output
+- Manual production step issue (label `squad:Joe`) required to disable the two legacy Key Vault secrets after release
+
+---
+
+## 2026-04-24 — #777 Architecture Update: LinkedIn Manual Re-Auth Constraint & Notification Pattern
+
+**Status:** ✅ COMPLETE (Architecture Amendment)  
+**Artifact:** `.squad/decisions/inbox/neo-777-oauth-arch.md` (§11 updated, §13 added)
+
+### Joseph's Input
+
+LinkedIn OAuth requires the user to interactively visit the site and complete the authorization flow — there is no programmatic token refresh endpoint available for this app type. This is why a Web page exists for it today. Facebook's `RefreshTokens.cs` Azure Function (automated) is the correct pattern only for platforms that expose a programmatic refresh endpoint.
+
+### Learnings
+
+- **LinkedIn manual re-auth constraint:** LinkedIn OAuth tokens CANNOT be silently refreshed by a background Function. Any design that implies a background Function can call LinkedIn to renew a token is architecturally incorrect for this project. The only valid refresh mechanism is the user returning to the site and completing the OAuth consent flow through `LinkedInController`.
+
+- **Email notification pattern (LinkedIn + similar platforms):** For platforms requiring manual re-authorization, the correct automated pattern is: daily timer Function → query tokens expiring within N days (`GetExpiringWindowAsync`) → queue email via `IEmailSender` → user clicks link back to the site. `IEmailSender` already exists and is already registered in `Functions/Program.cs`.
+
+- **`GetExpiringAsync` signature amendment needed:** The current `GetExpiringAsync(DateTimeOffset threshold)` returns all tokens expiring *at or before* threshold — it conflates already-expired tokens with soon-to-expire ones. Notification use requires a window query (`from`, `to`) to target tokens expiring soon but not yet expired. Method should be `GetExpiringWindowAsync(DateTimeOffset from, DateTimeOffset to)`. This amendment belongs in the notification follow-up issue, not #777.
+
+- **Deduplication via `LastNotifiedAt`:** Add `LastNotifiedAt datetimeoffset null` to `UserOAuthTokens` to prevent duplicate email spam if the timer Function retries. Skip notification if `LastNotifiedAt` is already today (UTC). This column migration is part of the notification follow-up issue.
+
+- **Scope boundary:** The notification Function is a follow-up issue (consumer of #777 infrastructure), not part of #777. #777 delivers the token storage/retrieval substrate; the notification Function adds the proactive alerting UX on top. Merging both would over-scope an already broad issue.
+
+- **`IEmailSender` is queue-based:** `EmailSender.QueueEmail()` enqueues to `Constants.Queues.SendEmail` (Azure Storage Queue, Base64-encoded). The email delivery Function picks this up. This is the correct pattern for Functions-triggered email — do not call Azure Communication Services directly from within a timer Function.

--- a/.squad/agents/oracle/charter.md
+++ b/.squad/agents/oracle/charter.md
@@ -47,6 +47,14 @@ Before starting work, read `.squad/decisions.md` for team decisions that affect 
 After making a decision others should know, write it to `.squad/decisions/inbox/oracle-{brief-slug}.md`.
 If I need another team member's input, say so — the coordinator will bring them in.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 Every secret has a cost. I make sure we pay it once, in the right place, to the right party.

--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -45,6 +45,14 @@ Before starting work, read `.squad/decisions.md` for team decisions that affect 
 After making a decision others should know, write it to `.squad/decisions/inbox/ralph-{brief-slug}.md`.
 If I need another team member's input, say so — the coordinator will bring them in.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 Watches the board, keeps the queue honest, nudges when things stall.

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -69,6 +69,14 @@ gh pr comment 123 --body "Use `GET` endpoint"
 
 This applies to all `gh pr comment`, `gh issue comment`, and `gh api` calls that include Markdown.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 Silent observer. Keeps the record straight so the team never loses context.

--- a/.squad/agents/sparks/charter.md
+++ b/.squad/agents/sparks/charter.md
@@ -61,6 +61,14 @@ Before starting work, run `git rev-parse --show-toplevel` to find the repo root,
 Before starting work, read `.squad/decisions.md` for team decisions that affect me.
 After making a decision others should know, write it to `.squad/decisions/inbox/sparks-{brief-slug}.md`.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 If the user can see it, Sparks owns it. Clean views, tight forms, and a UI that doesn't make people think too hard.

--- a/.squad/agents/switch/charter.md
+++ b/.squad/agents/switch/charter.md
@@ -47,6 +47,14 @@ Before starting work, read `.squad/decisions.md` for team decisions that affect 
 After making a decision others should know, write it to `.squad/decisions/inbox/switch-{brief-slug}.md`.
 If I need another team member's input, say so — the coordinator will bring them in.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 If it renders in a browser, it's mine. Pixel-perfect Razor, clean JS, zero console errors.

--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -67,6 +67,14 @@ Before starting work, read `.squad/decisions.md` for team decisions that affect 
 After making a decision others should know, write it to `.squad/decisions/inbox/tank-{brief-slug}.md`.
 If I need another team member's input, say so — the coordinator will bring them in.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Voice
 
 Breaks things on purpose so users never break them by accident.

--- a/.squad/agents/trinity/charter.md
+++ b/.squad/agents/trinity/charter.md
@@ -31,6 +31,14 @@
 
 **If I review others' work:** On rejection, I may require a different agent to revise (not the original author) or request a new specialist be spawned. The Coordinator enforces this.
 
+## GitHub Issues & PR Comments
+
+When writing GitHub issue bodies, PR descriptions, or PR review comments:
+- Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
+- Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
+- Never use backslashes to escape or quote code references
+- Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+
 ## Model
 
 - **Preferred:** auto

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -2,6 +2,37 @@
 
 ## Learnings
 
+### 2026-05-XX — Issue #777: OAuth/Token Runtime Exploration (Pre-Implementation)
+**Status:** ✅ EXPLORATION COMPLETE — Findings filed to inbox
+
+**Key file paths discovered:**
+- `src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs` — OAuth2 flow; writes to shared Key Vault secrets (`jjg-net-linkedin-access-token`, `jjg-net-linkedin-refresh-token`)
+- `src/JosephGuadagno.Broadcasting.Data.KeyVault/Interfaces/IKeyVault.cs` — flat interface: `GetSecretAsync(name)` + `UpdateSecretValueAndPropertiesAsync(name, value, expiresOn)`; no per-user concept
+- `src/JosephGuadagno.Broadcasting.Data.KeyVault/KeyVault.cs` — implementation via Azure `SecretClient`
+- `src/JosephGuadagno.Broadcasting.Managers.LinkedIn/Models/ILinkedInApplicationSettings.cs` — shared singleton: `ClientId`, `ClientSecret`, `AccessToken`, `AuthorId`, `AccessTokenUrl`
+- `src/JosephGuadagno.Broadcasting.Functions/Program.cs` → `ConfigureLinkedInManager()` — binds `LinkedIn:*` config to singleton `ILinkedInApplicationSettings` at startup
+- `src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs` — stamps `post.AccessToken = linkedInApplicationSettings.AccessToken` (shared)
+- `src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessScheduledItemFired.cs` — same pattern; uses `ScheduledItem.CreatedByEntraOid` for content ownership (owner OID available for lookup)
+- `src/JosephGuadagno.Broadcasting.Data.Sql/UserPublisherSettingDataStore.cs` — already stores `AccessToken`, `AuthorId`, `ClientId`, `ClientSecret` as JSON keys in `Settings` NVARCHAR(MAX)
+- `src/JosephGuadagno.Broadcasting.Managers/UserPublisherSettingManager.cs` — `ProjectForResponse()` sanitizes tokens to `HasAccessToken` (bool); raw values accessible before projection
+- `scripts/database/table-create.sql` — `UserPublisherSettings` table has all needed columns; `ApplicationUsers` has NO OAuth fields
+
+**Current patterns:**
+- All 4 LinkedIn "process" functions (`ProcessNewSyndicationDataFired`, `ProcessNewYouTubeDataFired`, `ProcessScheduledItemFired`, `ProcessNewRandomPost`) use the singleton access token
+- No LinkedIn `RefreshTokens` Function exists (only Facebook has one)
+- Tokens are stored **plaintext** in `UserPublisherSettings.Settings` JSON — encryption at rest is a known gap
+
+**What needs to change:**
+1. `LinkedInController.Callback` → write tokens to `UserPublisherSettings` (per user OID) instead of/alongside flat Key Vault secrets
+2. Functions: replace singleton `AccessToken`/`AuthorId` lookup with per-user `IUserPublisherSettingDataStore.GetByUserAndPlatformAsync(ownerOid, platformId)` resolution
+3. New `ILinkedInTokenResolver` service for Functions to bridge OID → raw token
+4. New `LinkedIn/RefreshTokens.cs` Function for per-user token refresh
+5. Encryption at rest decision for sensitive fields in `Settings` JSON
+
+**Deliverable:** `.squad/decisions/inbox/trinity-777-exploration.md`
+
+---
+
 ### 2026-05-XX — Issue #831: Branch Cleanup (PR #849)
 **Status:** ✅ COMPLETE — Branch `issue-831-log-forging-fix` cleaned up
 

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -2,7 +2,34 @@
 
 ## Learnings
 
-### 2026-05-XX — Issue #777: OAuth/Token Runtime Exploration (Pre-Implementation)
+### 2026-04-24 — Issue #777: Per-User LinkedIn OAuth Token Storage (Implementation)
+**Status:** ✅ COMPLETE — PR #854 open, Key Vault retirement issue #855 created
+
+**What was built:**
+- New `UserOAuthTokens` SQL table with unique constraint on `(CreatedByEntraOid, SocialMediaPlatformId)`, FK to `SocialMediaPlatforms`, index on `AccessTokenExpiresAt`
+- Full vertical slice: Domain model → EF entity → DataStore → Manager
+- `LinkedInController` refactored: removed `IKeyVault`, added `IUserOAuthTokenManager` + `ISocialMediaPlatformManager`; token values never logged or exposed raw to views; CSRF state validation preserved
+- All 4 LinkedIn Functions refactored to resolve per-user OAuth token via `IUserOAuthTokenManager.GetByUserAndPlatformAsync(ownerOid, SocialMediaPlatformIds.LinkedIn)`; null token → log warning + return null (no silent fallback)
+- 166 Functions unit tests + 232 Web unit tests: all green
+
+**Key learnings:**
+1. **`edit` tool file-overwrite hazard**: When `old_str` matches only a portion of a file, the replacement is applied but the remaining old content stays appended. For whole-file rewrites, always use `Set-Content` via PowerShell.
+2. **No `ImplicitUsings` in Managers project**: Must add `using System;`, `using System.Threading;`, `using System.Threading.Tasks;` explicitly — unlike Domain (which does have implicit usings).
+3. **`Talk` model uses `Name` not `Title`, `UrlForTalk`/`UrlForConferenceTalk` not `Url`**: Check domain model properties before writing test data builders.
+4. **Functions register dependencies directly in `ConfigureFunction()`**: `AddSqlDataStores()` is Web-only; Functions must add `IUserOAuthTokenDataStore` and `IUserOAuthTokenManager` explicitly in `Program.cs`.
+5. **`AuthorId` intentionally dropped**: The old code set `linkedInPost.AuthorId = linkedInApplicationSettings.AuthorId` from the shared singleton. LinkedIn API derives AuthorId from the access token, so this is safe to drop. No explicit `AuthorId` is needed.
+
+**Files created:**
+- `scripts/database/migrations/2026-04-24-user-oauth-tokens.sql`
+- `src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs`
+- `src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs`
+- `src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs`
+- `src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs`
+- `src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs`
+- `src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs`
+- `src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs`
+
+
 **Status:** ✅ EXPLORATION COMPLETE — Findings filed to inbox
 
 **Key file paths discovered:**

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,15 @@
 
 Compiled record of team decisions, architecture choices, and resolutions.
 
+## Directives
+
+### 2026-04-24T17:45:29Z: User directive
+**By:** Joseph (via Copilot)
+**What:** GitHub issues and PR comments must use GitHub Flavored Markdown. Inline code and file paths use backticks (`), never backslashes. GitHub renders GFM — always use it.
+**Why:** User request — agents have repeatedly used backslash-escaped text instead of GFM backtick code spans in issue and PR comment bodies.
+
+---
+
 ## Current Sprint Wrap-Up (Sprint 20)
 
 **Date:** 2026-04-19  

--- a/scripts/database/migrations/2026-04-24-user-oauth-tokens.sql
+++ b/scripts/database/migrations/2026-04-24-user-oauth-tokens.sql
@@ -1,0 +1,33 @@
+use JJGNet
+go
+
+-- Per-user OAuth token storage for LinkedIn (and future social platforms).
+-- Access tokens are stored as nvarchar(max) — SQL Server TDE provides OS-level at-rest encryption.
+-- Follow-up: evaluate SQL Server Always Encrypted for AccessToken / RefreshToken columns if compliance requirements arise.
+create table dbo.UserOAuthTokens
+(
+    Id                    int identity
+        constraint PK_UserOAuthTokens
+            primary key clustered,
+    CreatedByEntraOid     nvarchar(36)   not null,
+    SocialMediaPlatformId int            not null
+        constraint FK_UserOAuthTokens_SocialMediaPlatforms
+            references dbo.SocialMediaPlatforms,
+    AccessToken           nvarchar(max)  not null,
+    RefreshToken          nvarchar(max)  null,
+    AccessTokenExpiresAt  datetimeoffset not null,
+    RefreshTokenExpiresAt datetimeoffset null,
+    CreatedOn             datetimeoffset not null
+        constraint DF_UserOAuthTokens_CreatedOn
+            default (getutcdate()),
+    LastUpdatedOn         datetimeoffset not null
+        constraint DF_UserOAuthTokens_LastUpdatedOn
+            default (getutcdate()),
+    constraint UQ_UserOAuthTokens_User_Platform
+        unique (CreatedByEntraOid, SocialMediaPlatformId)
+)
+go
+
+create nonclustered index IX_UserOAuthTokens_AccessTokenExpiresAt
+    on dbo.UserOAuthTokens (AccessTokenExpiresAt)
+go

--- a/scripts/database/table-create.sql
+++ b/scripts/database/table-create.sql
@@ -355,3 +355,35 @@ ALTER TABLE dbo.MessageTemplates
         REFERENCES dbo.SocialMediaPlatforms(Id)
 go
 
+
+
+-- Per-user OAuth tokens for LinkedIn (and future platforms). Added by issue #777.
+-- Access tokens are stored as nvarchar(max) — SQL Server TDE provides OS-level at-rest encryption.
+-- Follow-up: evaluate SQL Server Always Encrypted for AccessToken / RefreshToken columns if compliance requirements arise.
+create table dbo.UserOAuthTokens
+(
+    Id                    int identity
+        constraint PK_UserOAuthTokens
+            primary key clustered,
+    CreatedByEntraOid     nvarchar(36)   not null,
+    SocialMediaPlatformId int            not null
+        constraint FK_UserOAuthTokens_SocialMediaPlatforms
+            references dbo.SocialMediaPlatforms,
+    AccessToken           nvarchar(max)  not null,
+    RefreshToken          nvarchar(max)  null,
+    AccessTokenExpiresAt  datetimeoffset not null,
+    RefreshTokenExpiresAt datetimeoffset null,
+    CreatedOn             datetimeoffset not null
+        constraint DF_UserOAuthTokens_CreatedOn
+            default (getutcdate()),
+    LastUpdatedOn         datetimeoffset not null
+        constraint DF_UserOAuthTokens_LastUpdatedOn
+            default (getutcdate()),
+    constraint UQ_UserOAuthTokens_User_Platform
+        unique (CreatedByEntraOid, SocialMediaPlatformId)
+)
+go
+
+create nonclustered index IX_UserOAuthTokens_AccessTokenExpiresAt
+    on dbo.UserOAuthTokens (AccessTokenExpiresAt)
+go

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs
@@ -1,0 +1,182 @@
+using AutoMapper;
+using JosephGuadagno.Broadcasting.Data.Sql.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace JosephGuadagno.Broadcasting.Data.Sql.Tests;
+
+/// <summary>
+/// Tests for UserOAuthTokenDataStore
+/// </summary>
+public class UserOAuthTokenDataStoreTests : IDisposable
+{
+    private readonly BroadcastingContext _context;
+    private readonly Mock<ILogger<UserOAuthTokenDataStore>> _logger = new();
+    private readonly UserOAuthTokenDataStore _dataStore;
+
+    public UserOAuthTokenDataStoreTests()
+    {
+        var options = new DbContextOptionsBuilder<BroadcastingContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new BroadcastingContext(options);
+
+        var mapperConfiguration = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<MappingProfiles.UserOAuthTokenMappingProfile>();
+        }, new LoggerFactory());
+
+        _dataStore = new UserOAuthTokenDataStore(
+            _context,
+            mapperConfiguration.CreateMapper(),
+            _logger.Object);
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    private async Task<int> CreatePlatformAsync(string name = "LinkedIn")
+    {
+        var platform = new SocialMediaPlatform
+        {
+            Name = name,
+            Url = $"https://{name.ToLowerInvariant()}.com",
+            Icon = $"bi-{name.ToLowerInvariant()}",
+            IsActive = true
+        };
+
+        _context.SocialMediaPlatforms.Add(platform);
+        await _context.SaveChangesAsync();
+        return platform.Id;
+    }
+
+    private async Task CreateTokenAsync(string ownerOid, int platformId, string accessToken = "token123")
+    {
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = ownerOid,
+            SocialMediaPlatformId = platformId,
+            AccessToken = accessToken,
+            RefreshToken = "refresh123",
+            AccessTokenExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(60),
+            CreatedOn = DateTimeOffset.UtcNow,
+            LastUpdatedOn = DateTimeOffset.UtcNow
+        });
+
+        await _context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetByUserAndPlatformAsync_ReturnsOnlyMatchingUserToken()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        const string ownerA = "owner-a-oid";
+        const string ownerB = "owner-b-oid";
+
+        await CreateTokenAsync(ownerA, platformId, "token-a");
+        await CreateTokenAsync(ownerB, platformId, "token-b");
+
+        // Act
+        var resultA = await _dataStore.GetByUserAndPlatformAsync(ownerA, platformId);
+        var resultB = await _dataStore.GetByUserAndPlatformAsync(ownerB, platformId);
+
+        // Assert
+        Assert.NotNull(resultA);
+        Assert.Equal(ownerA, resultA.CreatedByEntraOid);
+        Assert.Equal("token-a", resultA.AccessToken);
+
+        Assert.NotNull(resultB);
+        Assert.Equal(ownerB, resultB.CreatedByEntraOid);
+        Assert.Equal("token-b", resultB.AccessToken);
+    }
+
+    [Fact]
+    public async Task GetByUserAndPlatformAsync_DoesNotReturnOtherUsersTokens()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        const string ownerA = "owner-a-oid";
+        const string ownerB = "owner-b-oid";
+
+        // Only create token for owner B
+        await CreateTokenAsync(ownerB, platformId, "token-b");
+
+        // Act - try to get token for owner A
+        var resultA = await _dataStore.GetByUserAndPlatformAsync(ownerA, platformId);
+
+        // Assert - should return null, not owner B's token
+        Assert.Null(resultA);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_CreatesTokenForDifferentUsersOnSamePlatform()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        const string ownerA = "owner-a-oid";
+        const string ownerB = "owner-b-oid";
+
+        var tokenA = new Domain.Models.UserOAuthToken
+        {
+            CreatedByEntraOid = ownerA,
+            SocialMediaPlatformId = platformId,
+            AccessToken = "token-a",
+            AccessTokenExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        var tokenB = new Domain.Models.UserOAuthToken
+        {
+            CreatedByEntraOid = ownerB,
+            SocialMediaPlatformId = platformId,
+            AccessToken = "token-b",
+            AccessTokenExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act
+        await _dataStore.UpsertAsync(tokenA);
+        await _dataStore.UpsertAsync(tokenB);
+
+        // Assert - both tokens should exist independently
+        var resultA = await _dataStore.GetByUserAndPlatformAsync(ownerA, platformId);
+        var resultB = await _dataStore.GetByUserAndPlatformAsync(ownerB, platformId);
+
+        Assert.NotNull(resultA);
+        Assert.Equal("token-a", resultA.AccessToken);
+
+        Assert.NotNull(resultB);
+        Assert.Equal("token-b", resultB.AccessToken);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_OnlyDeletesSpecifiedUserToken()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        const string ownerA = "owner-a-oid";
+        const string ownerB = "owner-b-oid";
+
+        await CreateTokenAsync(ownerA, platformId, "token-a");
+        await CreateTokenAsync(ownerB, platformId, "token-b");
+
+        // Act - delete owner A's token
+        var deleted = await _dataStore.DeleteAsync(ownerA, platformId);
+
+        // Assert
+        Assert.True(deleted);
+
+        var resultA = await _dataStore.GetByUserAndPlatformAsync(ownerA, platformId);
+        var resultB = await _dataStore.GetByUserAndPlatformAsync(ownerB, platformId);
+
+        Assert.Null(resultA); // Owner A's token should be deleted
+        Assert.NotNull(resultB); // Owner B's token should still exist
+        Assert.Equal("token-b", resultB.AccessToken);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
@@ -47,6 +47,7 @@ public partial class BroadcastingContext : DbContext
     public virtual DbSet<SocialMediaPlatform> SocialMediaPlatforms { get; set; } = null!;
     public virtual DbSet<EngagementSocialMediaPlatform> EngagementSocialMediaPlatforms { get; set; } = null!;
     public virtual DbSet<UserPublisherSetting> UserPublisherSettings { get; set; } = null!;
+    public DbSet<Models.UserOAuthToken> UserOAuthTokens => Set<Models.UserOAuthToken>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -537,9 +538,52 @@ public partial class BroadcastingContext : DbContext
                 .HasConstraintName("FK_UserPublisherSettings_SocialMediaPlatforms");
         });
 
-        modelBuilder.Entity<EngagementSocialMediaPlatform>(entity =>
+        modelBuilder.Entity<Models.UserOAuthToken>(entity =>
         {
-            entity.HasKey(e => new { e.EngagementId, e.SocialMediaPlatformId })
+            entity.HasKey(e => e.Id)
+                .HasName("PK_UserOAuthTokens")
+                .IsClustered();
+
+            entity.HasIndex(e => new { e.CreatedByEntraOid, e.SocialMediaPlatformId }, "UQ_UserOAuthTokens_User_Platform")
+                .IsUnique();
+
+            entity.HasIndex(e => e.AccessTokenExpiresAt, "IX_UserOAuthTokens_AccessTokenExpiresAt");
+
+            entity.Property(e => e.CreatedByEntraOid)
+                .HasMaxLength(36)
+                .IsRequired();
+
+            entity.Property(e => e.SocialMediaPlatformId)
+                .IsRequired();
+
+            entity.Property(e => e.AccessToken)
+                .IsRequired();
+
+            entity.Property(e => e.AccessTokenExpiresAt)
+                .IsRequired()
+                .HasColumnType("datetimeoffset");
+
+            entity.Property(e => e.RefreshTokenExpiresAt)
+                .HasColumnType("datetimeoffset");
+
+            entity.Property(e => e.CreatedOn)
+                .IsRequired()
+                .HasColumnType("datetimeoffset")
+                .HasDefaultValueSql("(getutcdate())");
+
+            entity.Property(e => e.LastUpdatedOn)
+                .IsRequired()
+                .HasColumnType("datetimeoffset")
+                .HasDefaultValueSql("(getutcdate())");
+
+            entity.HasOne(e => e.SocialMediaPlatform)
+                .WithMany()
+                .HasForeignKey(e => e.SocialMediaPlatformId)
+                .HasConstraintName("FK_UserOAuthTokens_SocialMediaPlatforms");
+        });
+
+        modelBuilder.Entity<EngagementSocialMediaPlatform>(entity =>
+        {entity.HasKey(e => new { e.EngagementId, e.SocialMediaPlatformId })
                 .HasName("PK_EngagementSocialMediaPlatforms");
 
             entity.HasIndex(e => e.SocialMediaPlatformId, "IX_EngagementSocialMediaPlatforms_SocialMediaPlatformId");

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/MappingProfiles/UserOAuthTokenMappingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/MappingProfiles/UserOAuthTokenMappingProfile.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+
+namespace JosephGuadagno.Broadcasting.Data.Sql.MappingProfiles;
+
+/// <summary>
+/// AutoMapper profile for UserOAuthToken entities
+/// </summary>
+public class UserOAuthTokenMappingProfile : Profile
+{
+    public UserOAuthTokenMappingProfile()
+    {
+        CreateMap<Models.UserOAuthToken, Domain.Models.UserOAuthToken>().ReverseMap()
+            .ForMember(
+                destination => destination.SocialMediaPlatform,
+                options => options.Ignore());
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs
@@ -1,15 +1,57 @@
 namespace JosephGuadagno.Broadcasting.Data.Sql.Models;
 
+/// <summary>
+/// EF Core entity representing an OAuth token for a user and social media platform
+/// </summary>
 public class UserOAuthToken
 {
+    /// <summary>
+    /// Gets or sets the unique identifier
+    /// </summary>
     public int Id { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the Entra Object ID of the user who owns this token
+    /// </summary>
     public string CreatedByEntraOid { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the social media platform ID
+    /// </summary>
     public int SocialMediaPlatformId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the navigation property to the social media platform
+    /// </summary>
     public SocialMediaPlatform? SocialMediaPlatform { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the OAuth access token
+    /// </summary>
     public string AccessToken { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the OAuth refresh token if provided by the platform
+    /// </summary>
     public string? RefreshToken { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when the access token expires
+    /// </summary>
     public DateTimeOffset AccessTokenExpiresAt { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when the refresh token expires if provided by the platform
+    /// </summary>
     public DateTimeOffset? RefreshTokenExpiresAt { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when this token was created
+    /// </summary>
     public DateTimeOffset CreatedOn { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when this token was last updated
+    /// </summary>
     public DateTimeOffset LastUpdatedOn { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs
@@ -1,0 +1,15 @@
+namespace JosephGuadagno.Broadcasting.Data.Sql.Models;
+
+public class UserOAuthToken
+{
+    public int Id { get; set; }
+    public string CreatedByEntraOid { get; set; } = string.Empty;
+    public int SocialMediaPlatformId { get; set; }
+    public SocialMediaPlatform? SocialMediaPlatform { get; set; }
+    public string AccessToken { get; set; } = string.Empty;
+    public string? RefreshToken { get; set; }
+    public DateTimeOffset AccessTokenExpiresAt { get; set; }
+    public DateTimeOffset? RefreshTokenExpiresAt { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+    public DateTimeOffset LastUpdatedOn { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/ServiceCollectionExtensions.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/ServiceCollectionExtensions.cs
@@ -38,5 +38,6 @@ public static class BroadcastingDataSqlServiceCollectionExtensions
     {
         config.AddProfile<BroadcastingProfile>();
         config.AddProfile<RbacProfile>();
+        config.AddProfile<UserOAuthTokenMappingProfile>();
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/ServiceCollectionExtensions.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class BroadcastingDataSqlServiceCollectionExtensions
         services.TryAddScoped<ISocialMediaPlatformDataStore, SocialMediaPlatformDataStore>();
         services.TryAddScoped<IEngagementSocialMediaPlatformDataStore, EngagementSocialMediaPlatformDataStore>();
         services.TryAddScoped<IUserPublisherSettingDataStore, UserPublisherSettingDataStore>();
+        services.TryAddScoped<IUserOAuthTokenDataStore, UserOAuthTokenDataStore>();
         services.TryAddScoped<IApplicationUserDataStore, ApplicationUserDataStore>();
         services.TryAddScoped<IRoleDataStore, RoleDataStore>();
         services.TryAddScoped<IUserApprovalLogDataStore, UserApprovalLogDataStore>();

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
@@ -1,0 +1,131 @@
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Data.Sql;
+
+public class UserOAuthTokenDataStore(
+    BroadcastingContext broadcastingContext,
+    ILogger<UserOAuthTokenDataStore> logger) : IUserOAuthTokenDataStore
+{
+    public async Task<UserOAuthToken?> GetByUserAndPlatformAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+
+        var entity = await broadcastingContext.UserOAuthTokens
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                t => t.CreatedByEntraOid == ownerOid && t.SocialMediaPlatformId == platformId,
+                cancellationToken);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<UserOAuthToken?> UpsertAsync(
+        UserOAuthToken token, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        ArgumentException.ThrowIfNullOrWhiteSpace(token.CreatedByEntraOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(token.SocialMediaPlatformId);
+
+        try
+        {
+            var existing = await broadcastingContext.UserOAuthTokens
+                .FirstOrDefaultAsync(
+                    t => t.CreatedByEntraOid == token.CreatedByEntraOid
+                         && t.SocialMediaPlatformId == token.SocialMediaPlatformId,
+                    cancellationToken);
+
+            if (existing is null)
+            {
+                existing = new Models.UserOAuthToken
+                {
+                    CreatedByEntraOid = token.CreatedByEntraOid,
+                    SocialMediaPlatformId = token.SocialMediaPlatformId,
+                    CreatedOn = DateTimeOffset.UtcNow
+                };
+                broadcastingContext.UserOAuthTokens.Add(existing);
+            }
+
+            existing.AccessToken = token.AccessToken;
+            existing.RefreshToken = token.RefreshToken;
+            existing.AccessTokenExpiresAt = token.AccessTokenExpiresAt;
+            existing.RefreshTokenExpiresAt = token.RefreshTokenExpiresAt;
+            existing.LastUpdatedOn = DateTimeOffset.UtcNow;
+
+            await broadcastingContext.SaveChangesAsync(cancellationToken);
+
+            return await GetByUserAndPlatformAsync(token.CreatedByEntraOid, token.SocialMediaPlatformId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to upsert OAuth token for owner {OwnerOid} and platform {PlatformId}",
+                LogSanitizer.Sanitize(token.CreatedByEntraOid),
+                token.SocialMediaPlatformId);
+            return null;
+        }
+    }
+
+    public async Task<bool> DeleteAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+
+        try
+        {
+            var existing = await broadcastingContext.UserOAuthTokens
+                .FirstOrDefaultAsync(
+                    t => t.CreatedByEntraOid == ownerOid && t.SocialMediaPlatformId == platformId,
+                    cancellationToken);
+
+            if (existing is null)
+            {
+                return false;
+            }
+
+            broadcastingContext.UserOAuthTokens.Remove(existing);
+            return await broadcastingContext.SaveChangesAsync(cancellationToken) > 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to delete OAuth token for owner {OwnerOid} and platform {PlatformId}",
+                LogSanitizer.Sanitize(ownerOid),
+                platformId);
+            return false;
+        }
+    }
+
+    public async Task<List<UserOAuthToken>> GetExpiringAsync(
+        DateTimeOffset threshold, CancellationToken cancellationToken = default)
+    {
+        var entities = await broadcastingContext.UserOAuthTokens
+            .AsNoTracking()
+            .Where(t => t.AccessTokenExpiresAt <= threshold)
+            .ToListAsync(cancellationToken);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    private static UserOAuthToken MapToDomain(Models.UserOAuthToken entity) =>
+        new()
+        {
+            Id = entity.Id,
+            CreatedByEntraOid = entity.CreatedByEntraOid,
+            SocialMediaPlatformId = entity.SocialMediaPlatformId,
+            AccessToken = entity.AccessToken,
+            RefreshToken = entity.RefreshToken,
+            AccessTokenExpiresAt = entity.AccessTokenExpiresAt,
+            RefreshTokenExpiresAt = entity.RefreshTokenExpiresAt,
+            CreatedOn = entity.CreatedOn,
+            LastUpdatedOn = entity.LastUpdatedOn
+        };
+}

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Utilities;
@@ -6,10 +7,15 @@ using Microsoft.Extensions.Logging;
 
 namespace JosephGuadagno.Broadcasting.Data.Sql;
 
+/// <summary>
+/// SQL data store for user OAuth tokens
+/// </summary>
 public class UserOAuthTokenDataStore(
     BroadcastingContext broadcastingContext,
+    IMapper mapper,
     ILogger<UserOAuthTokenDataStore> logger) : IUserOAuthTokenDataStore
 {
+    /// <inheritdoc />
     public async Task<UserOAuthToken?> GetByUserAndPlatformAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default)
     {
@@ -22,9 +28,10 @@ public class UserOAuthTokenDataStore(
                 t => t.CreatedByEntraOid == ownerOid && t.SocialMediaPlatformId == platformId,
                 cancellationToken);
 
-        return entity is null ? null : MapToDomain(entity);
+        return entity is null ? null : mapper.Map<UserOAuthToken>(entity);
     }
 
+    /// <inheritdoc />
     public async Task<UserOAuthToken?> UpsertAsync(
         UserOAuthToken token, CancellationToken cancellationToken = default)
     {
@@ -72,6 +79,7 @@ public class UserOAuthTokenDataStore(
         }
     }
 
+    /// <inheritdoc />
     public async Task<bool> DeleteAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default)
     {
@@ -104,6 +112,7 @@ public class UserOAuthTokenDataStore(
         }
     }
 
+    /// <inheritdoc />
     public async Task<List<UserOAuthToken>> GetExpiringAsync(
         DateTimeOffset threshold, CancellationToken cancellationToken = default)
     {
@@ -112,20 +121,6 @@ public class UserOAuthTokenDataStore(
             .Where(t => t.AccessTokenExpiresAt <= threshold)
             .ToListAsync(cancellationToken);
 
-        return entities.Select(MapToDomain).ToList();
+        return mapper.Map<List<UserOAuthToken>>(entities);
     }
-
-    private static UserOAuthToken MapToDomain(Models.UserOAuthToken entity) =>
-        new()
-        {
-            Id = entity.Id,
-            CreatedByEntraOid = entity.CreatedByEntraOid,
-            SocialMediaPlatformId = entity.SocialMediaPlatformId,
-            AccessToken = entity.AccessToken,
-            RefreshToken = entity.RefreshToken,
-            AccessTokenExpiresAt = entity.AccessTokenExpiresAt,
-            RefreshTokenExpiresAt = entity.RefreshTokenExpiresAt,
-            CreatedOn = entity.CreatedOn,
-            LastUpdatedOn = entity.LastUpdatedOn
-        };
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs
@@ -1,6 +1,12 @@
 namespace JosephGuadagno.Broadcasting.Domain.Constants;
 
+/// <summary>
+/// Constant IDs for social media platforms matching database seed values
+/// </summary>
 public static class SocialMediaPlatformIds
 {
+    /// <summary>
+    /// LinkedIn platform ID
+    /// </summary>
     public const int LinkedIn = 3;
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs
@@ -1,0 +1,6 @@
+namespace JosephGuadagno.Broadcasting.Domain.Constants;
+
+public static class SocialMediaPlatformIds
+{
+    public const int LinkedIn = 3;
+}

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs
@@ -2,14 +2,37 @@ using JosephGuadagno.Broadcasting.Domain.Models;
 
 namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 
+/// <summary>
+/// Data store for managing OAuth tokens for users and social media platforms
+/// </summary>
 public interface IUserOAuthTokenDataStore
 {
+    /// <summary>
+    /// Retrieves the OAuth token for a specific user and platform
+    /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The OAuth token if found, otherwise null</returns>
     Task<UserOAuthToken?> GetByUserAndPlatformAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Creates or updates an OAuth token for a user and platform
+    /// </summary>
+    /// <param name="token">The token to upsert</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The upserted token if successful, otherwise null</returns>
     Task<UserOAuthToken?> UpsertAsync(
         UserOAuthToken token, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Deletes an OAuth token for a specific user and platform
+    /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if deleted, false if not found or error occurred</returns>
     Task<bool> DeleteAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default);
 
@@ -17,6 +40,9 @@ public interface IUserOAuthTokenDataStore
     /// Returns all tokens whose AccessTokenExpiresAt is at or before <paramref name="threshold"/>.
     /// Used by background refresh Functions.
     /// </summary>
+    /// <param name="threshold">The expiry threshold date</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of tokens expiring at or before the threshold</returns>
     Task<List<UserOAuthToken>> GetExpiringAsync(
         DateTimeOffset threshold, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs
@@ -1,0 +1,22 @@
+using JosephGuadagno.Broadcasting.Domain.Models;
+
+namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
+
+public interface IUserOAuthTokenDataStore
+{
+    Task<UserOAuthToken?> GetByUserAndPlatformAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default);
+
+    Task<UserOAuthToken?> UpsertAsync(
+        UserOAuthToken token, CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all tokens whose AccessTokenExpiresAt is at or before <paramref name="threshold"/>.
+    /// Used by background refresh Functions.
+    /// </summary>
+    Task<List<UserOAuthToken>> GetExpiringAsync(
+        DateTimeOffset threshold, CancellationToken cancellationToken = default);
+}

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs
@@ -1,0 +1,24 @@
+using JosephGuadagno.Broadcasting.Domain.Models;
+
+namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
+
+public interface IUserOAuthTokenManager
+{
+    Task<UserOAuthToken?> GetByUserAndPlatformAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores (create or replace) the token issued by an OAuth callback.
+    /// </summary>
+    Task<UserOAuthToken?> StoreOAuthCallbackTokenAsync(
+        string ownerOid,
+        int platformId,
+        string accessToken,
+        string? refreshToken,
+        DateTimeOffset accessTokenExpiresAt,
+        DateTimeOffset? refreshTokenExpiresAt,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default);
+}

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs
@@ -2,14 +2,32 @@ using JosephGuadagno.Broadcasting.Domain.Models;
 
 namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 
+/// <summary>
+/// Manager for OAuth token operations
+/// </summary>
 public interface IUserOAuthTokenManager
 {
+    /// <summary>
+    /// Retrieves the OAuth token for a specific user and platform
+    /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The OAuth token if found, otherwise null</returns>
     Task<UserOAuthToken?> GetByUserAndPlatformAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stores (create or replace) the token issued by an OAuth callback.
     /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="accessToken">The OAuth access token</param>
+    /// <param name="refreshToken">The OAuth refresh token if provided</param>
+    /// <param name="accessTokenExpiresAt">When the access token expires</param>
+    /// <param name="refreshTokenExpiresAt">When the refresh token expires if provided</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The stored token if successful, otherwise null</returns>
     Task<UserOAuthToken?> StoreOAuthCallbackTokenAsync(
         string ownerOid,
         int platformId,
@@ -19,6 +37,13 @@ public interface IUserOAuthTokenManager
         DateTimeOffset? refreshTokenExpiresAt,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Deletes an OAuth token for a specific user and platform
+    /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if deleted, false if not found or error occurred</returns>
     Task<bool> DeleteAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs
@@ -1,14 +1,52 @@
 namespace JosephGuadagno.Broadcasting.Domain.Models;
 
+/// <summary>
+/// Represents an OAuth token for a specific user and social media platform
+/// </summary>
 public class UserOAuthToken
 {
+    /// <summary>
+    /// Gets or sets the unique identifier
+    /// </summary>
     public int Id { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the Entra Object ID of the user who owns this token
+    /// </summary>
     public string CreatedByEntraOid { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the social media platform ID
+    /// </summary>
     public int SocialMediaPlatformId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the OAuth access token
+    /// </summary>
     public string AccessToken { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the OAuth refresh token if provided by the platform
+    /// </summary>
     public string? RefreshToken { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when the access token expires
+    /// </summary>
     public DateTimeOffset AccessTokenExpiresAt { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when the refresh token expires if provided by the platform
+    /// </summary>
     public DateTimeOffset? RefreshTokenExpiresAt { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when this token was created
+    /// </summary>
     public DateTimeOffset CreatedOn { get; set; }
+    
+    /// <summary>
+    /// Gets or sets when this token was last updated
+    /// </summary>
     public DateTimeOffset LastUpdatedOn { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs
@@ -1,0 +1,14 @@
+namespace JosephGuadagno.Broadcasting.Domain.Models;
+
+public class UserOAuthToken
+{
+    public int Id { get; set; }
+    public string CreatedByEntraOid { get; set; } = string.Empty;
+    public int SocialMediaPlatformId { get; set; }
+    public string AccessToken { get; set; } = string.Empty;
+    public string? RefreshToken { get; set; }
+    public DateTimeOffset AccessTokenExpiresAt { get; set; }
+    public DateTimeOffset? RefreshTokenExpiresAt { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+    public DateTimeOffset LastUpdatedOn { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/ProcessScheduledItemFiredTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/ProcessScheduledItemFiredTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +8,6 @@ using JosephGuadagno.Broadcasting.Domain.Enums;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
-using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -28,7 +27,8 @@ public class ProcessScheduledItemFiredTests
         ItemType = ScheduledItemType.SyndicationFeedSources,
         ItemPrimaryKey = primaryKey,
         Message = "existing scheduled message",
-        SendOnDateTime = DateTimeOffset.UtcNow
+        SendOnDateTime = DateTimeOffset.UtcNow,
+        CreatedByEntraOid = "test-oid"
     };
 
     private static SyndicationFeedSource BuildFeedSource() => new()
@@ -42,7 +42,7 @@ public class ProcessScheduledItemFiredTests
         PublicationDate = DateTimeOffset.UtcNow,
         AddedOn = DateTimeOffset.UtcNow,
         LastUpdatedOn = DateTimeOffset.UtcNow,
-        CreatedByEntraOid = ""
+        CreatedByEntraOid = "test-oid"
     };
 
     private static Engagement BuildEngagement(int id = 42) => new()
@@ -59,38 +59,43 @@ public class ProcessScheduledItemFiredTests
     private static Talk BuildTalk(int id = 42, int engagementId = 99) => new()
     {
         Id = id,
+        EngagementId = engagementId,
         Name = "Building .NET Apps",
-        UrlForConferenceTalk = "https://conf.example.com/talks/dotnet",
+        UrlForConferenceTalk = "https://conf.example.com/sessions/dotnet",
         UrlForTalk = "https://josephguadagno.net/talks/dotnet",
-        StartDateTime = new DateTimeOffset(2026, 6, 2, 10, 0, 0, TimeSpan.Zero),
-        EndDateTime = new DateTimeOffset(2026, 6, 2, 11, 0, 0, TimeSpan.Zero),
-        TalkLocation = "Room A",
-        Comments = "Excellent session",
-        EngagementId = engagementId
+        Comments = "Great session",
+        StartDateTime = DateTimeOffset.UtcNow,
+        EndDateTime = DateTimeOffset.UtcNow.AddHours(1),
+        TalkLocation = "Room A"
     };
 
-    private static YouTubeSource BuildYouTubeSource(int id = 42) => new()
+    private static YouTubeSource BuildYouTubeSource() => new()
     {
-        Id = id,
-        VideoId = "abc123def",
-        Author = "Joseph Guadagno",
+        Id = 42,
         Title = "Building Better Apps with .NET",
         Url = "https://youtube.com/watch?v=abc123def",
-        ShortenedUrl = null,
-        Tags = [],
+        VideoId = "abc123def",
         PublicationDate = DateTimeOffset.UtcNow,
         AddedOn = DateTimeOffset.UtcNow,
         LastUpdatedOn = DateTimeOffset.UtcNow,
-        CreatedByEntraOid = ""
+        CreatedByEntraOid = "test-oid"
     };
 
-    private static Mock<ILinkedInApplicationSettings> BuildLinkedInSettings()
+    /// <summary>
+    /// Builds a per-user OAuth token mock that returns a valid token for any OID.
+    /// </summary>
+    private static Mock<IUserOAuthTokenManager> BuildUserOAuthTokenManager(string accessToken = "test-access-token")
     {
-        var mock = new Mock<ILinkedInApplicationSettings>();
-        mock.Setup(m => m.AuthorId).Returns("urn:li:person:test123");
-        mock.Setup(m => m.AccessToken).Returns("test-access-token");
-        mock.Setup(m => m.ClientId).Returns("client-id");
-        mock.Setup(m => m.ClientSecret).Returns("client-secret");
+        var mock = new Mock<IUserOAuthTokenManager>();
+        mock.Setup(m => m.GetByUserAndPlatformAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserOAuthToken
+            {
+                CreatedByEntraOid = "test-oid",
+                SocialMediaPlatformId = 3,
+                AccessToken = accessToken,
+                AccessTokenExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+            });
         return mock;
     }
 
@@ -99,7 +104,7 @@ public class ProcessScheduledItemFiredTests
         Mock<ISyndicationFeedSourceManager> feedSourceManager,
         Mock<IYouTubeSourceManager> youTubeSourceManager,
         Mock<IEngagementManager> engagementManager,
-        Mock<ILinkedInApplicationSettings> linkedInSettings,
+        Mock<IUserOAuthTokenManager> userOAuthTokenManager,
         Mock<IMessageTemplateDataStore> messageTemplateDataStore,
         Mock<ISocialMediaPlatformManager> socialMediaPlatformManager)
     {
@@ -108,7 +113,7 @@ public class ProcessScheduledItemFiredTests
             engagementManager.Object,
             feedSourceManager.Object,
             youTubeSourceManager.Object,
-            linkedInSettings.Object,
+            userOAuthTokenManager.Object,
             messageTemplateDataStore.Object,
             socialMediaPlatformManager.Object,
             NullLogger<Functions.LinkedIn.ProcessScheduledItemFired>.Instance);
@@ -149,7 +154,7 @@ public class ProcessScheduledItemFiredTests
             mockFeedSourceManager,
             new Mock<IYouTubeSourceManager>(),
             new Mock<IEngagementManager>(),
-            BuildLinkedInSettings(),
+            BuildUserOAuthTokenManager(),
             mockMessageTemplateDataStore,
             BuildPlatformManager());
 
@@ -182,7 +187,7 @@ public class ProcessScheduledItemFiredTests
             mockFeedSourceManager,
             new Mock<IYouTubeSourceManager>(),
             new Mock<IEngagementManager>(),
-            BuildLinkedInSettings(),
+            BuildUserOAuthTokenManager(),
             mockMessageTemplateDataStore,
             BuildPlatformManager());
 
@@ -223,7 +228,7 @@ public class ProcessScheduledItemFiredTests
             mockFeedSourceManager,
             new Mock<IYouTubeSourceManager>(),
             new Mock<IEngagementManager>(),
-            BuildLinkedInSettings(),
+            BuildUserOAuthTokenManager(),
             mockMessageTemplateDataStore,
             BuildPlatformManager());
 
@@ -264,7 +269,7 @@ public class ProcessScheduledItemFiredTests
             mockFeedSourceManager,
             new Mock<IYouTubeSourceManager>(),
             new Mock<IEngagementManager>(),
-            BuildLinkedInSettings(),
+            BuildUserOAuthTokenManager(),
             mockMessageTemplateDataStore,
             BuildPlatformManager());
 
@@ -277,7 +282,7 @@ public class ProcessScheduledItemFiredTests
     }
 
     [Fact]
-    public async Task RunAsync_AuthorIdAndAccessToken_AlwaysSetFromLinkedInSettings()
+    public async Task RunAsync_AccessToken_ComesFromPerUserOAuthToken()
     {
         // Arrange
         var scheduledItem = BuildScheduledItem();
@@ -297,17 +302,46 @@ public class ProcessScheduledItemFiredTests
             mockFeedSourceManager,
             new Mock<IYouTubeSourceManager>(),
             new Mock<IEngagementManager>(),
-            BuildLinkedInSettings(),
+            BuildUserOAuthTokenManager("per-user-token-value"),
             mockMessageTemplateDataStore,
             BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
 
-        // Assert — credentials always come from settings, not from the template
+        // Assert — AccessToken is sourced from per-user IUserOAuthTokenManager, not a shared singleton
         Assert.NotNull(result);
-        Assert.Equal("urn:li:person:test123", result.AuthorId);
-        Assert.Equal("test-access-token", result.AccessToken);
+        Assert.Equal("per-user-token-value", result.AccessToken);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenNoOAuthTokenFound_ReturnsNull()
+    {
+        // Arrange
+        var scheduledItem = BuildScheduledItem();
+
+        var mockScheduledItemManager = new Mock<IScheduledItemManager>();
+        mockScheduledItemManager.Setup(m => m.GetAsync(1)).ReturnsAsync(scheduledItem);
+
+        var mockTokenManager = new Mock<IUserOAuthTokenManager>();
+        mockTokenManager.Setup(m => m.GetByUserAndPlatformAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserOAuthToken?)null);
+
+        var sut = BuildSut(
+            mockScheduledItemManager,
+            new Mock<ISyndicationFeedSourceManager>(),
+            new Mock<IYouTubeSourceManager>(),
+            new Mock<IEngagementManager>(),
+            mockTokenManager,
+            new Mock<IMessageTemplateDataStore>(),
+            BuildPlatformManager());
+
+        // Act
+        var result = await sut.RunAsync(BuildEventGridEvent(1));
+
+        // Assert — no token → return null, skip post
+        Assert.Null(result);
     }
 
     // ── Per-type template selection: Engagements ─────────────────────────────
@@ -319,7 +353,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
-            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var engagement = BuildEngagement();
 
@@ -334,7 +369,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync((MessageTemplate?)null);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         await sut.RunAsync(BuildEventGridEvent(1));
@@ -352,7 +387,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
-            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "engagement message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var engagement = BuildEngagement();
         var messageTemplate = new MessageTemplate
@@ -373,7 +409,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync(messageTemplate);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
@@ -381,7 +417,6 @@ public class ProcessScheduledItemFiredTests
         // Assert — rendered via Scriban using engagement fields
         Assert.NotNull(result);
         Assert.Equal("Speaking at Tech Conference 2026 - https://conf.example.com", result!.Text);
-        Assert.Equal("urn:li:person:test123", result.AuthorId);
     }
 
     [Fact]
@@ -391,7 +426,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.Engagements, ItemPrimaryKey = 42,
-            Message = "engagement fallback message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "engagement fallback message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var engagement = BuildEngagement();
 
@@ -406,7 +442,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync((MessageTemplate?)null);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
@@ -425,7 +461,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
-            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var talk = BuildTalk();
 
@@ -440,7 +477,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync((MessageTemplate?)null);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         await sut.RunAsync(BuildEventGridEvent(1));
@@ -458,7 +495,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
-            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "talk message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var talk = BuildTalk();
         var messageTemplate = new MessageTemplate
@@ -479,7 +517,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync(messageTemplate);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
@@ -496,7 +534,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.Talks, ItemPrimaryKey = 42,
-            Message = "talk fallback message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "talk fallback message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var talk = BuildTalk();
 
@@ -511,7 +550,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync((MessageTemplate?)null);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            new Mock<IYouTubeSourceManager>(), mockEngagementManager, BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
@@ -530,7 +569,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
-            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var youTubeSource = BuildYouTubeSource();
 
@@ -545,7 +585,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync((MessageTemplate?)null);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         await sut.RunAsync(BuildEventGridEvent(1));
@@ -563,7 +603,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
-            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "youtube message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var youTubeSource = BuildYouTubeSource();
         var messageTemplate = new MessageTemplate
@@ -584,7 +625,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync(messageTemplate);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
@@ -601,7 +642,8 @@ public class ProcessScheduledItemFiredTests
         var scheduledItem = new Domain.Models.ScheduledItem
         {
             Id = 1, ItemType = ScheduledItemType.YouTubeSources, ItemPrimaryKey = 42,
-            Message = "youtube fallback message", SendOnDateTime = DateTimeOffset.UtcNow
+            Message = "youtube fallback message", SendOnDateTime = DateTimeOffset.UtcNow,
+            CreatedByEntraOid = "test-oid"
         };
         var youTubeSource = BuildYouTubeSource();
 
@@ -616,7 +658,7 @@ public class ProcessScheduledItemFiredTests
             .ReturnsAsync((MessageTemplate?)null);
 
         var sut = BuildSut(mockScheduledItemManager, new Mock<ISyndicationFeedSourceManager>(),
-            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildLinkedInSettings(), mockMessageTemplateDataStore, BuildPlatformManager());
+            mockYouTubeSourceManager, new Mock<IEngagementManager>(), BuildUserOAuthTokenManager(), mockMessageTemplateDataStore, BuildPlatformManager());
 
         // Act
         var result = await sut.RunAsync(BuildEventGridEvent(1));
@@ -626,4 +668,3 @@ public class ProcessScheduledItemFiredTests
         Assert.Equal("youtube fallback message", result!.Text);
     }
 }
-

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewRandomPost.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewRandomPost.cs
@@ -7,6 +7,7 @@ using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -15,7 +16,7 @@ namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 
 public class ProcessNewRandomPost(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
-    ILinkedInApplicationSettings linkedInApplicationSettings,
+    IUserOAuthTokenManager userOAuthTokenManager,
     ILogger<ProcessNewRandomPost> logger)
 {
     [Function(ConfigurationFunctionNames.LinkedInProcessRandomPostFired)]
@@ -26,7 +27,6 @@ public class ProcessNewRandomPost(
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInProcessRandomPostFired, startedAt);
 
-        // Check to make sure the eventGridEvent.Data is not null
         if (eventGridEvent.Data is null)
         {
             logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
@@ -44,18 +44,29 @@ public class ProcessNewRandomPost(
             }
             var syndicationFeedSource = await syndicationFeedSourceManager.GetAsync(source.Id);
 
-            // Handle the event - compose the LinkedIn post
+            // Resolve per-user OAuth token — no silent fallback to shared token
+            var token = await userOAuthTokenManager.GetByUserAndPlatformAsync(
+                syndicationFeedSource.CreatedByEntraOid,
+                SocialMediaPlatformIds.LinkedIn);
+
+            if (token is null)
+            {
+                logger.LogWarning(
+                    "No OAuth token found for owner {OwnerOid} on LinkedIn — skipping random post {ItemId}",
+                    LogSanitizer.Sanitize(syndicationFeedSource.CreatedByEntraOid),
+                    syndicationFeedSource.Id);
+                return null;
+            }
+
             var statusText = "ICYMI: ";
             var post = new LinkedInPostLink
             {
                 Text = $"{statusText} {syndicationFeedSource.Title} {HashTagLists.BuildHashTagList(syndicationFeedSource.Tags)}",
                 Title = syndicationFeedSource.Title,
                 LinkUrl = syndicationFeedSource.Url,
-                AuthorId = linkedInApplicationSettings.AuthorId,
-                AccessToken = linkedInApplicationSettings.AccessToken
+                AccessToken = token.AccessToken
             };
 
-            // Return
             var properties = new Dictionary<string, string>
             {
                 {"title", syndicationFeedSource.Title},

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSyndicationDataFired.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
 using JosephGuadagno.Broadcasting.Domain;
@@ -7,6 +7,7 @@ using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -15,14 +16,9 @@ namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 
 public class ProcessNewSyndicationDataFired(
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
-    ILinkedInApplicationSettings linkedInApplicationSettings,
+    IUserOAuthTokenManager userOAuthTokenManager,
     ILogger<ProcessNewSyndicationDataFired> logger)
 {
-    // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
-    // Sample Code: https://github.com/Azure-Samples/event-grid-dotnet-publish-consume-events
-    // When debugging locally start ngrok
-    // Create a new EventGrid endpoint in Azure similar to
-    // `https://9ccb49e057a0.ngrok.io/runtime/webhooks/EventGrid?functionName=facebook_process_new_source_data`
     [Function(ConfigurationFunctionNames.LinkedInProcessNewSyndicationDataFired)]
     [QueueOutput(Queues.LinkedInPostLink)]
     public async Task<LinkedInPostLink?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
@@ -30,8 +26,7 @@ public class ProcessNewSyndicationDataFired(
         var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInProcessNewSyndicationDataFired, startedAt);
-        
-        // Get the Source Data identifier for the event
+
         if (eventGridEvent.Data is null)
         {
             logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
@@ -47,12 +42,24 @@ public class ProcessNewSyndicationDataFired(
         }
         var syndicationFeedSource = await syndicationFeedSourceManager.GetAsync(syndicationFeedItemEvent.Id);
 
-        // Create the Facebook posts for it
         logger.LogDebug("Processing New Syndication Feed Data Fired for '{Id}' with title of '{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
 
-        var status = ComposeStatus(syndicationFeedSource);
-        
-        // Done
+        // Resolve per-user OAuth token — no silent fallback to shared token
+        var token = await userOAuthTokenManager.GetByUserAndPlatformAsync(
+            syndicationFeedSource.CreatedByEntraOid,
+            SocialMediaPlatformIds.LinkedIn);
+
+        if (token is null)
+        {
+            logger.LogWarning(
+                "No OAuth token found for owner {OwnerOid} on LinkedIn — skipping syndication item {ItemId}",
+                LogSanitizer.Sanitize(syndicationFeedSource.CreatedByEntraOid),
+                syndicationFeedSource.Id);
+            return null;
+        }
+
+        var status = ComposeStatus(syndicationFeedSource, token.AccessToken);
+
         var properties = new Dictionary<string, string>
         {
             {"post", status.Text},
@@ -64,25 +71,24 @@ public class ProcessNewSyndicationDataFired(
         logger.LogDebug("Done composing LinkedIn status for '{Id}' with title of '{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
         return status;
     }
-    
-    private LinkedInPostLink ComposeStatus(SyndicationFeedSource syndicationFeedSource)
+
+    private LinkedInPostLink ComposeStatus(SyndicationFeedSource syndicationFeedSource, string accessToken)
     {
         logger.LogDebug("Composing LinkedIn post for Id: '{Id}', Title:'{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
         var statusText = syndicationFeedSource.LastUpdatedOn > syndicationFeedSource.PublicationDate
                 ? "Updated Blog Post: "
                 : "New Blog Post: ";
-        
+
         var post = new LinkedInPostLink
         {
             Text = $"{statusText} {syndicationFeedSource.Title} {HashTagLists.BuildHashTagList(syndicationFeedSource.Tags)}",
             Title = syndicationFeedSource.Title,
             LinkUrl = syndicationFeedSource.Url,
-            AuthorId = linkedInApplicationSettings.AuthorId,
-            AccessToken = linkedInApplicationSettings.AccessToken
+            AccessToken = accessToken
         };
 
         logger.LogDebug("Composed LinkedIn status for '{Id}' with title of '{Title}'", syndicationFeedSource.Id, syndicationFeedSource.Title);
-        
+
         return post;
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewYouTubeDataFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewYouTubeDataFired.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Azure.Messaging.EventGrid;
 
 using JosephGuadagno.Broadcasting.Domain;
@@ -7,6 +7,7 @@ using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -15,14 +16,9 @@ namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
 
 public class ProcessNewYouTubeDataFired(
     IYouTubeSourceManager youtubeSourceManager,
-    ILinkedInApplicationSettings linkedInApplicationSettings,
+    IUserOAuthTokenManager userOAuthTokenManager,
     ILogger<ProcessNewYouTubeDataFired> logger)
 {
-    // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
-    // Sample Code: https://github.com/Azure-Samples/event-grid-dotnet-publish-consume-events
-    // When debugging locally start ngrok
-    // Create a new EventGrid endpoint in Azure similar to
-    // `https://9ccb49e057a0.ngrok.io/runtime/webhooks/EventGrid?functionName=facebook_process_new_source_data`
     [Function(ConfigurationFunctionNames.LinkedInProcessNewYouTubeDataFired)]
     [QueueOutput(Queues.LinkedInPostLink)]
     public async Task<LinkedInPostLink?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
@@ -30,8 +26,7 @@ public class ProcessNewYouTubeDataFired(
         var startedAt = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInProcessNewYouTubeDataFired, startedAt);
-        
-        // Get the Source Data identifier for the event
+
         if (eventGridEvent.Data is null)
         {
             logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
@@ -47,12 +42,24 @@ public class ProcessNewYouTubeDataFired(
         }
         var youTubeSource = await youtubeSourceManager.GetAsync(newYouTubeItemEvent.Id);
 
-        // Create the Facebook posts for it
         logger.LogDebug("Processing New YouTube Feed Data Fired for '{Id}' with title of '{Title}'", youTubeSource.Id, youTubeSource.Title);
-            
-        var status = ComposeStatus(youTubeSource);
-        
-        // Done
+
+        // Resolve per-user OAuth token — no silent fallback to shared token
+        var token = await userOAuthTokenManager.GetByUserAndPlatformAsync(
+            youTubeSource.CreatedByEntraOid,
+            SocialMediaPlatformIds.LinkedIn);
+
+        if (token is null)
+        {
+            logger.LogWarning(
+                "No OAuth token found for owner {OwnerOid} on LinkedIn — skipping YouTube item {ItemId}",
+                LogSanitizer.Sanitize(youTubeSource.CreatedByEntraOid),
+                youTubeSource.Id);
+            return null;
+        }
+
+        var status = ComposeStatus(youTubeSource, token.AccessToken);
+
         var properties = new Dictionary<string, string>
         {
             {"post", status.Text},
@@ -64,25 +71,24 @@ public class ProcessNewYouTubeDataFired(
         logger.LogDebug("Done composing LinkedIn status for '{Id}' with title of '{Title}'", youTubeSource.Id, youTubeSource.Title);
         return status;
     }
-    
-    private LinkedInPostLink ComposeStatus(YouTubeSource youTubeSource)
+
+    private LinkedInPostLink ComposeStatus(YouTubeSource youTubeSource, string accessToken)
     {
         logger.LogDebug("Composing LinkedIn post for Id: '{Id}', Title:'{Title}'", youTubeSource.Id, youTubeSource.Title);
         var statusText = youTubeSource.LastUpdatedOn > youTubeSource.PublicationDate
                 ? "Updated Blog Post: "
                 : "New Blog Post: ";
-        
+
         var post = new LinkedInPostLink
         {
             Text = $"{statusText} {youTubeSource.Title} {HashTagLists.BuildHashTagList(youTubeSource.Tags)}",
             Title = youTubeSource.Title,
             LinkUrl = youTubeSource.Url,
-            AuthorId = linkedInApplicationSettings.AuthorId,
-            AccessToken = linkedInApplicationSettings.AccessToken
+            AccessToken = accessToken
         };
-        
+
         logger.LogDebug("Composed LinkedIn status for '{Id}' with title of '{Title}'", youTubeSource.Id, youTubeSource.Title);
-        
+
         return post;
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessScheduledItemFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessScheduledItemFired.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Azure.Messaging.EventGrid;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Constants;
@@ -7,6 +7,7 @@ using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Models.Events;
 using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -20,17 +21,11 @@ public class ProcessScheduledItemFired(
     IEngagementManager engagementManager,
     ISyndicationFeedSourceManager syndicationFeedSourceManager,
     IYouTubeSourceManager youTubeSourceManager,
-    ILinkedInApplicationSettings linkedInApplicationSettings,
+    IUserOAuthTokenManager userOAuthTokenManager,
     IMessageTemplateDataStore messageTemplateDataStore,
     ISocialMediaPlatformManager socialMediaPlatformManager,
     ILogger<ProcessScheduledItemFired> logger)
 {
-
-    // Debug Locally: https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
-    // Sample Code: https://github.com/Azure-Samples/event-grid-dotnet-publish-consume-events
-    // When debugging locally start ngrok
-    // Create a new EventGrid endpoint in Azure similar to
-    // `https://9ccb49e057a0.ngrok.io/runtime/webhooks/EventGrid?functionName=linkedin_process_scheduled_item_fired`
     [Function(ConfigurationFunctionNames.LinkedInProcessScheduledItemFired)]
     [QueueOutput(Queues.LinkedInPostLink)]
     public async Task<LinkedInPostLink?> RunAsync(
@@ -39,7 +34,7 @@ public class ProcessScheduledItemFired(
         var startedOn = DateTimeOffset.Now;
         logger.LogDebug("Started {FunctionName} at {StartedOn:f}",
             ConfigurationFunctionNames.LinkedInProcessScheduledItemFired, startedOn);
-        
+
         if (eventGridEvent.Data is null)
         {
             logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
@@ -60,9 +55,22 @@ public class ProcessScheduledItemFired(
             logger.LogDebug("Processing the event '{Id}' for '{TableName}', '{PartitionKey}'",
                 eventGridEvent.Id, scheduledItem.ItemTableName, scheduledItem.ItemPrimaryKey);
 
+            // Resolve per-user OAuth token — no silent fallback to shared token
+            var token = await userOAuthTokenManager.GetByUserAndPlatformAsync(
+                scheduledItem.CreatedByEntraOid ?? string.Empty,
+                SocialMediaPlatformIds.LinkedIn);
+
+            if (token is null)
+            {
+                logger.LogWarning(
+                    "No OAuth token found for owner {OwnerOid} on LinkedIn — skipping item {ItemId}",
+                    LogSanitizer.Sanitize(scheduledItem.CreatedByEntraOid ?? string.Empty),
+                    scheduledItem.Id);
+                return null;
+            }
+
             // Determine what type the post is for
             LinkedInPostLink linkedInPost;
-            // The scheduled post should always have a message.  We just need to craft the Title and Urls
 
             switch (scheduledItem.ItemType)
             {
@@ -83,7 +91,7 @@ public class ProcessScheduledItemFired(
                     return null;
             }
 
-            // Attempt Scriban template rendering for the post text; fall back to scheduledItem.Message if unavailable
+            // Attempt Scriban template rendering; fall back to scheduledItem.Message if unavailable
             var messageType = scheduledItem.ItemType switch
             {
                 ScheduledItemType.Engagements => MessageTemplates.MessageTypes.NewSpeakingEngagement,
@@ -91,18 +99,17 @@ public class ProcessScheduledItemFired(
                 ScheduledItemType.SyndicationFeedSources => MessageTemplates.MessageTypes.NewSyndicationFeedItem,
                 ScheduledItemType.YouTubeSources => MessageTemplates.MessageTypes.NewYouTubeItem,
                 _ => MessageTemplates.MessageTypes.RandomPost
-            };            
+            };
             var linkedInPlatform = await socialMediaPlatformManager.GetByNameAsync(MessageTemplates.Platforms.LinkedIn);
-            var messageTemplate = linkedInPlatform != null 
-                ? await messageTemplateDataStore.GetAsync(linkedInPlatform.Id, messageType) 
+            var messageTemplate = linkedInPlatform != null
+                ? await messageTemplateDataStore.GetAsync(linkedInPlatform.Id, messageType)
                 : null;
             string? renderedText = null;
             if (!string.IsNullOrWhiteSpace(messageTemplate?.Template))
                 renderedText = await TryRenderTemplateAsync(scheduledItem, messageTemplate.Template);
 
             linkedInPost.Text = renderedText ?? scheduledItem.Message;
-            linkedInPost.AuthorId = linkedInApplicationSettings.AuthorId;
-            linkedInPost.AccessToken = linkedInApplicationSettings.AccessToken;
+            linkedInPost.AccessToken = token.AccessToken;
             linkedInPost.ImageUrl = scheduledItem.ImageUrl;
 
             var properties = new Dictionary<string, string>
@@ -134,12 +141,10 @@ public class ProcessScheduledItemFired(
     private async Task<LinkedInPostLink> GetPostForEngagement(int primaryKey)
     {
         var post = new LinkedInPostLink();
-
         logger.LogDebug("Getting the text for engagement for '{PrimaryKey}'", primaryKey);
         try
         {
             var engagement = await engagementManager.GetAsync(primaryKey);
-            // Generate the title and Url for the LinkedIn post
             post.Title = engagement.Name;
             post.LinkUrl = engagement.Url;
         }
@@ -154,34 +159,28 @@ public class ProcessScheduledItemFired(
     private async Task<LinkedInPostLink> GetPostForTalk(int primaryKey)
     {
         var post = new LinkedInPostLink();
-
         logger.LogDebug("Getting the text for Talk for '{PrimaryKey}'", primaryKey);
         try
         {
             var engagement = await engagementManager.GetTalkAsync(primaryKey);
-            // Generate the title and Url for the LinkedIn post
             post.Title = engagement.Name;
             post.LinkUrl = engagement.UrlForConferenceTalk;
-
         }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to get the text for talk for '{PrimaryKey}'", primaryKey);
             throw;
         }
-
         return post;
     }
 
     private async Task<LinkedInPostLink> GetPostForSyndicationSource(int primaryKey)
     {
         var post = new LinkedInPostLink();
-
         logger.LogDebug("Getting the text for syndication source for '{PrimaryKey}'", primaryKey);
         try
         {
             var syndicationFeedSource = await syndicationFeedSourceManager.GetAsync(primaryKey);
-            // Generate the title and Url for the LinkedIn post
             post.Title = syndicationFeedSource.Title;
             post.LinkUrl = syndicationFeedSource.ShortenedUrl ?? syndicationFeedSource.Url;
         }
@@ -190,29 +189,24 @@ public class ProcessScheduledItemFired(
             logger.LogError(e, "Failed to get the text for engagement for '{PrimaryKey}'", primaryKey);
             throw;
         }
-
         return post;
     }
 
     private async Task<LinkedInPostLink> GetPostForYouTubeSource(int primaryKey)
     {
         var post = new LinkedInPostLink();
-
         logger.LogDebug("Getting the text for YouTube source for '{PrimaryKey}'", primaryKey);
         try
         {
             var youTubeSource = await youTubeSourceManager.GetAsync(primaryKey);
-            // Generate the title and Url for the LinkedIn post
             post.Title = youTubeSource.Title;
             post.LinkUrl = youTubeSource.ShortenedUrl ?? youTubeSource.Url;
-
         }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to get the text for engagement for '{PrimaryKey}'", primaryKey);
             throw;
         }
-
         return post;
     }
 

--- a/src/JosephGuadagno.Broadcasting.Functions/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Program.cs
@@ -211,6 +211,8 @@ void ConfigureFunction(IServiceCollection services)
     services.TryAddScoped<ISocialMediaPlatformManager, SocialMediaPlatformManager>();
     services.TryAddScoped<IUserPublisherSettingDataStore, UserPublisherSettingDataStore>();
     services.TryAddScoped<IUserPublisherSettingManager, UserPublisherSettingManager>();
+    services.TryAddScoped<IUserOAuthTokenDataStore, UserOAuthTokenDataStore>();
+    services.TryAddScoped<IUserOAuthTokenManager, UserOAuthTokenManager>();
 
     // RBAC Phase 1
     services.TryAddScoped<IApplicationUserDataStore, ApplicationUserDataStore>();

--- a/src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+
+namespace JosephGuadagno.Broadcasting.Managers;
+
+public class UserOAuthTokenManager(IUserOAuthTokenDataStore dataStore) : IUserOAuthTokenManager
+{
+    public Task<UserOAuthToken?> GetByUserAndPlatformAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+
+        return dataStore.GetByUserAndPlatformAsync(ownerOid, platformId, cancellationToken);
+    }
+
+    public Task<UserOAuthToken?> StoreOAuthCallbackTokenAsync(
+        string ownerOid,
+        int platformId,
+        string accessToken,
+        string? refreshToken,
+        DateTimeOffset accessTokenExpiresAt,
+        DateTimeOffset? refreshTokenExpiresAt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+
+        return dataStore.UpsertAsync(
+            new UserOAuthToken
+            {
+                CreatedByEntraOid = ownerOid,
+                SocialMediaPlatformId = platformId,
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
+                AccessTokenExpiresAt = accessTokenExpiresAt,
+                RefreshTokenExpiresAt = refreshTokenExpiresAt
+            },
+            cancellationToken);
+    }
+
+    public Task<bool> DeleteAsync(
+        string ownerOid, int platformId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+
+        return dataStore.DeleteAsync(ownerOid, platformId, cancellationToken);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs
@@ -6,8 +6,12 @@ using JosephGuadagno.Broadcasting.Domain.Models;
 
 namespace JosephGuadagno.Broadcasting.Managers;
 
+/// <summary>
+/// Manager for user OAuth token operations
+/// </summary>
 public class UserOAuthTokenManager(IUserOAuthTokenDataStore dataStore) : IUserOAuthTokenManager
 {
+    /// <inheritdoc />
     public Task<UserOAuthToken?> GetByUserAndPlatformAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default)
     {
@@ -17,6 +21,7 @@ public class UserOAuthTokenManager(IUserOAuthTokenDataStore dataStore) : IUserOA
         return dataStore.GetByUserAndPlatformAsync(ownerOid, platformId, cancellationToken);
     }
 
+    /// <inheritdoc />
     public Task<UserOAuthToken?> StoreOAuthCallbackTokenAsync(
         string ownerOid,
         int platformId,
@@ -43,6 +48,7 @@ public class UserOAuthTokenManager(IUserOAuthTokenDataStore dataStore) : IUserOA
             cancellationToken);
     }
 
+    /// <inheritdoc />
     public Task<bool> DeleteAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default)
     {

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/LinkedInControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/LinkedInControllerTests.cs
@@ -2,10 +2,9 @@ using Moq;
 using Moq.Protected;
 
 using System.Net;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
-
-using Azure.Security.KeyVault.Secrets;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -14,8 +13,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Web.Controllers;
 using JosephGuadagno.Broadcasting.Web.Models;
 using JosephGuadagno.Broadcasting.Web.Models.LinkedIn;
@@ -53,13 +53,18 @@ internal class TestSession : ISession
 
 public class LinkedInControllerTests
 {
-    private readonly Mock<IKeyVault> _keyVault;
+    private const string TestOwnerOid = "test-owner-oid-12345";
+
+    private readonly Mock<IUserOAuthTokenManager> _userOAuthTokenManager;
+    private readonly Mock<ISocialMediaPlatformManager> _socialMediaPlatformManager;
     private readonly LinkedInSettings _linkedInSettings;
     private readonly Mock<ILogger<LinkedInController>> _logger;
+    private readonly SocialMediaPlatform _linkedInPlatform;
 
     public LinkedInControllerTests()
     {
-        _keyVault = new Mock<IKeyVault>();
+        _userOAuthTokenManager = new Mock<IUserOAuthTokenManager>();
+        _socialMediaPlatformManager = new Mock<ISocialMediaPlatformManager>();
         _linkedInSettings = new LinkedInSettings
         {
             ClientId = "test-client-id",
@@ -69,25 +74,67 @@ public class LinkedInControllerTests
             AccessTokenUrl = "https://www.linkedin.com/oauth/v2/accessToken"
         };
         _logger = new Mock<ILogger<LinkedInController>>();
+        _linkedInPlatform = new SocialMediaPlatform { Id = 3, Name = "LinkedIn", IsActive = true };
+
+        // Default: platform lookup returns LinkedIn
+        _socialMediaPlatformManager
+            .Setup(m => m.GetByNameAsync("LinkedIn", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_linkedInPlatform);
     }
 
     private LinkedInController CreateController(HttpClient? httpClient = null)
     {
         httpClient ??= new HttpClient();
-        return new LinkedInController(httpClient, _keyVault.Object, Options.Create(_linkedInSettings), _logger.Object);
+        return new LinkedInController(
+            httpClient,
+            _userOAuthTokenManager.Object,
+            _socialMediaPlatformManager.Object,
+            Options.Create(_linkedInSettings),
+            _logger.Object);
+    }
+
+    /// <summary>
+    /// Builds an HttpContext with a ClaimsPrincipal containing an "oid" claim.
+    /// </summary>
+    private static DefaultHttpContext BuildAuthenticatedHttpContext(string? oid = TestOwnerOid, ISession? session = null)
+    {
+        var claims = new List<Claim>();
+        if (oid is not null)
+            claims.Add(new Claim("oid", oid));
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = principal
+        };
+        if (session is not null)
+            httpContext.Session = session;
+
+        return httpContext;
     }
 
     [Fact]
-    public async Task Index_ShouldReturnViewWithSavedTokenInfo()
+    public async Task Index_WhenTokenExists_ShouldReturnViewWithMaskedTokenInfo()
     {
         // Arrange
-        var secret = new KeyVaultSecret("jjg-net-linkedin-access-token", "test-access-token-value");
-        _keyVault.Setup(k => k.GetSecretAsync("jjg-net-linkedin-access-token")).ReturnsAsync(secret);
+        var storedToken = new UserOAuthToken
+        {
+            CreatedByEntraOid = TestOwnerOid,
+            SocialMediaPlatformId = 3,
+            AccessToken = "abcd1234efgh5678",
+            AccessTokenExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        _userOAuthTokenManager
+            .Setup(m => m.GetByUserAndPlatformAsync(TestOwnerOid, 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedToken);
 
         var controller = CreateController();
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = new DefaultHttpContext()
+            HttpContext = BuildAuthenticatedHttpContext()
         };
 
         // Act
@@ -96,9 +143,53 @@ public class LinkedInControllerTests
         // Assert
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<SavedTokenInfo>(viewResult.Model);
-        Assert.Equal("test-access-token-value", model.AccessToken);
-        Assert.Equal("jjg-net-linkedin-access-token", model.KeyVaultSecretName);
-        _keyVault.Verify(k => k.GetSecretAsync("jjg-net-linkedin-access-token"), Times.Once);
+        Assert.True(model.HasToken);
+        Assert.NotNull(model.MaskedAccessToken);
+        Assert.DoesNotContain("abcd1234efgh5678", model.MaskedAccessToken!); // raw token never exposed
+        Assert.Equal(storedToken.AccessTokenExpiresAt, model.ExpiresOn);
+        _userOAuthTokenManager.Verify(m => m.GetByUserAndPlatformAsync(TestOwnerOid, 3, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Index_WhenNoTokenStored_ShouldReturnViewWithHasTokenFalse()
+    {
+        // Arrange
+        _userOAuthTokenManager
+            .Setup(m => m.GetByUserAndPlatformAsync(TestOwnerOid, 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserOAuthToken?)null);
+
+        var controller = CreateController();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildAuthenticatedHttpContext()
+        };
+
+        // Act
+        var result = await controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SavedTokenInfo>(viewResult.Model);
+        Assert.False(model.HasToken);
+    }
+
+    [Fact]
+    public async Task Index_WhenOidClaimMissing_ShouldReturnViewWithHasTokenFalse()
+    {
+        // Arrange
+        var controller = CreateController();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildAuthenticatedHttpContext(oid: null)
+        };
+
+        // Act
+        var result = await controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SavedTokenInfo>(viewResult.Model);
+        Assert.False(model.HasToken);
     }
 
     [Fact]
@@ -108,8 +199,7 @@ public class LinkedInControllerTests
         var controller = CreateController();
 
         var session = new TestSession();
-        var httpContext = new DefaultHttpContext();
-        httpContext.Session = session;
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
 
         var mockUrlHelper = new Mock<IUrlHelper>();
         mockUrlHelper
@@ -137,8 +227,7 @@ public class LinkedInControllerTests
         var session = new TestSession();
         session.Set("state", Encoding.UTF8.GetBytes("session-state-value"));
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Session = session;
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
         httpContext.Request.QueryString = new QueryString("?code=auth-code&state=different-state");
 
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
@@ -160,9 +249,7 @@ public class LinkedInControllerTests
         var session = new TestSession();
         session.Set("state", Encoding.UTF8.GetBytes(stateValue));
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Session = session;
-        // State matches, but no code in query string
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
         httpContext.Request.QueryString = new QueryString($"?state={stateValue}");
 
         var mockUrlHelper = new Mock<IUrlHelper>();
@@ -181,7 +268,7 @@ public class LinkedInControllerTests
     }
 
     [Fact]
-    public async Task Callback_WhenValid_ShouldSaveTokenAndRedirectToIndex()
+    public async Task Callback_WhenValid_ShouldStoreTokenViaManagerAndRedirectToIndex()
     {
         // Arrange
         const string stateValue = "valid-state";
@@ -213,8 +300,7 @@ public class LinkedInControllerTests
         var session = new TestSession();
         session.Set("state", Encoding.UTF8.GetBytes(stateValue));
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Session = session;
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
         httpContext.Request.QueryString = new QueryString($"?code={authCode}&state={stateValue}");
 
         var mockUrlHelper = new Mock<IUrlHelper>();
@@ -225,12 +311,16 @@ public class LinkedInControllerTests
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
         controller.Url = mockUrlHelper.Object;
 
-        _keyVault
-            .Setup(k => k.UpdateSecretValueAndPropertiesAsync(
-                "jjg-net-linkedin-access-token",
-                It.IsAny<string>(),
-                It.IsAny<DateTime>()))
-            .Returns(Task.CompletedTask);
+        _userOAuthTokenManager
+            .Setup(m => m.StoreOAuthCallbackTokenAsync(
+                TestOwnerOid,
+                3,
+                "new-access-token",
+                It.IsAny<string?>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserOAuthToken?)null);
 
         // Act
         var result = await controller.Callback();
@@ -238,10 +328,16 @@ public class LinkedInControllerTests
         // Assert
         var redirectResult = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Index", redirectResult.ActionName);
-        _keyVault.Verify(k => k.UpdateSecretValueAndPropertiesAsync(
-            "jjg-net-linkedin-access-token",
+
+        // Token is stored per-user via manager — no Key Vault
+        _userOAuthTokenManager.Verify(m => m.StoreOAuthCallbackTokenAsync(
+            TestOwnerOid,
+            3,
             "new-access-token",
-            It.IsAny<DateTime>()), Times.Once);
+            It.IsAny<string?>(),
+            It.IsAny<DateTimeOffset>(),
+            It.IsAny<DateTimeOffset?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs
@@ -1,6 +1,8 @@
+using System.Security.Claims;
 using System.Text.Json;
 using JosephGuadagno.Broadcasting.Domain.Constants;
-using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Web.Models;
 using JosephGuadagno.Broadcasting.Web.Models.LinkedIn;
 using Microsoft.AspNetCore.Authorization;
@@ -16,92 +18,101 @@ namespace JosephGuadagno.Broadcasting.Web.Controllers;
 public class LinkedInController : Controller
 {
     private readonly HttpClient _httpClient;
-    private readonly IKeyVault _keyVault;
+    private readonly IUserOAuthTokenManager _userOAuthTokenManager;
+    private readonly ISocialMediaPlatformManager _socialMediaPlatformManager;
     private readonly LinkedInSettings _linkedInSettings;
     private readonly ILogger<LinkedInController> _logger;
-    
-    const string KeyVaultSecretName = "jjg-net-linkedin-access-token";
-    const string KeyVaultRefreshTokenSecretName = "jjg-net-linkedin-refresh-token";
+
     const string State = "state";
-    
+
     /// <summary>
-    /// Works with the LinkedIn Api to refresh tokens
+    /// Works with the LinkedIn OAuth flow to acquire and store per-user tokens
     /// </summary>
-    /// <param name="httpClient"></param>
-    /// <param name="keyVault"></param>
-    /// <param name="linkedInSettingsOptions"></param>
-    /// <param name="logger"></param>
-    public LinkedInController(HttpClient httpClient, IKeyVault keyVault, IOptions<LinkedInSettings> linkedInSettingsOptions, ILogger<LinkedInController> logger)
+    public LinkedInController(
+        HttpClient httpClient,
+        IUserOAuthTokenManager userOAuthTokenManager,
+        ISocialMediaPlatformManager socialMediaPlatformManager,
+        IOptions<LinkedInSettings> linkedInSettingsOptions,
+        ILogger<LinkedInController> logger)
     {
         _httpClient = httpClient;
-        _keyVault = keyVault;
+        _userOAuthTokenManager = userOAuthTokenManager;
+        _socialMediaPlatformManager = socialMediaPlatformManager;
         _linkedInSettings = linkedInSettingsOptions.Value;
         _logger = logger;
     }
-    
+
     /// <summary>
-    /// Returns the token information from Key Vault for LinkedIn
+    /// Shows current per-user LinkedIn token status (masked — never raw token value)
     /// </summary>
-    /// <returns></returns>
     public async Task<IActionResult> Index()
     {
-        var keyVaultSecret = await _keyVault.GetSecretAsync(KeyVaultSecretName);
+        var ownerOid = User.FindFirstValue("oid");
+        if (string.IsNullOrWhiteSpace(ownerOid))
+        {
+            _logger.LogWarning("User OID claim is missing on LinkedIn Index");
+            return View(new SavedTokenInfo { HasToken = false });
+        }
+
+        var platform = await _socialMediaPlatformManager.GetByNameAsync("LinkedIn");
+        if (platform is null)
+        {
+            _logger.LogWarning("LinkedIn platform not found in database");
+            return View(new SavedTokenInfo { HasToken = false });
+        }
+
+        var token = await _userOAuthTokenManager.GetByUserAndPlatformAsync(ownerOid, platform.Id);
+
+        if (token is null)
+        {
+            return View(new SavedTokenInfo { HasToken = false, PlatformId = platform.Id });
+        }
+
+        // Mask the token — never return raw value to the view
+        var masked = token.AccessToken.Length > 8
+            ? $"{token.AccessToken[..4]}...{token.AccessToken[^4..]}"
+            : "****";
+
         return View(new SavedTokenInfo
         {
-            AccessToken = keyVaultSecret.Value,
-            KeyVaultSecretName = keyVaultSecret.Name,
-            ExpiresOn = keyVaultSecret.Properties.ExpiresOn
+            HasToken = true,
+            MaskedAccessToken = masked,
+            ExpiresOn = token.AccessTokenExpiresAt,
+            PlatformId = platform.Id
         });
     }
 
     /// <summary>
-    /// Starts the LinkedIn OAuth2 flow
+    /// Starts the LinkedIn OAuth2 authorization code flow
     /// </summary>
-    /// <returns></returns>
     public async Task<IActionResult> RefreshToken()
     {
-        // Call the LinkedIn API to refresh the token
-        // Note: This is not actually refreshing the token but reauthorizing the user
-        // Documentation: https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin%2Fcontext&tabs=HTTPS1#step-2-request-an-authorization-code
-
         // Build the URL to redirect the user to
         var state = Guid.NewGuid().ToString();
         HttpContext.Session.SetString(State, state);
-        
+
         var callbackUrl = Url.Action("Callback", "LinkedIn", null, Request.Scheme) ?? string.Empty;
         if (string.IsNullOrEmpty(callbackUrl))
         {
             _logger.LogError("Callback URL is missing");
             return ViewBag["Message"] = "Callback URL is missing.";
         }
-        
+
         var url = $"{_linkedInSettings.AuthorizationUrl}?response_type=code&client_id={_linkedInSettings.ClientId}&redirect_uri={callbackUrl}&state={state}&scope={_linkedInSettings.Scopes}";
 
-        return Redirect(url);
-        //await _httpClient.GetAsync(url);
-
+        return await Task.FromResult(Redirect(url));
     }
-    
+
     /// <summary>
-    /// Handles the callback from LinkedIn
+    /// Handles the OAuth2 callback from LinkedIn and stores the token per-user
     /// </summary>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
-    public async Task<IActionResult> Callback()
+    public async Task<IActionResult> Callback(CancellationToken cancellationToken = default)
     {
-        // Handle the callback from LinkedIn
-        // Callback is handled in two parts
-        // 1. Retrieve the authorization code
-        // Documentation: https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin%2Fcontext&tabs=HTTPS1#step-2-request-an-authorization-code
-        // 2. Exchange the authorization code for an access token
-        // Documentation: https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin%2Fcontext&tabs=HTTPS1#step-3-exchange-authorization-code-for-an-access-token
-        
         // Read the code and state from the query string
-        // Compare the state to the session state
-        
         var code = HttpContext.Request.Query["code"].FirstOrDefault();
         var state = HttpContext.Request.Query["state"].FirstOrDefault();
-        
+
+        // CSRF state validation — must be preserved
         if (state != HttpContext.Session.GetString(State))
         {
             _logger.LogError("State does not match");
@@ -120,9 +131,8 @@ public class LinkedInController : Controller
             _logger.LogError("Callback URL is missing");
             return BadRequest();
         }
-        
+
         // Exchange the code for an access token
-        // Build the URL to exchange the code for an access token
         var headers = new Dictionary<string, string>
         {
             {"Content-Type", "application/x-www-form-urlencoded"},
@@ -132,33 +142,44 @@ public class LinkedInController : Controller
             {"client_id", _linkedInSettings.ClientId},
             {"client_secret", _linkedInSettings.ClientSecret}
         };
-        
-        var response = await _httpClient.PostAsync(_linkedInSettings.AccessTokenUrl, new FormUrlEncodedContent(headers));
-        
-        var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(await response.Content.ReadAsStringAsync());
-        
-        if (tokenResponse == null) 
+
+        var response = await _httpClient.PostAsync(_linkedInSettings.AccessTokenUrl, new FormUrlEncodedContent(headers), cancellationToken);
+
+        var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(await response.Content.ReadAsStringAsync(cancellationToken));
+
+        if (tokenResponse == null)
         {
             _logger.LogError("Token response is null");
             return BadRequest();
         }
-        
-        // Save the token and expiration to KeyVault
-        var tokenExpiration = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
-        await _keyVault.UpdateSecretValueAndPropertiesAsync(KeyVaultSecretName, tokenResponse.AccessToken, tokenExpiration.DateTime);
-        
-        _logger.LogInformation("Saved new token '{KeyVaultSecretName}' to KeyVault", KeyVaultSecretName);
 
-        // Save the refresh token if one was returned
-        if (!string.IsNullOrEmpty(tokenResponse.RefreshToken))
-        {
-            var refreshTokenExpiration = tokenResponse.RefreshTokenExpiresIn.HasValue
-                ? DateTimeOffset.UtcNow.AddSeconds(tokenResponse.RefreshTokenExpiresIn.Value)
-                : DateTimeOffset.UtcNow.AddDays(365);
-            await _keyVault.UpdateSecretValueAndPropertiesAsync(KeyVaultRefreshTokenSecretName, tokenResponse.RefreshToken, refreshTokenExpiration.DateTime);
-            _logger.LogInformation("Saved new refresh token '{KeyVaultRefreshTokenSecretName}' to KeyVault", KeyVaultRefreshTokenSecretName);
-        }
+        var ownerOid = User.FindFirstValue("oid")
+            ?? throw new InvalidOperationException("User OID claim is missing");
+
+        var platform = await _socialMediaPlatformManager.GetByNameAsync("LinkedIn", cancellationToken)
+            ?? throw new InvalidOperationException("LinkedIn platform not found");
+
+        var accessTokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
+        DateTimeOffset? refreshTokenExpiresAt = tokenResponse.RefreshTokenExpiresIn.HasValue
+            ? DateTimeOffset.UtcNow.AddSeconds(tokenResponse.RefreshTokenExpiresIn.Value)
+            : null;
+
+        await _userOAuthTokenManager.StoreOAuthCallbackTokenAsync(
+            ownerOid,
+            platform.Id,
+            tokenResponse.AccessToken,
+            tokenResponse.RefreshToken,
+            accessTokenExpiresAt,
+            refreshTokenExpiresAt,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Stored OAuth token for platform {PlatformId} owner {OwnerOid} expiring {ExpiresAt}",
+            platform.Id,
+            LogSanitizer.Sanitize(ownerOid),
+            accessTokenExpiresAt);
 
         return RedirectToAction("Index");
     }
 }
+

--- a/src/JosephGuadagno.Broadcasting.Web/Models/LinkedIn/SavedTokenInfo.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/LinkedIn/SavedTokenInfo.cs
@@ -2,7 +2,11 @@
 
 public class SavedTokenInfo
 {
-    public string AccessToken { get; set; }
-    public string KeyVaultSecretName { get; set; }
+    /// <summary>
+    /// Masked representation of the access token (never the raw value).
+    /// </summary>
+    public string? MaskedAccessToken { get; set; }
+    public bool HasToken { get; set; }
     public DateTimeOffset? ExpiresOn { get; set; }
+    public int? PlatformId { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -5,6 +5,7 @@ using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Managers;
 using JosephGuadagno.Broadcasting.Serilog;
+using JosephGuadagno.Broadcasting.Managers;
 using JosephGuadagno.Broadcasting.Web;
 using JosephGuadagno.Broadcasting.Web.HealthChecks;
 using JosephGuadagno.Broadcasting.Web.MappingProfiles;
@@ -257,6 +258,8 @@ void ConfigureApplication(IServiceCollection services)
     
     // Register all SQL data stores
     services.AddSqlDataStores();
+
+    services.TryAddScoped<IUserOAuthTokenManager, UserOAuthTokenManager>();
     
     services.TryAddScoped<IEngagementService, EngagementService>();
     services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();

--- a/src/JosephGuadagno.Broadcasting.Web/Views/LinkedIn/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/LinkedIn/Index.cshtml
@@ -11,19 +11,19 @@ ViewData["Title"] = "LinkedIn Token Refresh";
             <label for="AccessToken">Access Token</label>
         </dt>
         <dd class="col-sm-10">
-            <input type="text" id="AccessToken" name="AccessToken" value="@Model.AccessToken" class="form-control" />
+            <input type="text" id="AccessToken" name="AccessToken" value="@Model.MaskedAccessToken" class="form-control" readonly />
         </dd>
         <dt class="col-sm-2">
             <label for="ExpiresIn">Expires In</label>
         </dt>
         <dd class="col-sm-10">
-            <input type="text" id="ExpiresIn" name="ExpiresIn" value="@Model.ExpiresOn" class="form-control" />
+            <input type="text" id="ExpiresIn" name="ExpiresIn" value="@Model.ExpiresOn" class="form-control" readonly />
         </dd>
         <dt class="col-sm-2">
-            <label for="ExpiresIn">Secret Name</label>
+            <label for="HasToken">Token Present</label>
         </dt>
         <dd class="col-sm-10">
-            <input type="text" id="Secret Name" name="Secret Name" value="@Model.KeyVaultSecretName" class="form-control" />
+            <input type="text" id="HasToken" name="HasToken" value="@Model.HasToken" class="form-control" readonly />
         </dd>
     </dl>
 </div>


### PR DESCRIPTION
## Summary

Implements issue #777 — replaces the shared LinkedIn Key Vault OAuth token pattern with a per-user `UserOAuthTokens` database table.

## Changes

### New files
- `scripts/database/migrations/2026-04-24-user-oauth-tokens.sql` — DDL for new `UserOAuthTokens` table
- `Domain/Models/UserOAuthToken.cs` — domain model
- `Domain/Interfaces/IUserOAuthTokenDataStore.cs` — data store interface
- `Domain/Interfaces/IUserOAuthTokenManager.cs` — manager interface
- `Domain/Constants/SocialMediaPlatformIds.cs` — `LinkedIn = 3` constant
- `Data.Sql/Models/UserOAuthToken.cs` — EF entity
- `Data.Sql/UserOAuthTokenDataStore.cs` — full data store with per-OID isolation on all reads
- `Managers/UserOAuthTokenManager.cs` — thin delegation manager with input validation

### Modified files
- `scripts/database/table-create.sql` — DDL appended
- `Data.Sql/BroadcastingContext.cs` — added `DbSet` + full `OnModelCreating` config (unique constraint, FK, expiry index)
- `Data.Sql/ServiceCollectionExtensions.cs` — registered `IUserOAuthTokenDataStore`
- `Web/Controllers/LinkedInController.cs` — removed `IKeyVault`, store token per-user via `IUserOAuthTokenManager`; CSRF state validation preserved; token values never logged
- `Web/Models/LinkedIn/SavedTokenInfo.cs` — raw `AccessToken`/`KeyVaultSecretName` replaced with `MaskedAccessToken`/`HasToken`/`ExpiresOn`
- `Web/Views/LinkedIn/Index.cshtml` — shows masked token info only, readonly fields
- `Web/Program.cs` — registered `IUserOAuthTokenManager`
- `Functions/LinkedIn/ProcessScheduledItemFired.cs` — removed `ILinkedInApplicationSettings`, resolves per-user OAuth token; null token → skip + warn log
- `Functions/LinkedIn/ProcessNewSyndicationDataFired.cs` — same refactor
- `Functions/LinkedIn/ProcessNewYouTubeDataFired.cs` — same refactor
- `Functions/LinkedIn/ProcessNewRandomPost.cs` — same refactor
- `Functions/Program.cs` — registered `IUserOAuthTokenDataStore` + `IUserOAuthTokenManager`
- `Functions.Tests/LinkedIn/ProcessScheduledItemFiredTests.cs` — replaced `ILinkedInApplicationSettings` mocks with `IUserOAuthTokenManager`; added `WhenNoOAuthTokenFound_ReturnsNull` test
- `Web.Tests/Controllers/LinkedInControllerTests.cs` — rewritten with new constructor; per-user token assertions; Key Vault references removed

## Security
- Raw access tokens are **never** logged or exposed to views
- Per-user token lookup uses `CreatedByEntraOid` as isolation key on every read — cross-user access is structurally impossible
- No silent fallback to shared/singleton token

## Required manual production steps

**These must be completed before and after deploying this PR to production:**

1. **#857 — DB migration (BEFORE deploy):** Run `scripts/database/migrations/2026-04-24-user-oauth-tokens.sql` against the production `JJGNet` database to create the `UserOAuthTokens` table.
2. **#855 / #856 — Key Vault secret retirement (AFTER deploy):** Retire the `jjg-net-linkedin-access-token` and `jjg-net-linkedin-access-token-expiration-date` secrets from Key Vault once production smoke testing confirms per-user token flow is working.

## Tests
- 166 Functions unit tests: all passing ✅
- 232 Web unit tests: all passing ✅

Closes #777
