### PR TITLE
fix(#871): restore column headings on Engagements index page

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Index.cshtml
@@ -26,7 +26,7 @@
     </form>
     
     <table class="table table-striped">
-        <thead class="thead-dark">
+        <thead class="table-dark">
         <tr>
             <th scope="col">
                 <a asp-action="Index" asp-controller="Engagements" asp-route-sortBy="name" asp-route-sortDescending="@NextSortDirection("name")" asp-route-filter="@ViewBag.Filter" class="text-decoration-none text-white">


### PR DESCRIPTION
## What

Column headings on the Engagements Index page were invisible — rendered as white text on a white background.

## Root Cause

<thead class="thead-dark"> is a Bootstrap 4 class that was removed in Bootstrap 5. Without it, the thead has no dark background. The sortable column header links all carry class="text-decoration-none text-white", so the heading text becomes white-on-white and disappears entirely.

## Fix

Changed <thead class="thead-dark"> → <thead class="table-dark">, the correct Bootstrap 5 equivalent. The dark background is now applied and the white link text is legible.

**File changed:** src/JosephGuadagno.Broadcasting.Web/Views/Engagements/Index.cshtml (1-line change)

## Verification

- Build: dotnet build .\src\ --configuration Release — **0 errors**

Closes #871