### PR TITLE
fix(#893): warn on missing Settings:WebBaseUrl

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/NotifyExpiringTokensTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/LinkedIn/NotifyExpiringTokensTests.cs
@@ -8,7 +8,7 @@ using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Functions.LinkedIn;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace JosephGuadagno.Broadcasting.Functions.Tests.LinkedIn;
@@ -20,6 +20,7 @@ public class NotifyExpiringTokensTests
     private readonly Mock<IEmailTemplateManager> _emailTemplateManager;
     private readonly Mock<IEmailSender> _emailSender;
     private readonly Mock<IConfiguration> _configuration;
+    private readonly Mock<ILogger<NotifyExpiringTokens>> _logger;
     private readonly NotifyExpiringTokens _sut;
 
     private static readonly TimerInfo FakeTimer = new();
@@ -31,6 +32,7 @@ public class NotifyExpiringTokensTests
         _emailTemplateManager = new Mock<IEmailTemplateManager>();
         _emailSender = new Mock<IEmailSender>();
         _configuration = new Mock<IConfiguration>();
+        _logger = new Mock<ILogger<NotifyExpiringTokens>>();
         _configuration.Setup(c => c["Settings:WebBaseUrl"]).Returns("https://example.com");
 
         _sut = new NotifyExpiringTokens(
@@ -38,7 +40,7 @@ public class NotifyExpiringTokensTests
             _userDataStore.Object,
             _emailTemplateManager.Object,
             _emailSender.Object,
-            NullLogger<NotifyExpiringTokens>.Instance,
+            _logger.Object,
             _configuration.Object);
     }
 
@@ -358,5 +360,58 @@ public class NotifyExpiringTokensTests
 
         Assert.NotNull(capturedBody);
         Assert.Contains("https://example.com/LinkedIn", capturedBody);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task RunAsync_WhenWebBaseUrlIsMissingOrEmpty_LogsWarningAndUsesRelativeLink(string? configuredWebBaseUrl)
+    {
+        var token = BuildToken(lastNotifiedAt: null);
+        var user = BuildUser();
+        var template = BuildTemplate();
+        string? capturedBody = null;
+
+        _configuration.Setup(c => c["Settings:WebBaseUrl"]).Returns(configuredWebBaseUrl);
+
+        _tokenManager
+            .Setup(m => m.GetExpiringWindowAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([token]);
+
+        _emailTemplateManager
+            .Setup(m => m.GetTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        _userDataStore
+            .Setup(m => m.GetByEntraObjectIdAsync(token.CreatedByEntraOid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _emailSender
+            .Setup(s => s.QueueEmail(It.IsAny<MailAddress>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<MailAddress, string, string, CancellationToken>((_, _, body, _) => capturedBody = body)
+            .Returns(Task.CompletedTask);
+
+        _tokenManager
+            .Setup(m => m.UpdateLastNotifiedAtAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await _sut.RunAsync(FakeTimer);
+
+        VerifyWarningLogged("Settings:WebBaseUrl is not configured");
+        Assert.NotNull(capturedBody);
+        Assert.Contains("href='/LinkedIn'", capturedBody);
+    }
+
+    private void VerifyWarningLogged(string expectedMessage)
+    {
+        _logger.Verify(
+            target => target.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains(expectedMessage, StringComparison.Ordinal)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/NotifyExpiringTokens.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/NotifyExpiringTokens.cs
@@ -34,9 +34,10 @@ public class NotifyExpiringTokens(
         var now = DateTimeOffset.UtcNow;
         logger.LogDebug("{FunctionName} started at: {StartedAt:f}",
             ConfigurationFunctionNames.LinkedInNotifyExpiringTokens, now);
+        var webBaseUrl = GetWebBaseUrl();
 
-        await NotifyWindowAsync(now, now.AddDays(7), SevenDayTemplateName, cancellationToken);
-        await NotifyWindowAsync(now, now.AddDays(1), OneDayTemplateName, cancellationToken);
+        await NotifyWindowAsync(now, now.AddDays(7), SevenDayTemplateName, webBaseUrl, cancellationToken);
+        await NotifyWindowAsync(now, now.AddDays(1), OneDayTemplateName, webBaseUrl, cancellationToken);
 
         logger.LogDebug("{FunctionName} completed at: {CompletedAt:f}",
             ConfigurationFunctionNames.LinkedInNotifyExpiringTokens, DateTimeOffset.UtcNow);
@@ -46,6 +47,7 @@ public class NotifyExpiringTokens(
         DateTimeOffset from,
         DateTimeOffset to,
         string templateName,
+        string webBaseUrl,
         CancellationToken cancellationToken)
     {
         var expiringTokens = await userOAuthTokenManager.GetExpiringWindowAsync(from, to, cancellationToken);
@@ -80,13 +82,14 @@ public class NotifyExpiringTokens(
                 continue;
             }
 
-            await TrySendNotificationAsync(token, template, cancellationToken);
+            await TrySendNotificationAsync(token, template, webBaseUrl, cancellationToken);
         }
     }
 
     private async Task TrySendNotificationAsync(
         UserOAuthToken token,
         Domain.Models.EmailTemplate template,
+        string webBaseUrl,
         CancellationToken cancellationToken)
     {
         var user = await applicationUserDataStore.GetByEntraObjectIdAsync(
@@ -103,7 +106,6 @@ public class NotifyExpiringTokens(
 
         try
         {
-            var webBaseUrl = configuration["Settings:WebBaseUrl"]?.TrimEnd('/') ?? string.Empty;
             var reauthUrl = $"{webBaseUrl}/LinkedIn";
 
             var body = RenderTemplate(template.Body, user.DisplayName ?? user.Email,
@@ -129,6 +131,20 @@ public class NotifyExpiringTokens(
                 LogSanitizer.Sanitize(token.CreatedByEntraOid),
                 token.SocialMediaPlatformId);
         }
+    }
+
+    private string GetWebBaseUrl()
+    {
+        var webBaseUrl = configuration["Settings:WebBaseUrl"]?.Trim();
+        if (string.IsNullOrWhiteSpace(webBaseUrl))
+        {
+            logger.LogWarning(
+                "{FunctionName}: Settings:WebBaseUrl is not configured. Re-auth links in LinkedIn expiry emails will be relative paths.",
+                ConfigurationFunctionNames.LinkedInNotifyExpiringTokens);
+            return string.Empty;
+        }
+
+        return webBaseUrl.TrimEnd('/');
     }
 
     private static string RenderTemplate(string templateBody, string displayName, DateTimeOffset expiresAt, string reauthUrl)


### PR DESCRIPTION
## Summary
- resolve `Settings:WebBaseUrl` once per function run
- log a warning when the setting is missing or whitespace so operators can spot bad email links
- add coverage for warning logging and relative fallback links

## Testing
- `dotnet test .\src\JosephGuadagno.Broadcasting.Functions.Tests\JosephGuadagno.Broadcasting.Functions.Tests.csproj --configuration Release --filter "FullyQualifiedName~NotifyExpiringTokensTests"`

Closes #893
