### PR TITLE
docs(#877): add mandatory PR body-file rule to all agent charters

### DIFF
--- a/.squad/agents/cypher/charter.md
+++ b/.squad/agents/cypher/charter.md
@@ -58,6 +58,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 I don't write features. I make sure everything that gets written actually ships — reliably, repeatably, forever.

--- a/.squad/agents/ghost/charter.md
+++ b/.squad/agents/ghost/charter.md
@@ -70,6 +70,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 The surface you can't see is the one that gets you. Locks every door, checks every token, and never assumes trust.

--- a/.squad/agents/link/charter.md
+++ b/.squad/agents/link/charter.md
@@ -68,6 +68,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 Keeps the pipes running. If the infrastructure drifts, Link finds it before production does.

--- a/.squad/agents/morpheus/charter.md
+++ b/.squad/agents/morpheus/charter.md
@@ -41,6 +41,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Model
 
 - **Preferred:** auto

--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -45,6 +45,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Model
 
 - **Preferred:** auto

--- a/.squad/agents/oracle/charter.md
+++ b/.squad/agents/oracle/charter.md
@@ -57,6 +57,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 Every secret has a cost. I make sure we pay it once, in the right place, to the right party.

--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -50,8 +50,29 @@ If I need another team member's input, say so — the coordinator will bring the
 When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Use **GitHub Flavored Markdown (GFM)** — GitHub renders it natively
 - Inline code, file paths, method names, and CLI commands use backticks: `` `path/to/file.cs` ``, `` `MyMethod()` ``, `` `dotnet build` ``
-- Never use backslashes to escape or quote code references
+- **NEVER** use `\text\` (backslash-word-backslash) — this is the most common mistake; it renders as literal backslashes on GitHub, not code
+- **NEVER** use `\\\` or `\\` as a code fence — use triple backticks (` ``` `) instead
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
+- **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
+
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with `backticks` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
 
 ## Voice
 

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -80,6 +80,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 Silent observer. Keeps the record straight so the team never loses context.

--- a/.squad/agents/sparks/charter.md
+++ b/.squad/agents/sparks/charter.md
@@ -71,6 +71,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with `backticks` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 If the user can see it, Sparks owns it. Clean views, tight forms, and a UI that doesn't make people think too hard.

--- a/.squad/agents/sparks/history.md
+++ b/.squad/agents/sparks/history.md
@@ -10,10 +10,17 @@
 | 2026-04-11 | Fix double-submit bug in site.js (#708) | ✅ Added event.preventDefault() in submit handler to block duplicate form submissions; committed to branch social-media-708 |
 | 2026-04-24 | Fix dt/dd HTML pairing in Schedules Details view (#845) | ✅ Changed all value `<dt>` elements to `<dd>` inside the `<dl class="row">` — 8 pairs now correctly use `<dt>` (label) + `<dd>` (value); PR #848 |
 | 2026-04-11 | Fix AddPlatform 400 error (#708) | ✅ Removed redundant asp-route-engagementId from form causing model binding conflict; EngagementId now only posted via hidden field in ViewModel |
+| 2026-04-27 | Add sorting, filtering, searching to all index pages (#870) | ✅ Schedules index full sort/filter/H1/Bootstrap 5 fix; Engagements index H1; SyndicationFeedSources + YouTubeSources thead-dark → table-dark; wired Schedules service sort/filter to API; PR #876 |
 
 ## Learnings
 
-### 2026-04-27 — Issue #871: Engagements Index Column Headings Invisible
+### 2026-04-27 — Issue #870: Sorting/Filtering/Searching on All Index Pages
+- **Pattern established:** All index pages use: filter `<form method="get">` with hidden `sortBy`/`sortDescending` inputs, sortable `<thead class="table-dark">` column headers with `asp-route-sortBy/sortDescending/filter`, and `<partial name="_PaginationPartial" />` at bottom.
+- **Bootstrap 5 fix sweep:** `thead-dark` (Bootstrap 4) → `table-dark` (Bootstrap 5) on `<thead>`. Found in Schedules, SyndicationFeedSources, YouTubeSources. Engagements was fixed in PR #874.
+- **H1 requirement:** Issue #870 explicitly requires every index page to have `<h1>PageName</h1>`. Engagements was missing one; Schedules was missing one.
+- **Data layer rule applies:** Sort/filter wiring must go all the way to the service/API. For Schedules, `IScheduledItemService.GetScheduledItemsAsync` was updated with `sortBy`, `sortDescending`, `filter` params. The API (`GET /Schedules`) already supported these params.
+- **Non-applicable pages:** CollectorSettings (card/modal per-user settings), PublisherSettings (card-based per-platform view), MessageTemplates (platform-grouped admin view — `IMessageTemplateService` has no filter param), Home/LinkedIn (non-list pages).
+- **Branch:** `issue-870-sorting-filtering-searching-index-pages` | **PR:** #876
 - **Root Cause:** `<thead class="thead-dark">` is a Bootstrap 4 class removed in Bootstrap 5. The sort link anchors inside `<th>` elements use `class="text-decoration-none text-white"`, so without a dark background the text is white-on-white — completely invisible.
 - **Fix:** Changed `thead-dark` → `table-dark` (the Bootstrap 5 equivalent on `<thead>`).
 - **Scope:** One-line change in `Views/Engagements/Index.cshtml`.

--- a/.squad/agents/switch/charter.md
+++ b/.squad/agents/switch/charter.md
@@ -57,6 +57,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 If it renders in a browser, it's mine. Pixel-perfect Razor, clean JS, zero console errors.

--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -77,6 +77,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with ``backticks`` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Voice
 
 Breaks things on purpose so users never break them by accident.

--- a/.squad/agents/trinity/charter.md
+++ b/.squad/agents/trinity/charter.md
@@ -41,6 +41,25 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
+### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+
+**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+
+```powershell
+# Write body to temp file
+$prBody = @"
+## Summary
+Your PR description with `backticks` and **markdown** here...
+"@
+$prBody | Set-Content "$env:TEMP\pr-body.md"
+
+# Create PR using the file
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
+Remove-Item "$env:TEMP\pr-body.md" -Force
+```
+
+Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+
 ## Model
 
 - **Preferred:** auto


### PR DESCRIPTION
## Summary

Adds a mandatory `### ⚠️ PR Creation — MANDATORY` section to all 12 agent charters.

## Problem

The `\text\` backslash mangling in PR descriptions has occurred 20-30+ times. The root cause: agents use `gh pr create --body "..."` inline in PowerShell, which mangles backticks into `\text\` patterns.

Existing charters warned against `\text\` but did not give the mechanical fix for PR creation.

## Fix

All 12 charters (cypher, ghost, link, morpheus, neo, oracle, ralph, scribe, sparks, switch, tank, trinity) now include:

```powershell
$prBody | Set-Content "$env:TEMP\pr-body.md"
gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
```

Same rule documented for `gh pr edit`.

Closes #877
