### PR TITLE
chore: add Joe as human team member

### DIFF
--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -26,3 +26,4 @@
 | Azure AD app registrations, Key Vault secrets, secret rotation | Oracle | Ghost | Secret management & policy |
 | GitHub Actions CI/CD pipelines, Event Grid, Azure resource deployment | Link | Neo | Full infra-as-code ownership |
 | .NET Aspire AppHost, Bicep, local dev orchestration, container config | Cypher | Link | Local + staging environment config |
+| Manual human tasks (Azure portal, local secrets, config, secret rotation, permissions) | Joe | — | 👤 Human — coordinator pauses and waits for Joe |

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -24,6 +24,7 @@
 | Ghost | Security & Identity | `.squad/agents/ghost/charter.md` | ✅ Active |
 | Link | Platform & DevOps | `.squad/agents/link/charter.md` | ✅ Active |
 | Sparks | Frontend Developer | `.squad/agents/sparks/charter.md` | ✅ Active |
+| Joe | Human (Owner) | — | 👤 Human |
 
 ## Project Context
 


### PR DESCRIPTION
## Summary

Adds Joe (owner) as a human team member to the squad roster and routing table.

## Changes

- `.squad/team.md` — new row: `Joe | Human (Owner) | — | 👤 Human`
- `.squad/routing.md` — new row routing manual human tasks (Azure portal, local secrets, config, permissions) to Joe

## Why

The `squad:Joe` label was triggering a `⚠️ No squad member found` warning from the `squad-issue-assign.yml` workflow because Joe was not in the roster. With this change, `squad:Joe` issues receive a proper assignment acknowledgment.

Resolves #894
