### PR TITLE
fix(#890): guard expiring token window

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/UserOAuthTokenDataStoreTests.cs
@@ -288,6 +288,23 @@ public class UserOAuthTokenDataStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetExpiringWindowAsync_ThrowsWhenFromIsAfterTo()
+    {
+        // Arrange
+        var from = DateTimeOffset.UtcNow.AddDays(2);
+        var to = DateTimeOffset.UtcNow.AddDays(1);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => _dataStore.GetExpiringWindowAsync(from, to));
+
+        // Assert
+        Assert.Equal("from", exception.ParamName);
+        Assert.Contains("'from'", exception.Message);
+        Assert.Contains("'to'", exception.Message);
+    }
+
+    [Fact]
     public async Task UpdateLastNotifiedAtAsync_SetsLastNotifiedAt()
     {
         // Arrange

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/UserOAuthTokenDataStore.cs
@@ -128,6 +128,11 @@ public class UserOAuthTokenDataStore(
     public async Task<List<UserOAuthToken>> GetExpiringWindowAsync(
         DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
     {
+        if (from > to)
+        {
+            throw new ArgumentException($"'from' ({from:O}) must be less than or equal to 'to' ({to:O}).", nameof(from));
+        }
+
         var entities = await broadcastingContext.UserOAuthTokens
             .AsNoTracking()
             .Where(t => t.AccessTokenExpiresAt >= from && t.AccessTokenExpiresAt <= to)


### PR DESCRIPTION
## Summary
- add a fail-fast guard to `UserOAuthTokenDataStore.GetExpiringWindowAsync()` when `from` is after `to`
- cover the invalid window path with a focused unit test

## Testing
- `dotnet test .\src\JosephGuadagno.Broadcasting.Data.Sql.Tests\JosephGuadagno.Broadcasting.Data.Sql.Tests.csproj --configuration Release --filter "FullyQualifiedName~UserOAuthTokenDataStoreTests"`

Closes #890
