### PR TITLE
fix(#863): add missing AutoMapper mappings for SyndicationFeedSource in ApiBroadcastingProfile

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Api/MappingProfiles/ApiBroadcastingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/MappingProfiles/ApiBroadcastingProfile.cs
@@ -68,6 +68,16 @@ public class ApiBroadcastingProfile : Profile
         CreateMap<FacebookPublisherSettingRequest, FacebookPublisherSettingUpdate>();
         CreateMap<LinkedInPublisherSettingRequest, LinkedInPublisherSettingUpdate>();
 
+        // Syndication Feed Source
+        CreateMap<SyndicationFeedSource, SyndicationFeedSourceResponse>();
+        CreateMap<SyndicationFeedSourceRequest, SyndicationFeedSource>()
+            .ForMember(d => d.Id, o => o.Ignore())
+            .ForMember(d => d.AddedOn, o => o.Ignore())
+            .ForMember(d => d.ItemLastUpdatedOn, o => o.Ignore())
+            .ForMember(d => d.LastUpdatedOn, o => o.Ignore())
+            .ForMember(d => d.CreatedByEntraOid, o => o.Ignore())
+            .ForMember(d => d.Tags, o => o.MapFrom(s => s.Tags ?? new List<string>()));
+
         // User Collector Feed Source
         CreateMap<UserCollectorFeedSource, UserCollectorFeedSourceResponse>();
         CreateMap<UserCollectorFeedSourceRequest, UserCollectorFeedSource>()


### PR DESCRIPTION
## Summary

Fixes #863

## What was missing

`ApiBroadcastingProfile.cs` had no AutoMapper mappings for `SyndicationFeedSource`, causing `AutoMapperMappingException` on all GET and POST endpoints at `/api/syndication-feed-sources`.

## What was added

Two mappings in `ApiBroadcastingProfile.cs`, following the same pattern as the existing `YouTubeSource` mappings:

```csharp
// Syndication Feed Source
CreateMap<SyndicationFeedSource, SyndicationFeedSourceResponse>();
CreateMap<SyndicationFeedSourceRequest, SyndicationFeedSource>()
    .ForMember(d => d.Id, o => o.Ignore())
    .ForMember(d => d.AddedOn, o => o.Ignore())
    .ForMember(d => d.ItemLastUpdatedOn, o => o.Ignore())
    .ForMember(d => d.LastUpdatedOn, o => o.Ignore())
    .ForMember(d => d.CreatedByEntraOid, o => o.Ignore())
    .ForMember(d => d.Tags, o => o.MapFrom(s => s.Tags ?? new List<string>()));
```

## Pattern followed

Mirrors `YouTubeSourceRequest` → `YouTubeSource` — ignores server-managed fields (`Id`, `AddedOn`, `ItemLastUpdatedOn`, `LastUpdatedOn`, `CreatedByEntraOid`) and null-coalesces `Tags`.