### PR TITLE
fix(#667): pin SocialMediaPlatforms seed IDs with IDENTITY_INSERT

### DIFF
--- a/scripts/database/data-seed.sql
+++ b/scripts/database/data-seed.sql
@@ -81,21 +81,25 @@ IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.Roles WHERE Name = N'Viewer')
 --       See scripts/database/migrations/2026-04-02-rbac-user-approval.sql for the template SQL.
 
 -- Seed the SocialMediaPlatforms table (Epic #667)
-IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Twitter')
-    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
-    VALUES (N'Twitter', N'https://twitter.com', N'bi-twitter-x', 1)
-IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'BlueSky')
-    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
-    VALUES (N'BlueSky', N'https://bsky.app', N'bi-bluesky', 1)
-IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'LinkedIn')
-    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
-    VALUES (N'LinkedIn', N'https://www.linkedin.com', N'bi-linkedin', 1)
-IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Facebook')
-    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
-    VALUES (N'Facebook', N'https://www.facebook.com', N'bi-facebook', 1)
-IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Mastodon')
-    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Name, Url, Icon, IsActive)
-    VALUES (N'Mastodon', N'https://mastodon.social', N'bi-mastodon', 1)
+-- IMPORTANT: IDs here are pinned and must match SocialMediaPlatformIds.cs constants.
+-- SET IDENTITY_INSERT guarantees predictable IDs regardless of insertion order or prior state.
+SET IDENTITY_INSERT JJGNet.dbo.SocialMediaPlatforms ON;
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Id = 1)
+    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Id, Name, Url, Icon, IsActive)
+    VALUES (1, N'Twitter', N'https://twitter.com', N'bi-twitter-x', 1)
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Id = 2)
+    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Id, Name, Url, Icon, IsActive)
+    VALUES (2, N'BlueSky', N'https://bsky.app', N'bi-bluesky', 1)
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Id = 3)
+    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Id, Name, Url, Icon, IsActive)
+    VALUES (3, N'LinkedIn', N'https://www.linkedin.com', N'bi-linkedin', 1)
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Id = 4)
+    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Id, Name, Url, Icon, IsActive)
+    VALUES (4, N'Facebook', N'https://www.facebook.com', N'bi-facebook', 1)
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.SocialMediaPlatforms WHERE Id = 5)
+    INSERT INTO JJGNet.dbo.SocialMediaPlatforms (Id, Name, Url, Icon, IsActive)
+    VALUES (5, N'Mastodon', N'https://mastodon.social', N'bi-mastodon', 1)
+SET IDENTITY_INSERT JJGNet.dbo.SocialMediaPlatforms OFF;
 
 -- Seed CredentialSetupDocumentationUrl for SocialMediaPlatforms (Issue #812)
 UPDATE JJGNet.dbo.SocialMediaPlatforms SET CredentialSetupDocumentationUrl = N'/help/socialMediaPlatforms/twitter'

--- a/src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs
@@ -1,7 +1,10 @@
 namespace JosephGuadagno.Broadcasting.Domain.Constants;
 
 /// <summary>
-/// Constant IDs for social media platforms matching database seed values
+/// Constant IDs for social media platforms matching database seed values.
+/// These IDs are pinned via SET IDENTITY_INSERT in
+/// <c>scripts/database/data-seed.sql</c>.
+/// If a new platform is added, update BOTH that seed script and this file.
 /// </summary>
 public static class SocialMediaPlatformIds
 {


### PR DESCRIPTION
## Summary

Pins `SocialMediaPlatforms` seed row IDs using `SET IDENTITY_INSERT` so they are deterministic regardless of insertion order in a fresh database.

## Problem

The previous seed used `IF NOT EXISTS ... WHERE Name = N'...'` without explicit `Id` values. This relied on IDENTITY auto-increment order — fragile because any row inserted before these in a fresh DB would shift the IDs. `SocialMediaPlatformIds.LinkedIn = 3` is used in production Functions to look up the LinkedIn platform; a wrong ID causes **silent dropped LinkedIn posts** with no exception.

## Changes

### `scripts/database/data-seed.sql`
- Replaced name-based `IF NOT EXISTS` guards with ID-based guards
- Added `SET IDENTITY_INSERT JJGNet.dbo.SocialMediaPlatforms ON/OFF` wrapper
- Supplied explicit `Id` values (1–5) matching `SocialMediaPlatformIds.cs` constants

### `src/JosephGuadagno.Broadcasting.Domain/Constants/SocialMediaPlatformIds.cs`
- Updated class-level `<summary>` XML doc to document the seed contract and cross-reference `data-seed.sql`

## Testing

- Seed script is idempotent: re-running on an existing DB with correct IDs is a no-op (guards check by `Id`)
- Existing unit tests unchanged — no business logic modified

## Related

Closes #667
- Unblocks PRs #911 and #912
