### PR TITLE
feat(#852): LinkedIn OAuth token expiry notification data layer

### DIFF
--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,34 +1,38 @@
 # Team Focus — Now
 
-> **Last updated:** 2026-04-24T21:30:57Z
-> **Sprint:** 27 (in progress) — Milestone 21
-> **Status:** Core multi-tenancy work merged. Joe validating site functionality; #855 and #856 will close after validation. #852 and #853 remain open — deferred to next sprint.
-> **Next:** Close open issues from backlog. CodeQL CSRF alert #41 pending next scan.
+> **Last updated:** 2026-04-28T05:30:00Z
+> **Sprint:** 28 — Milestone 22
+> **Status:** Sprint 27 complete. #855 closed. #856 flagged to Joe (manual Azure Portal step). Sprint 28 begins with #852 (Trinity, in flight) and #853 (blocked on #852 merge).
+> **Next:** Merge #852, unblock #853. Complete Joe's manual #856 step asynchronously.
 
 ## Current Focus
 
-**Sprint 27 — IN PROGRESS** 🔄
+**Sprint 28 — IN PROGRESS** 🔄
 
-**Completed:**
+**Sprint 27 — COMPLETE:**
 - ✅ #777 — Per-user OAuth/token runtime (merged via PR #854)
 - ✅ #778 — Per-user collector onboarding/configuration (merged via PR #859)
 - ✅ #858 — Manual DB migration for per-user collector config tables (Joe, production 2026-04-24)
+- ✅ #855 — Site validation complete (closed)
 
-**Pending (Joe validating):**
-- ⏳ #855 — Closes after site usability/config validation passes
-- ⏳ #856 — Closes after site usability/config validation passes
+**Sprint 28 — ACTIVE:**
+- 🔄 #852 — LinkedIn OAuth token expiry data layer (Trinity, in flight)
+  - LastNotifiedAt column addition
+  - GetExpiringWindowAsync repository method
+  - Domain model + manager + unit tests
+- 🔜 #853 — Blocked on #852 merge (Trinity, next after merge)
+- ⏳ #856 — Manual production step pending Joe (squad:Joe label)
+  - Disable old LinkedIn Key Vault secrets in Azure Portal
+  - Non-blocking code task
 
-**Deferred to next sprint:**
-- 🔜 #852 — Next sprint
-- 🔜 #853 — Next sprint
+**Goal:** Merge #852 → unblock #853. Joe completes #856 Azure Portal step asynchronously. Monitor CodeQL CSRF alert #41 for next scan resolution.
 
-**Goal:** Complete #855 and #856 after Joe's validation. Then begin next sprint with #852 and #853. Monitor CodeQL CSRF alert #41 for next scan resolution.
+## Key Patterns (Sprint 28)
 
-## Key Patterns (Sprint 27)
-
-1. **Per-user OAuth:** `LinkedinController` (and other platforms) acquire and store tokens per user.
-2. **Per-user collectors:** `UserCollectors` data model; queries filter by current user's OID — no cross-user leakage.
-3. **Security invariant:** Tests prove a user cannot read or execute another user's tokens or collector configurations.
+1. **LinkedIn OAuth expiry tracking:** New `LastNotifiedAt` column tracks when users were last notified of token expiry (supports #852 → #853 notification flow).
+2. **Per-user OAuth:** Continues from Sprint 27 — `LinkedinController` acquires and stores tokens per user.
+3. **Per-user collectors:** `UserCollectors` data model; queries filter by current user's OID — no cross-user leakage.
+4. **Security invariant:** Tests prove a user cannot read or execute another user's tokens or collector configurations.
 
 ## Standing Work
 
@@ -38,16 +42,15 @@
 
 ## Team Composition
 
-**Sprint 27 (Complete):**
-- Trinity — Implementation (#777, #778) ✅
-- Tank — Test coverage ✅
-- Neo — Review & architecture ✅
+**Sprint 28 (Active):**
+- Trinity — Implementation (#852, #853) 🔄
+- Joe — Manual Azure Portal step (#856) ⏳
 
 **Rotating Roles:** Squad roster available in `.squad/team.md`
 
 ---
 
-**Last Updated:** 2026-04-24T21:30:57Z
-**Sprint:** 27 (Multi-Tenancy: Per-User OAuth & Collectors) — COMPLETE
-**Current Focus:** Remaining open issues / Sprint planning or backlog
-**Next Decision Point:** Sprint 28 kickoff or ongoing issue completion
+**Last Updated:** 2026-04-28T05:30:00Z
+**Sprint:** 28 (LinkedIn OAuth Token Expiry) — IN PROGRESS
+**Current Focus:** #852 (Trinity), #853 (blocked), #856 (Joe manual step)
+**Next Decision Point:** #852 merge completion

--- a/scripts/database/migrations/2026-05-01-user-oauth-tokens-add-last-notified-at.sql
+++ b/scripts/database/migrations/2026-05-01-user-oauth-tokens-add-last-notified-at.sql
@@ -1,0 +1,18 @@
+-- Migration: 2026-05-01-user-oauth-tokens-add-last-notified-at.sql
+-- Adds LastNotifiedAt column to dbo.UserOAuthTokens for LinkedIn token expiry notifications (Issue #852).
+-- Idempotent: safe to run multiple times.
+
+USE JJGNet;
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID('dbo.UserOAuthTokens')
+      AND name = 'LastNotifiedAt'
+)
+BEGIN
+    ALTER TABLE dbo.UserOAuthTokens
+        ADD LastNotifiedAt datetimeoffset NULL;
+END
+GO

--- a/scripts/database/table-create.sql
+++ b/scripts/database/table-create.sql
@@ -379,6 +379,7 @@ create table dbo.UserOAuthTokens
     LastUpdatedOn         datetimeoffset not null
         constraint DF_UserOAuthTokens_LastUpdatedOn
             default (getutcdate()),
+    LastNotifiedAt        datetimeoffset null,
     constraint UQ_UserOAuthTokens_User_Platform
         unique (CreatedByEntraOid, SocialMediaPlatformId)
 )

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs
@@ -179,4 +179,168 @@ public class UserOAuthTokenDataStoreTests : IDisposable
         Assert.NotNull(resultB); // Owner B's token should still exist
         Assert.Equal("token-b", resultB.AccessToken);
     }
+
+    [Fact]
+    public async Task GetExpiringWindowAsync_ReturnsOnlyTokensWithinWindow()
+    {
+        // Arrange
+        var platformIdA = await CreatePlatformAsync("LinkedIn");
+        var platformIdB = await CreatePlatformAsync("Twitter");
+        var platformIdC = await CreatePlatformAsync("Facebook");
+
+        var now = DateTimeOffset.UtcNow;
+        var windowFrom = now.AddDays(5);
+        var windowTo = now.AddDays(10);
+
+        // Token expiring before the window
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = "owner-a",
+            SocialMediaPlatformId = platformIdA,
+            AccessToken = "token-before-window",
+            AccessTokenExpiresAt = now.AddDays(2),
+            CreatedOn = now,
+            LastUpdatedOn = now
+        });
+
+        // Token expiring at the start of the window (inclusive)
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = "owner-b",
+            SocialMediaPlatformId = platformIdA,
+            AccessToken = "token-at-window-start",
+            AccessTokenExpiresAt = windowFrom,
+            CreatedOn = now,
+            LastUpdatedOn = now
+        });
+
+        // Token expiring within the window
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = "owner-a",
+            SocialMediaPlatformId = platformIdB,
+            AccessToken = "token-inside-window",
+            AccessTokenExpiresAt = now.AddDays(7),
+            CreatedOn = now,
+            LastUpdatedOn = now
+        });
+
+        // Token expiring at the end of the window (inclusive)
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = "owner-a",
+            SocialMediaPlatformId = platformIdC,
+            AccessToken = "token-at-window-end",
+            AccessTokenExpiresAt = windowTo,
+            CreatedOn = now,
+            LastUpdatedOn = now
+        });
+
+        // Token expiring after the window
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = "owner-b",
+            SocialMediaPlatformId = platformIdB,
+            AccessToken = "token-after-window",
+            AccessTokenExpiresAt = now.AddDays(15),
+            CreatedOn = now,
+            LastUpdatedOn = now
+        });
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var results = await _dataStore.GetExpiringWindowAsync(windowFrom, windowTo);
+
+        // Assert - only tokens within [windowFrom, windowTo] should be returned
+        Assert.Equal(3, results.Count);
+        Assert.Contains(results, t => t.AccessToken == "token-at-window-start");
+        Assert.Contains(results, t => t.AccessToken == "token-inside-window");
+        Assert.Contains(results, t => t.AccessToken == "token-at-window-end");
+        Assert.DoesNotContain(results, t => t.AccessToken == "token-before-window");
+        Assert.DoesNotContain(results, t => t.AccessToken == "token-after-window");
+    }
+
+    [Fact]
+    public async Task GetExpiringWindowAsync_ReturnsEmptyListWhenNoTokensInWindow()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        var now = DateTimeOffset.UtcNow;
+
+        _context.UserOAuthTokens.Add(new UserOAuthToken
+        {
+            CreatedByEntraOid = "owner-a",
+            SocialMediaPlatformId = platformId,
+            AccessToken = "token-outside-window",
+            AccessTokenExpiresAt = now.AddDays(30),
+            CreatedOn = now,
+            LastUpdatedOn = now
+        });
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var results = await _dataStore.GetExpiringWindowAsync(now.AddDays(5), now.AddDays(10));
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task UpdateLastNotifiedAtAsync_SetsLastNotifiedAt()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        const string ownerOid = "owner-a-oid";
+        await CreateTokenAsync(ownerOid, platformId);
+
+        var notifiedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var result = await _dataStore.UpdateLastNotifiedAtAsync(ownerOid, platformId, notifiedAt);
+
+        // Assert
+        Assert.True(result);
+
+        var token = await _dataStore.GetByUserAndPlatformAsync(ownerOid, platformId);
+        Assert.NotNull(token);
+        Assert.NotNull(token.LastNotifiedAt);
+        Assert.Equal(notifiedAt, token.LastNotifiedAt!.Value, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task UpdateLastNotifiedAtAsync_ReturnsFalseWhenTokenNotFound()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+
+        // Act - no token exists for this owner
+        var result = await _dataStore.UpdateLastNotifiedAtAsync("nonexistent-oid", platformId, DateTimeOffset.UtcNow);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task UpdateLastNotifiedAtAsync_DoesNotAffectOtherUsersTokens()
+    {
+        // Arrange
+        var platformId = await CreatePlatformAsync("LinkedIn");
+        const string ownerA = "owner-a-oid";
+        const string ownerB = "owner-b-oid";
+
+        await CreateTokenAsync(ownerA, platformId, "token-a");
+        await CreateTokenAsync(ownerB, platformId, "token-b");
+
+        var notifiedAt = DateTimeOffset.UtcNow;
+
+        // Act - update only owner A
+        await _dataStore.UpdateLastNotifiedAtAsync(ownerA, platformId, notifiedAt);
+
+        // Assert - owner B should not be affected
+        var tokenB = await _dataStore.GetByUserAndPlatformAsync(ownerB, platformId);
+        Assert.NotNull(tokenB);
+        Assert.Null(tokenB.LastNotifiedAt);
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/UserOAuthToken.cs
@@ -54,4 +54,9 @@ public class UserOAuthToken
     /// Gets or sets when this token was last updated
     /// </summary>
     public DateTimeOffset LastUpdatedOn { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the user was last notified of token expiry, or null if never notified
+    /// </summary>
+    public DateTimeOffset? LastNotifiedAt { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
@@ -123,4 +123,49 @@ public class UserOAuthTokenDataStore(
 
         return mapper.Map<List<UserOAuthToken>>(entities);
     }
+
+    /// <inheritdoc />
+    public async Task<List<UserOAuthToken>> GetExpiringWindowAsync(
+        DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
+    {
+        var entities = await broadcastingContext.UserOAuthTokens
+            .AsNoTracking()
+            .Where(t => t.AccessTokenExpiresAt >= from && t.AccessTokenExpiresAt <= to)
+            .ToListAsync(cancellationToken);
+
+        return mapper.Map<List<UserOAuthToken>>(entities);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateLastNotifiedAtAsync(
+        string ownerOid, int platformId, DateTimeOffset notifiedAt, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+
+        try
+        {
+            var existing = await broadcastingContext.UserOAuthTokens
+                .FirstOrDefaultAsync(
+                    t => t.CreatedByEntraOid == ownerOid && t.SocialMediaPlatformId == platformId,
+                    cancellationToken);
+
+            if (existing is null)
+            {
+                return false;
+            }
+
+            existing.LastNotifiedAt = notifiedAt;
+            return await broadcastingContext.SaveChangesAsync(cancellationToken) > 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to update LastNotifiedAt for owner {OwnerOid} and platform {PlatformId}",
+                LogSanitizer.Sanitize(ownerOid),
+                platformId);
+            return false;
+        }
+    }
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenDataStore.cs
@@ -45,4 +45,26 @@ public interface IUserOAuthTokenDataStore
     /// <returns>List of tokens expiring at or before the threshold</returns>
     Task<List<UserOAuthToken>> GetExpiringAsync(
         DateTimeOffset threshold, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all tokens whose AccessTokenExpiresAt falls within the window [<paramref name="from"/>, <paramref name="to"/>].
+    /// Used by notification Functions to find tokens expiring soon.
+    /// </summary>
+    /// <param name="from">Start of the expiry window (inclusive)</param>
+    /// <param name="to">End of the expiry window (inclusive)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of tokens whose access token expires within the window</returns>
+    Task<List<UserOAuthToken>> GetExpiringWindowAsync(
+        DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the LastNotifiedAt timestamp for a specific token.
+    /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="notifiedAt">The timestamp when the notification was sent</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if updated, false if the token was not found</returns>
+    Task<bool> UpdateLastNotifiedAtAsync(
+        string ownerOid, int platformId, DateTimeOffset notifiedAt, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IUserOAuthTokenManager.cs
@@ -46,4 +46,26 @@ public interface IUserOAuthTokenManager
     /// <returns>True if deleted, false if not found or error occurred</returns>
     Task<bool> DeleteAsync(
         string ownerOid, int platformId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all tokens whose AccessTokenExpiresAt falls within the window [<paramref name="from"/>, <paramref name="to"/>].
+    /// Used by notification Functions to find tokens expiring soon.
+    /// </summary>
+    /// <param name="from">Start of the expiry window (inclusive)</param>
+    /// <param name="to">End of the expiry window (inclusive)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of tokens whose access token expires within the window</returns>
+    Task<List<UserOAuthToken>> GetExpiringWindowAsync(
+        DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the LastNotifiedAt timestamp for a specific token.
+    /// </summary>
+    /// <param name="ownerOid">The Entra Object ID of the user</param>
+    /// <param name="platformId">The social media platform ID</param>
+    /// <param name="notifiedAt">The timestamp when the notification was sent</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if updated, false if the token was not found</returns>
+    Task<bool> UpdateLastNotifiedAtAsync(
+        string ownerOid, int platformId, DateTimeOffset notifiedAt, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/UserOAuthToken.cs
@@ -49,4 +49,9 @@ public class UserOAuthToken
     /// Gets or sets when this token was last updated
     /// </summary>
     public DateTimeOffset LastUpdatedOn { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the user was last notified of token expiry, or null if never notified
+    /// </summary>
+    public DateTimeOffset? LastNotifiedAt { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserOAuthTokenManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -56,5 +57,22 @@ public class UserOAuthTokenManager(IUserOAuthTokenDataStore dataStore) : IUserOA
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
 
         return dataStore.DeleteAsync(ownerOid, platformId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<List<UserOAuthToken>> GetExpiringWindowAsync(
+        DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
+    {
+        return dataStore.GetExpiringWindowAsync(from, to, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> UpdateLastNotifiedAtAsync(
+        string ownerOid, int platformId, DateTimeOffset notifiedAt, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(platformId);
+
+        return dataStore.UpdateLastNotifiedAtAsync(ownerOid, platformId, notifiedAt, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary

Implements the data layer required by the LinkedIn token expiry notification Function (issue #852).

### Changes

- **Domain model** (UserOAuthToken): Added LastNotifiedAt (DateTimeOffset?) property
- **EF entity** (Data.Sql/Models/UserOAuthToken): Added LastNotifiedAt (DateTimeOffset?) property
- **Migration script**: scripts/database/migrations/2026-05-01-user-oauth-tokens-add-last-notified-at.sql — idempotent ALTER TABLE that adds LastNotifiedAt datetimeoffset NULL to dbo.UserOAuthTokens
- **	able-create.sql**: Updated for fresh environment parity (AppHost replays this on init)
- **IUserOAuthTokenDataStore**: Added GetExpiringWindowAsync(from, to) and UpdateLastNotifiedAtAsync(ownerOid, platformId, notifiedAt)
- **UserOAuthTokenDataStore**: Implemented both new methods (.AsNoTracking() on the window query; targeted update on LastNotifiedAt)
- **IUserOAuthTokenManager**: Exposed GetExpiringWindowAsync and UpdateLastNotifiedAtAsync
- **UserOAuthTokenManager**: Delegated both new methods to the data store
- **UserOAuthTokenDataStoreTests**: Added 5 new tests covering window boundary conditions (inclusive from/to), empty window, UpdateLastNotifiedAt sets value, returns false when not found, and does not affect other users

### Files Changed

| File | Change |
|------|--------|
| scripts/database/migrations/2026-05-01-user-oauth-tokens-add-last-notified-at.sql | New migration |
| scripts/database/table-create.sql | Added LastNotifiedAt column |
| src/.../Domain/Models/UserOAuthToken.cs | Added LastNotifiedAt property |
| src/.../Data.Sql/Models/UserOAuthToken.cs | Added LastNotifiedAt property |
| src/.../Domain/Interfaces/IUserOAuthTokenDataStore.cs | Added two new method signatures |
| src/.../Domain/Interfaces/IUserOAuthTokenManager.cs | Added two new method signatures |
| src/.../Data.Sql/UserOAuthTokenDataStore.cs | Implemented GetExpiringWindowAsync and UpdateLastNotifiedAtAsync |
| src/.../Managers/UserOAuthTokenManager.cs | Delegated new methods to data store |
| src/.../Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs | 5 new unit tests |

Closes #852