### PR TITLE
feat(#935): add IMemoryCache caching to SyndicationFeedSourceManager and YouTubeSourceManager

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -539,3 +539,111 @@ That made a stacked PR the safest reviewable shape. It keeps one issue per PR, p
 - PR #911: `feat(#897): define ISocialMediaPublisher common interface`
 - PR #912: `refactor(#902): move LinkedIn composition to manager`
 
+---
+
+# Decision: .squad/ Housekeeping PR Policy
+
+**Date:** 2026-05-08T08:37:47.421-07:00
+**Author:** Neo
+**Issue:** #803
+**PR:** #934
+**Status:** Implemented — merged to main
+
+## Decision
+
+`.squad/`-only PRs bypass the `pr-metadata` CI validation gate. Any PR where **every** changed file is under `.squad/` will skip branch-naming, PR-title-format, and single-issue-linking checks.
+
+## Rationale
+
+Agent housekeeping commits (state, decisions, history updates) are not feature work. Forcing them through the same strict naming and issue-linking gate as code PRs is unnecessary friction. The bypass is implemented in the existing `pr-metadata` job — no new infrastructure.
+
+## Implementation
+
+Modified `.github/workflows/ci.yml` `pr-metadata` job. After the Dependabot bypass, added:
+
+```bash
+changed_files="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename' 2>/dev/null || true)"
+if [[ -n "$changed_files" ]]; then
+  non_squad_files="$(printf '%s\n' "$changed_files" | grep -v '^\.squad/' || true)"
+  if [[ -z "$non_squad_files" ]]; then
+    echo ".squad/-only PR on branch '$BRANCH_NAME' — skipping PR metadata validation."
+    exit 0
+  fi
+fi
+```
+
+## Security Properties
+
+- **Fail-secure**: API failure → validation proceeds normally. No bypass on error.
+- **`build-and-test` unaffected**: runs on every PR.
+- **`codeql-analysis` unaffected**: runs on every PR.
+- **Scope-limited**: one non-`.squad/` file forces full validation.
+
+## Team Impact
+
+Scribe (or any agent) can now open a PR from any branch containing only `.squad/` changes without following the conventional-commit PR title or `Closes #N` body format.
+
+---
+
+# Decision: IMemoryCache caching pattern for dual-overload managers
+
+**Date:** 2026-05
+**Author:** Trinity
+**Related:** Issue #935, PR #938, Issue #78
+
+## Context
+
+`SyndicationFeedSourceManager` and `YouTubeSourceManager` each expose two `GetAllAsync()` overloads:
+- `GetAllAsync(CancellationToken)` — global (all records)
+- `GetAllAsync(string ownerEntraOid, CancellationToken)` — user-scoped
+
+The `SocialMediaPlatformManager` was the established caching reference, but it only has list-scoped and id-scoped keys (`CacheKeyAllActive`, `CacheKeyAllIncludingInactive`, `CacheKeyById`). The dual-overload managers require a different key strategy.
+
+## Decision
+
+Use two cache keys per manager:
+
+- **Global key** (`*_All`): covers `GetAllAsync()` with no OID filter
+- **Per-user key** (`*_User_{ownerEntraOid}`): covers `GetAllAsync(ownerEntraOid)`
+
+```csharp
+private const string CacheKeyAll = "SyndicationFeedSources_All";
+private static string CacheKeyByUser(string ownerEntraOid) => $"SyndicationFeedSources_User_{ownerEntraOid}";
+```
+
+Invalidation rules:
+- `SaveAsync(entity)` / `DeleteAsync(entity)`: call `InvalidateUserCaches(entity.CreatedByEntraOid)` — removes both global and per-user key
+- `DeleteAsync(int primaryKey)`: remove only global key (`_cache.Remove(CacheKeyAll)`) — no OID available; user-scoped cache expires naturally within 5 minutes
+
+## Consequences
+
+- Cache hit rates are higher since global and user-scoped queries are cached independently
+- A `DeleteAsync(int)` leaves a stale user-scoped entry for up to 5 minutes — acceptable for this use case
+- All managers that have both global and user-scoped `GetAllAsync` overloads should follow this same dual-key pattern
+
+---
+
+# 2026-05-08: PR #934 merged — #803 complete
+
+**By:** Joe (jguadagno)
+**What:** PR #934 (.squad-only CI bypass for pr-metadata job) has been merged to main. Issue #803 is closed.
+**Why:** Confirmed by Joe.
+
+## Summary
+
+Sprint 31 (Milestone 27) active with focus on caching enhancements. PR #934 merged to main:
+- `.squad/`-only PRs now bypass `pr-metadata` branch-naming, title-format, and issue-linking checks
+- Implementation: `pr-metadata` job in `.github/workflows/ci.yml` detects when all changed files are under `.squad/` and exits early
+- Security: fail-secure (API failure → proceeds with normal validation), `build-and-test` and `codeql-analysis` unaffected
+- Impact: Scribe and other agents can open `.squad/`-only PRs from any branch without forced conventional-commit naming
+
+## Caching Work in Progress (Sprint 31)
+
+Four caching issues assigned to Milestone 27:
+- **#78** (parent): Add caching to WebApi
+- **#935** (P3): Add caching to SyndicationFeedSourceManager and YouTubeSourceManager — PR #938 open
+- **#936** (P1): Add caching to MessageTemplateManager — in progress
+- **#937** (P2): Add user-scoped caching to Engagements, Schedules, and UserPublisherSettings managers — in progress
+
+Pattern: Dual-key `IMemoryCache` with 5-minute absolute expiry (global + user-scoped keys where applicable).
+

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,65 +1,53 @@
 # Team Focus — Now
 
-> **Last updated:** 2026-05-01T12:00:00Z
-> **Sprint:** 30 — Milestone 26
-> **Status:** Sprint 29 CLOSED (PR #909 #890/#893 + PR #910 misc fixes merged to main). Sprint 30 ACTIVE. #897 (ISocialMediaPublisher interface) COMPLETE. #902→#899–#900–#901 composition refactor sequence UNBLOCKED.
-> **Next:** #902 (LinkedIn composition) starts immediately; #899–#900–#901 (Twitter, Facebook, Bluesky) follow after #902 pattern validation. Joe executes parallel tasks (#892, #856, #896) independently.
+> **Last updated:** 2026-05-08T16:15:00Z
+> **Sprint:** 31 — Milestone 27
+> **Status:** Sprint 30 CLOSED (ISocialMediaPublisher #897 complete; composition refactor #902 merged). Sprint 31 ACTIVE — caching enhancements. #803 COMPLETE (PR #934 merged to main).
+> **Next:** Sprint 31 caching work: #935 (P3, PR #938 open), #936 (P1), #937 (P2) under way; #933 (speaking engagement functions) in progress; #930 (NuGet deprecation) queued.
 
 ## Current Focus
 
-**Sprint 28 — COMPLETE** ✅
-- ✅ #852 — LinkedIn OAuth token expiry data layer (merged)
-- ✅ #853 — Token expiry notification API (merged)
-- ✅ #904 — Code quality session (merged PR #908)
-
-**Sprint 29 — COMPLETE** ✅
-- ✅ #890 — Add from ≤ to guard to GetExpiringWindowAsync (Trinity implementation + Tank tests)
-- ✅ #893 — Log warning when Settings:WebBaseUrl is missing (Trinity implementation + Tank tests)
-- ✅ PR #909 merged (#890 + #893 implementation)
-- ✅ PR #910 merged (misc fixes)
-
-**Sprint 30 — ACTIVE** 🔄
+**Sprint 30 — COMPLETE** ✅
 - ✅ #897 — Define ISocialMediaPublisher common interface (COMPLETE — test coverage finalized, DI wiring verified)
-- 🔜 #902 — Move LinkedIn message composition to LinkedInManager (start immediately after #897 merge)
-- 🔜 #899, #900, #901 — Move Twitter/Facebook/Bluesky message composition (parallel after #902 pattern validation)
+- ✅ #902 — Move LinkedIn message composition to LinkedInManager (COMPLETE — merged to main)
 
-**Joe's Parallel Tasks (Non-blocking):**
-- ⏳ #892 — Add Settings:WebBaseUrl config to Functions and Web (post-#893)
-- ⏳ #856 — Retire LinkedIn Key Vault secrets in Azure Portal
-- ⏳ #896 — Move jjgnet resource group to new Azure subscription
+**Sprint 31 — ACTIVE** 🔄
+- ✅ #803 — Allow `.squad` updates to commit from main (COMPLETE — PR #934 merged to main)
+- 🔜 #78 — Add caching to WebApi (parent issue)
+  - 🔜 #935 — Add caching to SyndicationFeedSourceManager and YouTubeSourceManager (P3, PR #938 open)
+  - 🔜 #936 — Add caching to MessageTemplateManager (P1)
+  - 🔜 #937 — Add user-scoped caching to Engagements, Schedules, UserPublisherSettings managers (P2)
+- 🔜 #933 — Create Azure Functions for handling new speaking engagements (Trinity agent running)
+- ⏳ #930 — NuGet package AspNetCore.HealthChecks.AzureStorage has been deprecated (queued for Trinity)
 
-**Goal:** Sprint 30 unblocks #897 (ISocialMediaPublisher interface) COMPLETE. Composition refactor sequence (#902→#899–#900–#901) begins immediately. Joe executes parallel infrastructure tasks independently.
+**Goal:** Sprint 31 delivers #803 completion (PR #934 merged) + caching phase 1 (SyndicationFeed/YouTube, MessageTemplate, user-scoped managers).
 
-## Key Patterns (Sprint 30)
+## Key Patterns (Sprint 31)
 
-1. **Shared publisher interface:** `ISocialMediaPublisher` with platform identity + unified `PublishAsync(SocialMediaPublishRequest)` entry point
-2. **Three-layer test strategy:** Interface shape + inheritance validation + platform-specific routing proof (avoids test duplication)
-3. **Composition refactor sequence:** #902 (LinkedIn pattern reference) → #899–#900–#901 (Twitter/Facebook/Bluesky parallel) after pattern validation
-4. **Risk mitigation:** Serial pattern (#902 first) reduces merge conflicts from ISocialMediaPublisher implementation divergence
-5. **Backward compatibility:** Existing manager interfaces + queue handlers unchanged; shared contract enables future runtime discovery
+1. **Dual-key caching:** Global + user-scoped `IMemoryCache` with 5-minute absolute expiry
+2. **Cache invalidation:** Remove both keys on Save/Delete(entity); global key only on Delete(id)
+3. **Stale tolerance:** Up to 5 minutes for user-scoped entries when Delete(id) only available
 
 ## Standing Work
 
-- #897–#902: ISocialMediaPublisher interface + per-platform composition refactor (Sprint 30, #897 COMPLETE)
-- #902: LinkedIn composition refactor (Tank team, next assignment post-#897 merge)
-- #899–#900–#901: Twitter, Facebook, Bluesky composition refactors (Tank team, parallel after #902 validation)
-- #892: Settings:WebBaseUrl config (Joe, post-#893)
-- #856, #896: Joe's Azure Portal + infrastructure tasks (non-blocking, async)
+- #78: Caching enhancements (parent issue, Sprint 31)
+- #933: Speaking engagement functions (Trinity, in progress)
+- #930: NuGet deprecation (queued for Trinity)
 - #724: Multi-user teams/groups — Deferred pending explicit Joe confirmation that #609 is 100% production-ready
-- #803: Allow `.squad` updates to commit from main (squad:neo, low priority)
 
 ## Team Composition
 
-**Sprint 30 (Active):**
-- #897 (ISocialMediaPublisher) — ✅ COMPLETE
-- #902 (LinkedIn composition) — Next assignment pending
-- Joe — Parallel tasks (#892, #856, #896) — can execute independently
+**Sprint 31 (Active):**
+- #78 / #935–#937 — Caching work (Trinity)
+- #933 — Speaking engagements (Trinity agent)
+- #930 — NuGet deprecation (queued)
+- Joe — Parallel infrastructure tasks
 
 **Rotating Roles:** Squad roster available in `.squad/team.md`
 
 ---
 
-**Last Updated:** 2026-05-01T12:00:00Z
-**Sprint:** 30 (ISocialMediaPublisher + Composition Refactor) — #897 COMPLETE
-**Current Focus:** #902 (LinkedIn composition refactor) — begins immediately post-#897 merge; #899–#900–#901 ready for parallel execution after #902 pattern validation
-**Next Decision Point:** #902 completion unlocks #899–#900–#901 parallel execution
+**Last Updated:** 2026-05-08T16:15:00Z
+**Sprint:** 31 (Caching enhancements + housekeeping PR bypass) — #803 COMPLETE, #78 in progress
+**Current Focus:** #935 (P3) PR #938 open; #936 (P1) and #937 (P2) in progress
+**Next Decision Point:** #935–#937 completion → Sprint 32 readiness

--- a/src/JosephGuadagno.Broadcasting.FixSourceDataShortUrl/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.FixSourceDataShortUrl/Program.cs
@@ -50,6 +50,7 @@ services.AddSingleton<IBitlyConfiguration>(new BitlyConfiguration
 });
 services.AddSingleton<Bitly>();
 services.AddDbContext<BroadcastingContext>(options => options.UseSqlServer("name=ConnectionStrings:JJGNetDatabaseSqlServer"));
+services.AddMemoryCache();
 services.AddSingleton<IYouTubeSourceDataStore, YouTubeSourceDataStore>();
 services.AddSingleton<IYouTubeSourceManager, YouTubeSourceManager>();
 services.AddSingleton<ISyndicationFeedSourceDataStore, SyndicationFeedSourceDataStore>();

--- a/src/JosephGuadagno.Broadcasting.Functions/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Program.cs
@@ -176,6 +176,7 @@ void ConfigureKeyVault(IServiceCollection services)
 void ConfigureFunction(IServiceCollection services)
 {
     services.AddHttpClient();
+    services.AddMemoryCache();
 
     services.TryAddSingleton<IEventPublisher, EventPublisher>();
 

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/SyndicationFeedSourceManagerTests.cs
@@ -1,19 +1,23 @@
-﻿using Moq;
+﻿using FluentAssertions;
+using Moq;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers.Tests;
 
 public class SyndicationFeedSourceManagerTests
 {
     private readonly Mock<ISyndicationFeedSourceDataStore> _repository;
+    private readonly IMemoryCache _cache;
     private readonly SyndicationFeedSourceManager _syndicationFeedSourceManager;
 
     public SyndicationFeedSourceManagerTests()
     {
         _repository = new Mock<ISyndicationFeedSourceDataStore>();
-        _syndicationFeedSourceManager = new SyndicationFeedSourceManager(_repository.Object);
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _syndicationFeedSourceManager = new SyndicationFeedSourceManager(_repository.Object, _cache);
     }
 
     [Fact]
@@ -75,6 +79,55 @@ public class SyndicationFeedSourceManagerTests
         // Assert
         Assert.Equal(sources, result);
         _repository.Verify(r => r.GetAllAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_OnCacheHit_ShouldReturnCachedResultWithoutCallingDataStore()
+    {
+        // Arrange
+        var sources = new List<SyndicationFeedSource> { new SyndicationFeedSource { Id = 1, FeedIdentifier = "Test", CreatedByEntraOid = "" } };
+        _repository.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(sources);
+
+        // Act — first call populates cache, second is served from cache
+        await _syndicationFeedSourceManager.GetAllAsync();
+        var result = await _syndicationFeedSourceManager.GetAllAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(sources);
+        _repository.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_OnCacheHit_ShouldReturnCachedResultWithoutCallingDataStore()
+    {
+        // Arrange
+        var sources = new List<SyndicationFeedSource> { new SyndicationFeedSource { Id = 1, FeedIdentifier = "Test", CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>())).ReturnsAsync(sources);
+
+        // Act — first call populates cache, second is served from cache
+        await _syndicationFeedSourceManager.GetAllAsync("owner-1");
+        var result = await _syndicationFeedSourceManager.GetAllAsync("owner-1");
+
+        // Assert
+        result.Should().BeEquivalentTo(sources);
+        _repository.Verify(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldInvalidateCacheSoNextCallHitsDataStore()
+    {
+        // Arrange
+        var source = new SyndicationFeedSource { Id = 1, FeedIdentifier = "Test", CreatedByEntraOid = "owner-1" };
+        _repository.Setup(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>())).ReturnsAsync(new List<SyndicationFeedSource> { source });
+        _repository.Setup(r => r.SaveAsync(source, default)).ReturnsAsync(OperationResult<SyndicationFeedSource>.Success(source));
+
+        // Act — populate cache, then save (invalidates), then fetch again
+        await _syndicationFeedSourceManager.GetAllAsync("owner-1");
+        await _syndicationFeedSourceManager.SaveAsync(source);
+        await _syndicationFeedSourceManager.GetAllAsync("owner-1");
+
+        // Assert — data store called twice: before and after invalidation
+        _repository.Verify(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/YouTubeSourceManagerTests.cs
@@ -1,19 +1,23 @@
-﻿using Moq;
+﻿using FluentAssertions;
+using Moq;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers.Tests;
 
 public class YouTubeSourceManagerTests
 {
     private readonly Mock<IYouTubeSourceDataStore> _repository;
+    private readonly IMemoryCache _cache;
     private readonly YouTubeSourceManager _youTubeSourceManager;
 
     public YouTubeSourceManagerTests()
     {
         _repository = new Mock<IYouTubeSourceDataStore>();
-        _youTubeSourceManager = new YouTubeSourceManager(_repository.Object);
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _youTubeSourceManager = new YouTubeSourceManager(_repository.Object, _cache);
     }
 
     [Fact]
@@ -75,6 +79,55 @@ public class YouTubeSourceManagerTests
         // Assert
         Assert.Equal(sources, result);
         _repository.Verify(r => r.GetAllAsync("owner-1", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_OnCacheHit_ShouldReturnCachedResultWithoutCallingDataStore()
+    {
+        // Arrange
+        var sources = new List<YouTubeSource> { new YouTubeSource { Id = 1, CreatedByEntraOid = "" } };
+        _repository.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(sources);
+
+        // Act — first call populates cache, second is served from cache
+        await _youTubeSourceManager.GetAllAsync();
+        var result = await _youTubeSourceManager.GetAllAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(sources);
+        _repository.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOwnerOid_OnCacheHit_ShouldReturnCachedResultWithoutCallingDataStore()
+    {
+        // Arrange
+        var sources = new List<YouTubeSource> { new YouTubeSource { Id = 1, CreatedByEntraOid = "owner-1" } };
+        _repository.Setup(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>())).ReturnsAsync(sources);
+
+        // Act — first call populates cache, second is served from cache
+        await _youTubeSourceManager.GetAllAsync("owner-1");
+        var result = await _youTubeSourceManager.GetAllAsync("owner-1");
+
+        // Assert
+        result.Should().BeEquivalentTo(sources);
+        _repository.Verify(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldInvalidateCacheSoNextCallHitsDataStore()
+    {
+        // Arrange
+        var source = new YouTubeSource { Id = 1, CreatedByEntraOid = "owner-1" };
+        _repository.Setup(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>())).ReturnsAsync(new List<YouTubeSource> { source });
+        _repository.Setup(r => r.SaveAsync(source, default)).ReturnsAsync(OperationResult<YouTubeSource>.Success(source));
+
+        // Act — populate cache, then save (invalidates), then fetch again
+        await _youTubeSourceManager.GetAllAsync("owner-1");
+        await _youTubeSourceManager.SaveAsync(source);
+        await _youTubeSourceManager.GetAllAsync("owner-1");
+
+        // Assert — data store called twice: before and after invalidation
+        _repository.Verify(r => r.GetAllAsync("owner-1", It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers/SyndicationFeedSourceManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/SyndicationFeedSourceManager.cs
@@ -6,16 +6,25 @@ using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers;
 
 public class SyndicationFeedSourceManager : ISyndicationFeedSourceManager
 {
     private readonly ISyndicationFeedSourceDataStore _syndicationFeedSourceDataStore;
+    private readonly IMemoryCache _cache;
 
-    public SyndicationFeedSourceManager(ISyndicationFeedSourceDataStore syndicationFeedSourceDataStore)
+    private const string CacheKeyAll = "SyndicationFeedSources_All";
+    private static string CacheKeyByUser(string ownerEntraOid) => $"SyndicationFeedSources_User_{ownerEntraOid}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public SyndicationFeedSourceManager(ISyndicationFeedSourceDataStore syndicationFeedSourceDataStore, IMemoryCache cache)
     {
         _syndicationFeedSourceDataStore = syndicationFeedSourceDataStore;
+        _cache = cache;
     }
 
     public async Task<SyndicationFeedSource> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
@@ -25,27 +34,48 @@ public class SyndicationFeedSourceManager : ISyndicationFeedSourceManager
 
     public async Task<OperationResult<SyndicationFeedSource>> SaveAsync(SyndicationFeedSource entity, CancellationToken cancellationToken = default)
     {
-        return await _syndicationFeedSourceDataStore.SaveAsync(entity, cancellationToken);
+        var result = await _syndicationFeedSourceDataStore.SaveAsync(entity, cancellationToken);
+        InvalidateUserCaches(entity.CreatedByEntraOid);
+        return result;
     }
 
     public async Task<List<SyndicationFeedSource>> GetAllAsync(CancellationToken cancellationToken = default)
     {
-        return await _syndicationFeedSourceDataStore.GetAllAsync(cancellationToken);
+        if (_cache.TryGetValue(CacheKeyAll, out List<SyndicationFeedSource>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _syndicationFeedSourceDataStore.GetAllAsync(cancellationToken);
+        _cache.Set(CacheKeyAll, result, CacheOptions);
+        return result;
     }
 
     public async Task<List<SyndicationFeedSource>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
     {
-        return await _syndicationFeedSourceDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        var cacheKey = CacheKeyByUser(ownerEntraOid);
+        if (_cache.TryGetValue(cacheKey, out List<SyndicationFeedSource>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _syndicationFeedSourceDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        _cache.Set(cacheKey, result, CacheOptions);
+        return result;
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(SyndicationFeedSource entity, CancellationToken cancellationToken = default)
     {
-        return await _syndicationFeedSourceDataStore.DeleteAsync(entity, cancellationToken);
+        var result = await _syndicationFeedSourceDataStore.DeleteAsync(entity, cancellationToken);
+        InvalidateUserCaches(entity.CreatedByEntraOid);
+        return result;
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(int primaryKey, CancellationToken cancellationToken = default)
     {
-        return await _syndicationFeedSourceDataStore.DeleteAsync(primaryKey, cancellationToken);
+        var result = await _syndicationFeedSourceDataStore.DeleteAsync(primaryKey, cancellationToken);
+        _cache.Remove(CacheKeyAll);
+        return result;
     }
 
     public async Task<SyndicationFeedSource?> GetByUrlAsync(string url, CancellationToken cancellationToken = default)
@@ -81,5 +111,11 @@ public class SyndicationFeedSourceManager : ISyndicationFeedSourceManager
     public async Task<PagedResult<SyndicationFeedSource>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "title", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default)
     {
         return await _syndicationFeedSourceDataStore.GetAllAsync(ownerEntraOid, page, pageSize, sortBy, sortDescending, filter, cancellationToken);
+    }
+
+    private void InvalidateUserCaches(string ownerEntraOid)
+    {
+        _cache.Remove(CacheKeyAll);
+        _cache.Remove(CacheKeyByUser(ownerEntraOid));
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/YouTubeSourceManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/YouTubeSourceManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -5,16 +6,25 @@ using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers;
 
 public class YouTubeSourceManager : IYouTubeSourceManager
 {
     private readonly IYouTubeSourceDataStore _youTubeSourceDataStore;
+    private readonly IMemoryCache _cache;
 
-    public YouTubeSourceManager(IYouTubeSourceDataStore youTubeSourceDataStore)
+    private const string CacheKeyAll = "YouTubeSources_All";
+    private static string CacheKeyByUser(string ownerEntraOid) => $"YouTubeSources_User_{ownerEntraOid}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public YouTubeSourceManager(IYouTubeSourceDataStore youTubeSourceDataStore, IMemoryCache cache)
     {
         _youTubeSourceDataStore = youTubeSourceDataStore;
+        _cache = cache;
     }
 
     public async Task<YouTubeSource> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
@@ -24,27 +34,48 @@ public class YouTubeSourceManager : IYouTubeSourceManager
 
     public async Task<OperationResult<YouTubeSource>> SaveAsync(YouTubeSource entity, CancellationToken cancellationToken = default)
     {
-        return await _youTubeSourceDataStore.SaveAsync(entity, cancellationToken);
+        var result = await _youTubeSourceDataStore.SaveAsync(entity, cancellationToken);
+        InvalidateUserCaches(entity.CreatedByEntraOid);
+        return result;
     }
 
     public async Task<List<YouTubeSource>> GetAllAsync(CancellationToken cancellationToken = default)
     {
-        return await _youTubeSourceDataStore.GetAllAsync(cancellationToken);
+        if (_cache.TryGetValue(CacheKeyAll, out List<YouTubeSource>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _youTubeSourceDataStore.GetAllAsync(cancellationToken);
+        _cache.Set(CacheKeyAll, result, CacheOptions);
+        return result;
     }
 
     public async Task<List<YouTubeSource>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
     {
-        return await _youTubeSourceDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        var cacheKey = CacheKeyByUser(ownerEntraOid);
+        if (_cache.TryGetValue(cacheKey, out List<YouTubeSource>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _youTubeSourceDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        _cache.Set(cacheKey, result, CacheOptions);
+        return result;
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(YouTubeSource entity, CancellationToken cancellationToken = default)
     {
-        return await _youTubeSourceDataStore.DeleteAsync(entity, cancellationToken);
+        var result = await _youTubeSourceDataStore.DeleteAsync(entity, cancellationToken);
+        InvalidateUserCaches(entity.CreatedByEntraOid);
+        return result;
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(int primaryKey, CancellationToken cancellationToken = default)
     {
-        return await _youTubeSourceDataStore.DeleteAsync(primaryKey, cancellationToken);
+        var result = await _youTubeSourceDataStore.DeleteAsync(primaryKey, cancellationToken);
+        _cache.Remove(CacheKeyAll);
+        return result;
     }
 
     public async Task<YouTubeSource?> GetByUrlAsync(string url, CancellationToken cancellationToken = default)
@@ -70,5 +101,11 @@ public class YouTubeSourceManager : IYouTubeSourceManager
     public async Task<PagedResult<YouTubeSource>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "title", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default)
     {
         return await _youTubeSourceDataStore.GetAllAsync(ownerEntraOid, page, pageSize, sortBy, sortDescending, filter, cancellationToken);
+    }
+
+    private void InvalidateUserCaches(string ownerEntraOid)
+    {
+        _cache.Remove(CacheKeyAll);
+        _cache.Remove(CacheKeyByUser(ownerEntraOid));
     }
 }


### PR DESCRIPTION
## Summary

Adds `IMemoryCache` caching to `SyndicationFeedSourceManager` and `YouTubeSourceManager` as part of #78 (Add caching to WebApi).

## Changes

### SyndicationFeedSourceManager
- Inject `IMemoryCache` via constructor
- Cache `GetAllAsync()` (global key `SyndicationFeedSources_All`) and `GetAllAsync(ownerEntraOid)` (per-user key `SyndicationFeedSources_User_{oid}`)
- 5-minute absolute expiry on all cache entries
- Invalidate both keys on `SaveAsync`/`DeleteAsync(entity)`; invalidate only global key on `DeleteAsync(int)` (no OID available)

### YouTubeSourceManager
- Same pattern with `YouTubeSources_All` / `YouTubeSources_User_{oid}` keys

### DI registrations
- Add `services.AddMemoryCache()` to `Functions/Program.cs` (was missing, pre-existing bug)
- Add `services.AddMemoryCache()` to `FixSourceDataShortUrl/Program.cs` (was missing)

### Tests
- 6 new tests (3 per manager): cache-hit (second call skips data store), user-scoped cache-hit, `SaveAsync` invalidation
- Uses real `MemoryCache` instance per pattern established in `SocialMediaPlatformManagerTests`

## Test Results

140 tests passed (134 existing + 6 new), 0 failed

Closes #935
Part of #78