### PR TITLE
feat(#933): add ProcessNewSpeakingEngagementFired Azure Functions for each social media platform

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -166,6 +166,27 @@ For speaking engagements, need 4 new functions, one per platform, with names add
 - **Squad assignment patterns:** `squad:cypher` = GitHub Actions CI/CD + Azure infrastructure deployment; `squad:trinity` = API + Azure Functions business logic + persistence layer. Don't confuse Azure resource management (Cypher) with Azure Functions code (Trinity).
 - **Functions folder pattern:** Each platform has a dedicated folder with standardized function naming (`ProcessNew*Fired`, `ProcessScheduled*Fired`, `ProcessRandom*`). New functions should follow this pattern exactly and register in `ConfigurationFunctionNames`.
 - **Caching scope for APIs:** Most API controllers are cache-naive. The `SocialMediaPlatformManager` pattern (full-list cache + in-memory pagination) is the template. Replicate it for reference data (MessageTemplates, SocialMediaPlatforms) and user-owned data (Engagements, Schedules). Invalidation strategy: `InvalidateListCaches()` on mutation.
+- **PR comment markdown in PowerShell (2026-05-08):** Never use `gh pr review --body` or `gh pr comment --body` inline in PowerShell — the shell mangles special characters and causes backslash escaping. Always write to a .md temp file, convert to JSON with Python, then post via `gh api` with `--input`. This pattern ensures clean backtick formatting, proper em-dashes, and no encoding corruption.
+
+---
+
+## 2026-05-08 — Malformed PR Comments Replaced on PRs #939, #940, #941
+
+**Status:** ✅ COMPLETE — Clean comments posted; old comments minimized
+
+**Action:** Identified and replaced malformed review comments that contained backslash-word patterns (`\ScheduledItemAsync\` instead of `` `ScheduledItemAsync` ``) and garbled UTF-8 characters (e.g., `ΓÇö` for em-dash). Used the correct workflow:
+1. Wrote clean comment body to temp .md file
+2. Converted to JSON with Python: `json.dumps({'body': body})`
+3. Posted via `gh api repos/{owner}/{repo}/issues/{N}/comments --input file.json`
+4. Cleaned up temp files immediately
+5. Edited old malformed comments to just say "*(replaced — see updated review below)*"
+
+**Comments posted:**
+- PR #939: New clean comment with 3 blocking issues (null dereference, missing guard, test command fix)
+- PR #940: Reposted APPROVED verdict for gold-standard caching pattern
+- PR #941: New clean comment on cache invalidation issue in `SentScheduledItemAsync`
+
+**Learning:** Always use file-based JSON workflow for PR comments instead of inline `--body` flag. PowerShell mangles Markdown inline, leading to backslash escaping issues and encoding corruption. The temp file + Python JSON + `--input` pattern prevents this entirely.
 
 ---
 

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -75,3 +75,10 @@ Trinity (Backend API Developer) implements core API functionality including CRUD
 ---
 
 ## Learnings
+
+### 2026-05-08 — PR #939 blocking fix (null checks + IsNullOrWhiteSpace guards)
+
+1. Always add a null check after `IEngagementManager.GetAsync` before accessing any property — the method returns `null` when the engagement is not found, causing a `NullReferenceException` on the next line.
+2. Match the Bluesky `IsNullOrWhiteSpace` guard pattern exactly in every other platform function; Bluesky was the reference implementation but Facebook, Twitter, and LinkedIn were missing it.
+3. The team directive in `decisions.md` prohibits `--filter "FullyQualifiedName!~SyndicationFeedReader"` in PR bodies — always use the no-filter command when writing the Testing section.
+4. When inspecting a PR body string with Python for replacement, use `repr()` to check exact backslash escaping before constructing replace patterns — `\\src\\` in the file renders differently depending on how it was captured.

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -36,4 +36,26 @@ Trinity (Backend API Developer) implements core API functionality including CRUD
 
 ---
 
+### 2026-05-08 — Issue #933: ProcessNewSpeakingEngagementFired Azure Functions
+
+**Status:** ✅ COMPLETE — PR #939 on `issue-933-speaking-engagement-functions`; 242 tests passing
+
+**What was delivered:**
+- `Bluesky/ProcessNewSpeakingEngagementFired.cs` — Event Grid trigger → `IBlueskyManager.ComposeMessageAsync` → `BlueskyPostMessage` output queue (truncated to 300)
+- `Facebook/ProcessNewSpeakingEngagementFired.cs` — Event Grid trigger → `IFacebookManager.ComposeMessageAsync` → `FacebookPostStatus` output queue
+- `LinkedIn/ProcessNewSpeakingEngagementFired.cs` — per-user OAuth via `IUserOAuthTokenManager`; null-guard on `CreatedByEntraOid` before token lookup
+- `Twitter/ProcessNewSpeakingEngagementFired.cs` — Event Grid trigger → `ITwitterManager.ComposeMessageAsync` → `TwitterTweetMessage` output queue
+- `ConfigurationFunctionNames.cs`: 4 new function-name constants
+- `Metrics.cs`: 4 new telemetry event constants
+
+**Key patterns confirmed:**
+1. `LinkedInPostLink` (and `FacebookPostStatus`, `TwitterTweetMessage`) live in `JosephGuadagno.Broadcasting.Domain.Models.Messages`. `BlueskyPostMessage` is the exception — it's in `JosephGuadagno.Broadcasting.Managers.Bluesky.Models`.
+2. `ITwitterManager` lives in the **Domain** layer (`JosephGuadagno.Broadcasting.Domain.Interfaces`), not in a `Managers.Twitter` project. Unlike every other platform manager whose interface lives in the manager project.
+3. `ILinkedInManager` is in `JosephGuadagno.Broadcasting.Managers.LinkedIn.Models` (unusual — the interface file is physically in the `Models/` folder, not `Interfaces/`).
+4. `engagement.CreatedByEntraOid` is `string?` (nullable). Always null-guard before calling `IUserOAuthTokenManager.GetByUserAndPlatformAsync` to avoid CS8604.
+5. Per-user isolation (OAuth token lookup) is LinkedIn-only; Bluesky, Facebook, and Twitter use shared credentials.
+6. The synthetic `ScheduledItem` approach: set `ItemType = ScheduledItemType.Engagements` and `ItemPrimaryKey = engagement.Id`. The platform manager internally re-fetches the engagement when rendering Scriban templates.
+
+---
+
 ## Learnings

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -58,4 +58,20 @@ Trinity (Backend API Developer) implements core API functionality including CRUD
 
 ---
 
+### 2026-05-08 — Issue #937 PR #941: Fix SentScheduledItemAsync cache invalidation
+
+**Status:** ✅ COMPLETE — commit `5cf213d` on `issue-937-user-owned-caching`; all tests pass
+
+**What was delivered:**
+- `ScheduledItemManager.SentScheduledItemAsync(int, DateTimeOffset, CancellationToken)`: applied fetch-before-mutate pattern — `GetAsync` first to capture `CreatedByEntraOid`, early `return false` if item not found, `InvalidateUserCaches(entity.CreatedByEntraOid)` after a successful data-store update
+- Single-arg overload delegates to the full overload unchanged, picks up fix automatically
+- Comment posted on PR #941
+
+**Key patterns confirmed:**
+1. When `SentScheduledItemAsync` is a void-like mutation, still fetch entity first to get owner for cache invalidation — same as `DeleteAsync(int primaryKey)` pattern.
+2. Both overloads are handled by fixing only the full overload since the single-arg delegate-chains to it.
+3. Branch lives in worktree at `D:\Projects\jjgnet-broadcast-937` — always work there, never `git checkout` in main tree.
+
+---
+
 ## Learnings

--- a/src/JosephGuadagno.Broadcasting.Domain/Constants/ConfigurationFunctionNames.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants/ConfigurationFunctionNames.cs
@@ -37,6 +37,10 @@ public static class ConfigurationFunctionNames
     public const string BlueskyProcessNewSyndicationDataFired = "BlueskyProcessNewSyndicationDataFired";
     public const string BlueskyProcessNewYouTubeDataFired = "BlueskyProcessNewYouTubeDataFired";
     public const string BlueskyProcessScheduledItemFired = "BlueskyProcessScheduledItemFired";
+    public const string BlueskyProcessNewSpeakingEngagementFired = "BlueskyProcessNewSpeakingEngagementFired";
+    public const string FacebookProcessNewSpeakingEngagementFired = "FacebookProcessNewSpeakingEngagementFired";
+    public const string LinkedInProcessNewSpeakingEngagementFired = "LinkedInProcessNewSpeakingEngagementFired";
+    public const string TwitterProcessNewSpeakingEngagementFired = "TwitterProcessNewSpeakingEngagementFired";
 
     // Email
     public const string EmailSendEmail = "EmailSendEmail";

--- a/src/JosephGuadagno.Broadcasting.Domain/Constants/Metrics.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants/Metrics.cs
@@ -14,12 +14,14 @@ public static class Metrics
     public const string BlueskyProcessedScheduledItemFired = "BlueskyProcessedScheduledItemFired";
     public const string BlueskyProcessedRandomPost = "BlueskyProcessedRandomPost";
     public const string BlueskyPostSent = "BlueskyPostSent";
+    public const string BlueskyProcessedNewSpeakingEngagement = "BlueskyProcessedNewSpeakingEngagement";
 
     public const string FacebookProcessedNewSyndicationData = "FacebookProcessedNewSyndicationData";
     public const string FacebookProcessedRandomPost = "FacebookProcessedRandomPost";
     public const string FacebookProcessedNewYouTubeData = "FacebookProcessedNewYouTubeData";
     public const string FacebookProcessedScheduledItemFired = "FacebookProcessedScheduledItemFired";
     public const string FacebookPostPageStatus = "FacebookPostPageStatus";
+    public const string FacebookProcessedNewSpeakingEngagement = "FacebookProcessedNewSpeakingEngagement";
 
     public const string LinkedInProcessedNewSyndicationData = "LinkedInProcessedNewSyndicationData";
     public const string LinkedInProcessedRandomPost = "LinkedInProcessedRandomPost";
@@ -28,10 +30,12 @@ public static class Metrics
     public const string LinkedInPostImage = "LinkedInPostImage";
     public const string LinkedInPostLink = "LinkedInPostLink";
     public const string LinkedInPostText = "LinkedInPostText";
+    public const string LinkedInProcessedNewSpeakingEngagement = "LinkedInProcessedNewSpeakingEngagement";
 
     public const string TwitterProcessedNewSyndicationData = "TwitterProcessedNewSyndicationData";
     public const string TwitterProcessedNewYouTubeData = "TwitterProcessedNewYouTubeData";
     public const string TwitterProcessScheduledItemFired = "TwitterProcessScheduledItemFired";
     public const string TwitterProcessedRandomPost = "TwitterProcessedRandomPost";
     public const string TwitterPostSent = "TwitterPostSent";
+    public const string TwitterProcessedNewSpeakingEngagement = "TwitterProcessedNewSpeakingEngagement";
 }

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSpeakingEngagementFired.cs
@@ -47,6 +47,11 @@ public class ProcessNewSpeakingEngagementFired(
             }
 
             var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+            if (engagement is null)
+            {
+                logger.LogWarning("Engagement {EngagementId} not found. Skipping.", newSpeakingEngagementEvent.Id);
+                return null;
+            }
 
             logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
                 engagement.Id, LogSanitizer.Sanitize(engagement.Name));

--- a/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Bluesky/ProcessNewSpeakingEngagementFired.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using Azure.Messaging.EventGrid;
+
+using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Enums;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Models.Events;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+using JosephGuadagno.Broadcasting.Managers.Bluesky.Interfaces;
+using JosephGuadagno.Broadcasting.Managers.Bluesky.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Functions.Bluesky;
+
+public class ProcessNewSpeakingEngagementFired(
+    IEngagementManager engagementManager,
+    IBlueskyManager blueskyManager,
+    ILogger<ProcessNewSpeakingEngagementFired> logger)
+{
+    private const int MaxPostLength = 300;
+
+    [Function(ConfigurationFunctionNames.BlueskyProcessNewSpeakingEngagementFired)]
+    [QueueOutput(Queues.BlueskyPostToSend)]
+    public async Task<BlueskyPostMessage?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
+    {
+        var startedOn = DateTimeOffset.UtcNow;
+        logger.LogDebug("{FunctionName} started at: {StartedOn:f}",
+            ConfigurationFunctionNames.BlueskyProcessNewSpeakingEngagementFired, startedOn);
+
+        if (eventGridEvent.Data is null)
+        {
+            logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
+            return null;
+        }
+
+        try
+        {
+            var eventGridData = eventGridEvent.Data.ToString();
+            var newSpeakingEngagementEvent = JsonSerializer.Deserialize<NewSpeakingEngagementEvent>(eventGridData);
+            if (newSpeakingEngagementEvent is null)
+            {
+                logger.LogError("Failed to parse the data for event '{Id}'", eventGridEvent.Id);
+                return null;
+            }
+
+            var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+
+            logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
+                engagement.Id, LogSanitizer.Sanitize(engagement.Name));
+
+            var scheduledItem = new ScheduledItem
+            {
+                ItemType = ScheduledItemType.Engagements,
+                ItemPrimaryKey = engagement.Id,
+                Message = $"New Speaking Engagement: {engagement.Name} {engagement.Url}",
+                SendOnDateTime = DateTimeOffset.UtcNow,
+                CreatedByEntraOid = engagement.CreatedByEntraOid
+            };
+
+            var postText = await blueskyManager.ComposeMessageAsync(scheduledItem);
+
+            if (string.IsNullOrWhiteSpace(postText))
+            {
+                logger.LogWarning("No Bluesky post text for speaking engagement {Id}", engagement.Id);
+                return null;
+            }
+
+            var properties = new Dictionary<string, string>
+            {
+                { "post", postText },
+                { "name", engagement.Name },
+                { "url", engagement.Url },
+                { "id", engagement.Id.ToString() }
+            };
+            logger.LogCustomEvent(Metrics.BlueskyProcessedNewSpeakingEngagement, properties);
+            logger.LogDebug("Generated the Bluesky post for speaking engagement {Id}", engagement.Id);
+
+            return new BlueskyPostMessage
+            {
+                Text = postText.Length > MaxPostLength ? postText[..MaxPostLength] : postText,
+                Url = engagement.Url
+            };
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to process new speaking engagement. Exception: {ExceptionMessage}", e.Message);
+            throw;
+        }
+        finally
+        {
+            var endedOn = DateTimeOffset.UtcNow;
+            logger.LogDebug("Ended {FunctionName} at {EndedOn:f} with duration {Duration:c}",
+                ConfigurationFunctionNames.BlueskyProcessNewSpeakingEngagementFired, endedOn, endedOn - startedOn);
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSpeakingEngagementFired.cs
@@ -45,6 +45,11 @@ public class ProcessNewSpeakingEngagementFired(
             }
 
             var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+            if (engagement is null)
+            {
+                logger.LogWarning("Engagement {EngagementId} not found. Skipping.", newSpeakingEngagementEvent.Id);
+                return null;
+            }
 
             logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
                 engagement.Id, LogSanitizer.Sanitize(engagement.Name));
@@ -60,7 +65,13 @@ public class ProcessNewSpeakingEngagementFired(
 
             var statusText = await facebookManager.ComposeMessageAsync(scheduledItem);
 
-            var properties = new Dictionary<string, string>
+            if (string.IsNullOrWhiteSpace(statusText))
+            {
+                logger.LogWarning("Composed message was empty for engagement {EngagementId}. Skipping.", engagement.Id);
+                return null;
+            }
+
+            var properties= new Dictionary<string, string>
             {
                 { "post", statusText },
                 { "name", engagement.Name },

--- a/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Facebook/ProcessNewSpeakingEngagementFired.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using Azure.Messaging.EventGrid;
+
+using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Enums;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Models.Events;
+using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+using JosephGuadagno.Broadcasting.Managers.Facebook.Interfaces;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Functions.Facebook;
+
+public class ProcessNewSpeakingEngagementFired(
+    IEngagementManager engagementManager,
+    IFacebookManager facebookManager,
+    ILogger<ProcessNewSpeakingEngagementFired> logger)
+{
+    [Function(ConfigurationFunctionNames.FacebookProcessNewSpeakingEngagementFired)]
+    [QueueOutput(Queues.FacebookPostStatusToPage)]
+    public async Task<FacebookPostStatus?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
+    {
+        var startedOn = DateTimeOffset.UtcNow;
+        logger.LogDebug("{FunctionName} started at: {StartedOn:f}",
+            ConfigurationFunctionNames.FacebookProcessNewSpeakingEngagementFired, startedOn);
+
+        if (eventGridEvent.Data is null)
+        {
+            logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
+            return null;
+        }
+
+        try
+        {
+            var eventGridData = eventGridEvent.Data.ToString();
+            var newSpeakingEngagementEvent = JsonSerializer.Deserialize<NewSpeakingEngagementEvent>(eventGridData);
+            if (newSpeakingEngagementEvent is null)
+            {
+                logger.LogError("Failed to parse the data for event '{Id}'", eventGridEvent.Id);
+                return null;
+            }
+
+            var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+
+            logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
+                engagement.Id, LogSanitizer.Sanitize(engagement.Name));
+
+            var scheduledItem = new ScheduledItem
+            {
+                ItemType = ScheduledItemType.Engagements,
+                ItemPrimaryKey = engagement.Id,
+                Message = $"New Speaking Engagement: {engagement.Name} {engagement.Url}",
+                SendOnDateTime = DateTimeOffset.UtcNow,
+                CreatedByEntraOid = engagement.CreatedByEntraOid
+            };
+
+            var statusText = await facebookManager.ComposeMessageAsync(scheduledItem);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "post", statusText },
+                { "name", engagement.Name },
+                { "url", engagement.Url },
+                { "id", engagement.Id.ToString() }
+            };
+            logger.LogCustomEvent(Metrics.FacebookProcessedNewSpeakingEngagement, properties);
+            logger.LogDebug("Generated the Facebook post for speaking engagement {Id}", engagement.Id);
+
+            return new FacebookPostStatus
+            {
+                StatusText = statusText,
+                LinkUri = engagement.Url
+            };
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to process new speaking engagement. Exception: {ExceptionMessage}", e.Message);
+            throw;
+        }
+        finally
+        {
+            var endedOn = DateTimeOffset.UtcNow;
+            logger.LogDebug("Ended {FunctionName} at {EndedOn:f} with duration {Duration:c}",
+                ConfigurationFunctionNames.FacebookProcessNewSpeakingEngagementFired, endedOn, endedOn - startedOn);
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSpeakingEngagementFired.cs
@@ -46,6 +46,11 @@ public class ProcessNewSpeakingEngagementFired(
             }
 
             var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+            if (engagement is null)
+            {
+                logger.LogWarning("Engagement {EngagementId} not found. Skipping.", newSpeakingEngagementEvent.Id);
+                return null;
+            }
 
             logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
                 engagement.Id, LogSanitizer.Sanitize(engagement.Name));
@@ -81,7 +86,13 @@ public class ProcessNewSpeakingEngagementFired(
 
             var postText = await linkedInManager.ComposeMessageAsync(scheduledItem);
 
-            var properties = new Dictionary<string, string>
+            if (string.IsNullOrWhiteSpace(postText))
+            {
+                logger.LogWarning("Composed message was empty for engagement {EngagementId}. Skipping.", engagement.Id);
+                return null;
+            }
+
+            var properties= new Dictionary<string, string>
             {
                 { "post", postText },
                 { "name", engagement.Name },

--- a/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/LinkedIn/ProcessNewSpeakingEngagementFired.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Azure.Messaging.EventGrid;
+
+using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Enums;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Models.Events;
+using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+using JosephGuadagno.Broadcasting.Managers.LinkedIn.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Functions.LinkedIn;
+
+public class ProcessNewSpeakingEngagementFired(
+    IEngagementManager engagementManager,
+    ILinkedInManager linkedInManager,
+    IUserOAuthTokenManager userOAuthTokenManager,
+    ILogger<ProcessNewSpeakingEngagementFired> logger)
+{
+    [Function(ConfigurationFunctionNames.LinkedInProcessNewSpeakingEngagementFired)]
+    [QueueOutput(Queues.LinkedInPostLink)]
+    public async Task<LinkedInPostLink?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
+    {
+        var startedOn = DateTimeOffset.UtcNow;
+        logger.LogDebug("{FunctionName} started at: {StartedOn:f}",
+            ConfigurationFunctionNames.LinkedInProcessNewSpeakingEngagementFired, startedOn);
+
+        if (eventGridEvent.Data is null)
+        {
+            logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
+            return null;
+        }
+
+        try
+        {
+            var eventGridData = eventGridEvent.Data.ToString();
+            var newSpeakingEngagementEvent = JsonSerializer.Deserialize<NewSpeakingEngagementEvent>(eventGridData);
+            if (newSpeakingEngagementEvent is null)
+            {
+                logger.LogError("Failed to parse the data for event '{Id}'", eventGridEvent.Id);
+                return null;
+            }
+
+            var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+
+            logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
+                engagement.Id, LogSanitizer.Sanitize(engagement.Name));
+
+            if (engagement.CreatedByEntraOid is null)
+            {
+                logger.LogWarning("No owner OID on engagement {Id} — skipping LinkedIn post", engagement.Id);
+                return null;
+            }
+
+            // Per-user OAuth token — no silent fallback to shared token
+            var token = await userOAuthTokenManager.GetByUserAndPlatformAsync(
+                engagement.CreatedByEntraOid,
+                SocialMediaPlatformIds.LinkedIn);
+
+            if (token is null)
+            {
+                logger.LogWarning(
+                    "No OAuth token found for owner {OwnerOid} on LinkedIn — skipping engagement {Id}",
+                    LogSanitizer.Sanitize(engagement.CreatedByEntraOid),
+                    engagement.Id);
+                return null;
+            }
+
+            var scheduledItem = new ScheduledItem
+            {
+                ItemType = ScheduledItemType.Engagements,
+                ItemPrimaryKey = engagement.Id,
+                Message = $"New Speaking Engagement: {engagement.Name} {engagement.Url}",
+                SendOnDateTime = DateTimeOffset.UtcNow,
+                CreatedByEntraOid = engagement.CreatedByEntraOid
+            };
+
+            var postText = await linkedInManager.ComposeMessageAsync(scheduledItem);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "post", postText },
+                { "name", engagement.Name },
+                { "url", engagement.Url },
+                { "id", engagement.Id.ToString() }
+            };
+            logger.LogCustomEvent(Metrics.LinkedInProcessedNewSpeakingEngagement, properties);
+            logger.LogDebug("Generated the LinkedIn post for speaking engagement {Id}", engagement.Id);
+
+            return new LinkedInPostLink
+            {
+                Text = postText,
+                Title = engagement.Name,
+                LinkUrl = engagement.Url,
+                AccessToken = token.AccessToken
+            };
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to process new speaking engagement. Exception: {ExceptionMessage}", e.Message);
+            throw;
+        }
+        finally
+        {
+            var endedOn = DateTimeOffset.UtcNow;
+            logger.LogDebug("Ended {FunctionName} at {EndedOn:f} with duration {Duration:c}",
+                ConfigurationFunctionNames.LinkedInProcessNewSpeakingEngagementFired, endedOn, endedOn - startedOn);
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSpeakingEngagementFired.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Azure.Messaging.EventGrid;
+
+using JosephGuadagno.Broadcasting.Domain;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Enums;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Models.Events;
+using JosephGuadagno.Broadcasting.Domain.Models.Messages;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace JosephGuadagno.Broadcasting.Functions.Twitter;
+
+public class ProcessNewSpeakingEngagementFired(
+    IEngagementManager engagementManager,
+    ITwitterManager twitterManager,
+    ILogger<ProcessNewSpeakingEngagementFired> logger)
+{
+    [Function(ConfigurationFunctionNames.TwitterProcessNewSpeakingEngagementFired)]
+    [QueueOutput(Queues.TwitterTweetsToSend)]
+    public async Task<TwitterTweetMessage?> RunAsync([EventGridTrigger] EventGridEvent eventGridEvent)
+    {
+        var startedOn = DateTimeOffset.UtcNow;
+        logger.LogDebug("{FunctionName} started at: {StartedOn:f}",
+            ConfigurationFunctionNames.TwitterProcessNewSpeakingEngagementFired, startedOn);
+
+        if (eventGridEvent.Data is null)
+        {
+            logger.LogError("The event data was null for event '{Id}'", eventGridEvent.Id);
+            return null;
+        }
+
+        try
+        {
+            var eventGridData = eventGridEvent.Data.ToString();
+            var newSpeakingEngagementEvent = JsonSerializer.Deserialize<NewSpeakingEngagementEvent>(eventGridData);
+            if (newSpeakingEngagementEvent is null)
+            {
+                logger.LogError("Failed to parse the data for event '{Id}'", eventGridEvent.Id);
+                return null;
+            }
+
+            var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+
+            logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
+                engagement.Id, LogSanitizer.Sanitize(engagement.Name));
+
+            var scheduledItem = new ScheduledItem
+            {
+                ItemType = ScheduledItemType.Engagements,
+                ItemPrimaryKey = engagement.Id,
+                Message = $"New Speaking Engagement: {engagement.Name} {engagement.Url}",
+                SendOnDateTime = DateTimeOffset.UtcNow,
+                CreatedByEntraOid = engagement.CreatedByEntraOid
+            };
+
+            var tweetText = await twitterManager.ComposeMessageAsync(scheduledItem);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "post", tweetText },
+                { "name", engagement.Name },
+                { "url", engagement.Url },
+                { "id", engagement.Id.ToString() }
+            };
+            logger.LogCustomEvent(Metrics.TwitterProcessedNewSpeakingEngagement, properties);
+            logger.LogDebug("Generated the tweet for speaking engagement {Id}", engagement.Id);
+
+            return new TwitterTweetMessage { Text = tweetText };
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to process new speaking engagement. Exception: {ExceptionMessage}", e.Message);
+            throw;
+        }
+        finally
+        {
+            var endedOn = DateTimeOffset.UtcNow;
+            logger.LogDebug("Ended {FunctionName} at {EndedOn:f} with duration {Duration:c}",
+                ConfigurationFunctionNames.TwitterProcessNewSpeakingEngagementFired, endedOn, endedOn - startedOn);
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSpeakingEngagementFired.cs
+++ b/src/JosephGuadagno.Broadcasting.Functions/Twitter/ProcessNewSpeakingEngagementFired.cs
@@ -44,6 +44,11 @@ public class ProcessNewSpeakingEngagementFired(
             }
 
             var engagement = await engagementManager.GetAsync(newSpeakingEngagementEvent.Id);
+            if (engagement is null)
+            {
+                logger.LogWarning("Engagement {EngagementId} not found. Skipping.", newSpeakingEngagementEvent.Id);
+                return null;
+            }
 
             logger.LogDebug("Processing new speaking engagement '{Id}' with name '{Name}'",
                 engagement.Id, LogSanitizer.Sanitize(engagement.Name));
@@ -59,7 +64,13 @@ public class ProcessNewSpeakingEngagementFired(
 
             var tweetText = await twitterManager.ComposeMessageAsync(scheduledItem);
 
-            var properties = new Dictionary<string, string>
+            if (string.IsNullOrWhiteSpace(tweetText))
+            {
+                logger.LogWarning("Composed message was empty for engagement {EngagementId}. Skipping.", engagement.Id);
+                return null;
+            }
+
+            var properties= new Dictionary<string, string>
             {
                 { "post", tweetText },
                 { "name", engagement.Name },

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
@@ -13,8 +13,7 @@ public class ScheduledItemManagerTests
     public ScheduledItemManagerTests()
     {
         _repository = new Mock<IScheduledItemDataStore>();
-        var cache = new Mock<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
-        _scheduledItemManager = new ScheduledItemManager(_repository.Object, cache.Object);
+        _scheduledItemManager = new ScheduledItemManager(_repository.Object);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
@@ -13,7 +13,8 @@ public class ScheduledItemManagerTests
     public ScheduledItemManagerTests()
     {
         _repository = new Mock<IScheduledItemDataStore>();
-        _scheduledItemManager = new ScheduledItemManager(_repository.Object);
+        var cache = new Mock<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+        _scheduledItemManager = new ScheduledItemManager(_repository.Object, cache.Object);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements Azure Functions to broadcast new speaking engagement events across all four social media platforms.

Closes #933

## Changes

### New Azure Functions
- `Bluesky/ProcessNewSpeakingEngagementFired.cs` ΓÇö triggers on `Topics.NewSpeakingEngagement`, composes a Bluesky post via `IBlueskyManager.ComposeMessageAsync`, truncates to 300 characters, outputs to `Queues.BlueskyPostToSend`
- `Facebook/ProcessNewSpeakingEngagementFired.cs` ΓÇö composes a Facebook post via `IFacebookManager.ComposeMessageAsync`, outputs `FacebookPostStatus` (StatusText + LinkUri) to `Queues.FacebookPostStatusToPage`
- `LinkedIn/ProcessNewSpeakingEngagementFired.cs` ΓÇö per-user OAuth isolation via `IUserOAuthTokenManager.GetByUserAndPlatformAsync`; null-guards `engagement.CreatedByEntraOid` before lookup; outputs `LinkedInPostLink` to `Queues.LinkedInPostLink`
- `Twitter/ProcessNewSpeakingEngagementFired.cs` ΓÇö composes a tweet via `ITwitterManager.ComposeMessageAsync`, outputs `TwitterTweetMessage` to `Queues.TwitterTweetsToSend`

### Constants
- `ConfigurationFunctionNames.cs` ΓÇö added four new function-name constants (one per platform)
- `Metrics.cs` ΓÇö added four new telemetry event constants for new speaking engagement processing

## Approach

Each function:
1. Deserializes the `NewSpeakingEngagementEvent` payload (just `{ int Id }`)
2. Fetches the full `Engagement` from `IEngagementManager.GetAsync`
3. Builds a synthetic `ScheduledItem` (ItemType = Engagements, ItemPrimaryKey = engagement.Id)
4. Calls the platform manager's `ComposeMessageAsync(scheduledItem)` which uses Scriban MessageTemplates
5. Publishes the platform-specific message model to the appropriate output queue

LinkedIn is the only platform requiring per-user OAuth ΓÇö the other three use shared credentials/page tokens. An early return is added if `engagement.CreatedByEntraOid` is null (no token to look up).

## Testing

Build: `dotnet build .\src\ --configuration Release` ΓÇö 0 errors

Tests: `dotnet test .\src\ --no-build --verbosity normal --configuration Release` ΓÇö 242 passed, 4 skipped (integration)

