### PR TITLE
feat(#936): add IMemoryCache caching to MessageTemplateManager

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -2,9 +2,31 @@
 
 ## Summary
 
-Trinity (Backend API Developer) implements core API functionality including CRUD endpoints, authentication/authorization workflows, OAuth token refresh, and data persistence. Work spans three layers: Controllers (HTTP routing), Managers (business logic), and Data/Data.Sql (Entity Framework Core persistence). Key contributions include EngagementSocialMediaPlatforms CRUD endpoints, UserApprovalManager for RBAC workflows, OAuth token refresh with token versioning, and ownership isolation enforcement. Trinity follows Neo's architectural patterns: explicit service contracts with DTOs, response mapping to isolate Data layer changes from API contracts, and role-based authorization. Established pattern: implement feature vertically from API controller through Manager to Data layer, write explicit request/response types in API, and map Data objects to DTOs before returning. Close collaboration with Tank (integration tests), Switch (Web-layer service mapping), and Neo (architectural reviews). Notable: Trinity maintains API contract stability by mapping internal changes to stable response shapes, preventing breaking changes to Web-layer consumers. Key decision: use DTOs consistently for all API responses to maintain contracts.
+Trinity (Backend API Developer) implements core API functionality including CRUD endpoints, authentication/authorization workflows, OAuth token refresh, and data persistence. Work spans three layers: Controllers (HTTP routing), Managers (business logic), and Data/Data.Sql (Entity Framework Core persistence). Key contributions include EngagementSocialMediaPlatforms CRUD endpoints, UserApprovalManager for RBAC workflows, OAuth token refresh with token versioning, ownership isolation enforcement, and `IMemoryCache` caching layer for managers. Trinity follows Neo's architectural patterns: explicit service contracts with DTOs, response mapping to isolate Data layer changes from API contracts, and role-based authorization. Established pattern: implement feature vertically from API controller through Manager to Data layer, write explicit request/response types in API, and map Data objects to DTOs before returning. Close collaboration with Tank (integration tests), Switch (Web-layer service mapping), and Neo (architectural reviews). Notable: Trinity maintains API contract stability by mapping internal changes to stable response shapes, preventing breaking changes to Web-layer consumers. Key decision: use DTOs consistently for all API responses to maintain contracts.
 
-### 2026-05-XX — Issue #899: Move Twitter message composition to TwitterManager
+### 2026-05-XX — Issue #936: Add IMemoryCache caching to MessageTemplateManager
+
+**Status:** ✅ COMPLETE — PR #940 on `issue-936-messagetemplates-caching`; 253 tests passing
+
+**What was delivered:**
+- `IMessageTemplateManager` (Domain/Interfaces): interface with `GetAsync`, `GetAllAsync` (admin + owner-filtered overloads with filter/sort/page), and `UpdateAsync`
+- `MessageTemplateManager` (Managers): `IMemoryCache` implementation
+  - Full list cached at `MessageTemplate_All` with 5-min absolute expiry
+  - Individual items cached at `MessageTemplate_{platformId}_{messageType}`
+  - `ApplyFilterSortPage` private helper handles in-memory filter/sort/pagination for both admin and owner-filtered paths
+  - `InvalidateListCaches()` + individual key removal on `UpdateAsync`
+- `MessageTemplatesController`: swapped `IMessageTemplateDataStore` → `IMessageTemplateManager` (4 call sites)
+- `Program.cs`: added `services.TryAddScoped<IMessageTemplateManager, MessageTemplateManager>()` after the DataStore registration
+- `MessageTemplatesControllerTests`: mocks `IMessageTemplateManager` instead of `IMessageTemplateDataStore`; admin and owner-filtered path tests unchanged in intent
+
+**Key patterns confirmed:**
+1. When a controller was calling `IDataStore` directly with no Manager, create `IManager` + `Manager` from scratch following `SocialMediaPlatformManager` as the gold standard.
+2. `ApplyFilterSortPage` static helper: pull all items from cache once, then filter/sort/page in-memory. Avoids separate cache keys per query combination.
+3. `InvalidateListCaches()` on any mutation is sufficient when there is no Add/Delete — only `UpdateAsync` exists.
+4. Git branch confusion guard: ALWAYS run `git branch --show-current` before any `git add` or `git commit`. Multiple branch switches in a session can leave HEAD on an unexpected branch.
+
+---
+
 
 **Status:** ✅ COMPLETE — PR #924 on `issue-899-twitter-message-composition`; 11 tests passing
 

--- a/.squad/decisions/trinity-936-caching-messagetemplates.md
+++ b/.squad/decisions/trinity-936-caching-messagetemplates.md
@@ -1,0 +1,60 @@
+# Decision: Introduce IMessageTemplateManager Caching Layer
+
+**Date:** 2025-07-14
+**Author:** Trinity (Backend Dev)
+**Issue:** #936 (part of #78 — Add caching to WebApi)
+**PR:** #940
+**Status:** Implemented
+
+---
+
+## Context
+
+`MessageTemplatesController` called `IMessageTemplateDataStore` directly — the only API
+controller in the project without a manager layer. Every request hit SQL Server with no
+caching, and there was no place to intercept reads for cache invalidation on writes.
+
+The `SocialMediaPlatformManager` was the established gold-standard pattern for
+`IMemoryCache` caching in this project (see PR #935 / issue #933).
+
+## Decision
+
+Introduce `IMessageTemplateManager` (interface) and `MessageTemplateManager`
+(implementation) following the `SocialMediaPlatformManager` pattern exactly:
+
+- **Cache keys**
+  - `MessageTemplate_All` — full unfiltered list, shared by paged admin + owner paths
+  - `MessageTemplate_{platformId}_{messageType}` — individual item
+- **Expiry** — 5-minute absolute, via `static readonly MemoryCacheEntryOptions`
+- **Invalidation** — `InvalidateListCaches()` removes `MessageTemplate_All`; called
+  from `UpdateAsync` (only mutating operation on this entity)
+- **In-memory filtering** — `ApplyFilterSortPage` private helper applies `ownerEntraOid`
+  filter, optional text filter (MessageType/Template), sort, and skip/take after
+  retrieving the full cached list — avoids cache fragmentation from parameterized keys
+- **`IMemoryCache` already registered** — `builder.Services.AddMemoryCache()` existed;
+  no new DI registration needed
+- **No NuGet package needed** — `Microsoft.AspNetCore.App` FrameworkReference in
+  `Managers.csproj` already covers `Microsoft.Extensions.Caching.Memory`
+
+## Consequences
+
+- **Positive:** SQL reads for message templates are reduced dramatically; repeated
+  controller calls within a 5-minute window hit only the in-memory cache
+- **Positive:** Controller is now consistent with all other controllers — it calls a
+  manager, not a data store directly
+- **Positive:** Single invalidation point in `UpdateAsync`; cache never goes stale
+  beyond 5 minutes even if invalidation were missed
+- **Neutral:** Full list is loaded into cache on first read; for small tables like
+  message templates this is a net win (no query per item), but would need revisiting
+  if the table grew large
+- **Negative (minor):** One additional abstraction layer; mitigated by the fact that
+  the same pattern is used throughout the project
+
+## Alternatives Considered
+
+1. **Keep calling DataStore directly, add cache there** — rejected; DataStore is a
+   generic repository layer and shouldn't contain business-level cache policies
+2. **Per-query cache keys** — rejected; leads to cache fragmentation and complex
+   invalidation logic for filtered/paged queries
+3. **Distributed cache (IDistributedCache)** — out of scope for this issue; in-process
+   `IMemoryCache` matches the pattern used by all other managers in this project

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs
@@ -17,7 +17,7 @@ namespace JosephGuadagno.Broadcasting.Api.Tests.Controllers;
 
 public class MessageTemplatesControllerTests
 {
-    private readonly Mock<IMessageTemplateDataStore> _messageTemplateDataStoreMock;
+    private readonly Mock<IMessageTemplateManager> _messageTemplateManagerMock;
     private readonly Mock<ISocialMediaPlatformManager> _socialMediaPlatformManagerMock;
     private readonly Mock<ILogger<MessageTemplatesController>> _loggerMock;
 
@@ -27,7 +27,7 @@ public class MessageTemplatesControllerTests
 
     public MessageTemplatesControllerTests()
     {
-        _messageTemplateDataStoreMock = new Mock<IMessageTemplateDataStore>();
+        _messageTemplateManagerMock = new Mock<IMessageTemplateManager>();
         _socialMediaPlatformManagerMock = new Mock<ISocialMediaPlatformManager>();
         _loggerMock = new Mock<ILogger<MessageTemplatesController>>();
     }
@@ -39,7 +39,7 @@ public class MessageTemplatesControllerTests
     private MessageTemplatesController CreateSut(string ownerOid = "owner-oid-12345", bool isSiteAdmin = false)
     {
         var controller = new MessageTemplatesController(
-            _messageTemplateDataStoreMock.Object,
+            _messageTemplateManagerMock.Object,
             _socialMediaPlatformManagerMock.Object,
             _loggerMock.Object,
             _mapper)
@@ -66,7 +66,7 @@ public class MessageTemplatesControllerTests
     };
 
     // -------------------------------------------------------------------------
-    // Security: GetAsync ΓÇö non-owner returns 403
+    // Security: GetAsync — non-owner returns 403
     // -------------------------------------------------------------------------
 
     [Fact]
@@ -80,7 +80,7 @@ public class MessageTemplatesControllerTests
         _socialMediaPlatformManagerMock
             .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
             .ReturnsAsync(platform);
-        _messageTemplateDataStoreMock
+        _messageTemplateManagerMock
             .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()))
             .ReturnsAsync(template);
 
@@ -91,13 +91,13 @@ public class MessageTemplatesControllerTests
 
         // Assert
         result.Result.Should().BeOfType<ForbidResult>();
-        _messageTemplateDataStoreMock.Verify(
+        _messageTemplateManagerMock.Verify(
             m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     // -------------------------------------------------------------------------
-    // Security: UpdateAsync ΓÇö non-owner returns 403
+    // Security: UpdateAsync — non-owner returns 403
     // -------------------------------------------------------------------------
 
     [Fact]
@@ -111,7 +111,7 @@ public class MessageTemplatesControllerTests
         _socialMediaPlatformManagerMock
             .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
             .ReturnsAsync(platform);
-        _messageTemplateDataStoreMock
+        _messageTemplateManagerMock
             .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()))
             .ReturnsAsync(template);
 
@@ -122,13 +122,13 @@ public class MessageTemplatesControllerTests
 
         // Assert
         result.Result.Should().BeOfType<ForbidResult>();
-        _messageTemplateDataStoreMock.Verify(
+        _messageTemplateManagerMock.Verify(
             m => m.UpdateAsync(It.IsAny<MessageTemplate>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
     // -------------------------------------------------------------------------
-    // Security: GetAllAsync ΓÇö SiteAdmin calls unfiltered overload
+    // Security: GetAllAsync — SiteAdmin calls unfiltered overload
     // -------------------------------------------------------------------------
 
     [Fact]
@@ -136,8 +136,8 @@ public class MessageTemplatesControllerTests
     {
         // Arrange
         var templates = new List<MessageTemplate> { BuildTemplate() };
-        // Set up the unfiltered overload (no ownerOid ΓÇö first param is int page).
-        _messageTemplateDataStoreMock
+        // Set up the unfiltered overload (no ownerOid — first param is int page).
+        _messageTemplateManagerMock
             .Setup(m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PagedResult<MessageTemplate> { Items = templates, TotalCount = templates.Count });
 
@@ -150,12 +150,12 @@ public class MessageTemplatesControllerTests
         result.Value.Should().NotBeNull();
         result.Value!.TotalCount.Should().Be(1);
 
-        // Unfiltered overload must be invoked exactly once ΓÇª
-        _messageTemplateDataStoreMock.Verify(
+        // Unfiltered overload must be invoked exactly once …
+        _messageTemplateManagerMock.Verify(
             m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         // … and the owner-filtered overload must never be called.
-        _messageTemplateDataStoreMock.Verify(
+        _messageTemplateManagerMock.Verify(
             m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -169,7 +169,7 @@ public class MessageTemplatesControllerTests
     {
         // Arrange
         var templates = new List<MessageTemplate> { BuildTemplate() };
-        _messageTemplateDataStoreMock
+        _messageTemplateManagerMock
             .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PagedResult<MessageTemplate> { Items = templates, TotalCount = templates.Count });
 
@@ -183,11 +183,11 @@ public class MessageTemplatesControllerTests
         result.Value!.TotalCount.Should().Be(1);
 
         // Owner-filtered overload must fire …
-        _messageTemplateDataStoreMock.Verify(
+        _messageTemplateManagerMock.Verify(
             m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         // … and the unfiltered overload must never be called.
-        _messageTemplateDataStoreMock.Verify(
+        _messageTemplateManagerMock.Verify(
             m => m.GetAllAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -196,7 +196,7 @@ public class MessageTemplatesControllerTests
     public async Task GetAllAsync_WhenPageIsZero_ClampsToDefaultPage()
     {
         // Arrange
-        _messageTemplateDataStoreMock
+        _messageTemplateManagerMock
             .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PagedResult<MessageTemplate> { Items = new List<MessageTemplate>(), TotalCount = 0 });
 
@@ -214,7 +214,7 @@ public class MessageTemplatesControllerTests
     public async Task GetAllAsync_WhenPageSizeIsZero_ClampsToDefaultPageSize()
     {
         // Arrange
-        _messageTemplateDataStoreMock
+        _messageTemplateManagerMock
             .Setup(m => m.GetAllAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PagedResult<MessageTemplate> { Items = new List<MessageTemplate>(), TotalCount = 0 });
 

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
@@ -20,7 +20,7 @@ namespace JosephGuadagno.Broadcasting.Api.Controllers;
 [Produces("application/json")]
 public class MessageTemplatesController : ControllerBase
 {
-    private readonly IMessageTemplateDataStore _messageTemplateDataStore;
+    private readonly IMessageTemplateManager _messageTemplateManager;
     private readonly ISocialMediaPlatformManager _socialMediaPlatformManager;
     private readonly ILogger<MessageTemplatesController> _logger;
     private readonly IMapper _mapper;
@@ -28,15 +28,15 @@ public class MessageTemplatesController : ControllerBase
     /// <summary>
     /// Handles the interactions with Message Templates
     /// </summary>
-    /// <param name="messageTemplateDataStore">The message template data store</param>
+    /// <param name="messageTemplateManager">The message template manager</param>
     /// <param name="socialMediaPlatformManager">The social media platform manager</param>
     /// <param name="logger">The logger</param>
     /// <param name="mapper">The AutoMapper instance</param>
-    public MessageTemplatesController(IMessageTemplateDataStore messageTemplateDataStore,
+    public MessageTemplatesController(IMessageTemplateManager messageTemplateManager,
         ISocialMediaPlatformManager socialMediaPlatformManager,
         ILogger<MessageTemplatesController> logger, IMapper mapper)
     {
-        _messageTemplateDataStore = messageTemplateDataStore;
+        _messageTemplateManager = messageTemplateManager;
         _socialMediaPlatformManager = socialMediaPlatformManager;
         _logger = logger;
         _mapper = mapper;
@@ -63,12 +63,12 @@ public class MessageTemplatesController : ControllerBase
         PagedResult<MessageTemplate> result;
         if (User.IsSiteAdministrator())
         {
-            result = await _messageTemplateDataStore.GetAllAsync(page, pageSize, sortBy, sortDescending, filter);
+            result = await _messageTemplateManager.GetAllAsync(page, pageSize, sortBy, sortDescending, filter);
         }
         else
         {
             var ownerOid = User.GetOwnerOid();
-            result = await _messageTemplateDataStore.GetAllAsync(ownerOid, page, pageSize, sortBy, sortDescending, filter);
+            result = await _messageTemplateManager.GetAllAsync(ownerOid, page, pageSize, sortBy, sortDescending, filter);
         }
 
         var items = _mapper.Map<List<MessageTemplateResponse>>(result.Items);
@@ -105,7 +105,7 @@ public class MessageTemplatesController : ControllerBase
             return NotFound();
         }
         
-        var template = await _messageTemplateDataStore.GetAsync(socialMediaPlatform.Id, messageType);
+        var template = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType);
         if (template is null)
         {
             _logger.LogWarning("MessageTemplate not found for PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
@@ -153,7 +153,7 @@ public class MessageTemplatesController : ControllerBase
             return NotFound();
         }
 
-        var existing = await _messageTemplateDataStore.GetAsync(socialMediaPlatform.Id, messageType);
+        var existing = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType);
         if (existing is null)
         {
             _logger.LogWarning("MessageTemplate not found for update: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
@@ -169,7 +169,7 @@ public class MessageTemplatesController : ControllerBase
         messageTemplate.SocialMediaPlatformId = socialMediaPlatform.Id;
         messageTemplate.MessageType = messageType;
         messageTemplate.CreatedByEntraOid = existing.CreatedByEntraOid;
-        var updated = await _messageTemplateDataStore.UpdateAsync(messageTemplate);
+        var updated = await _messageTemplateManager.UpdateAsync(messageTemplate);
         if (updated is null)
         {
             _logger.LogWarning("MessageTemplate update failed: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));

--- a/src/JosephGuadagno.Broadcasting.Api/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Program.cs
@@ -222,6 +222,7 @@ void ConfigureRepositories(IServiceCollection services)
 
     // MessageTemplate
     services.TryAddScoped<IMessageTemplateDataStore, MessageTemplateDataStore>();
+    services.TryAddScoped<IMessageTemplateManager, MessageTemplateManager>();
 
     // SocialMediaPlatform
     services.TryAddScoped<ISocialMediaPlatformDataStore, SocialMediaPlatformDataStore>();

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateManager.cs
@@ -1,0 +1,12 @@
+using JosephGuadagno.Broadcasting.Domain.Models;
+
+namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
+
+public interface IMessageTemplateManager
+{
+    Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default);
+    Task<List<MessageTemplate>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<MessageTemplate?> UpdateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default);
+    Task<PagedResult<MessageTemplate>> GetAllAsync(int page, int pageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default);
+    Task<PagedResult<MessageTemplate>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default);
+}

--- a/src/JosephGuadagno.Broadcasting.Managers/MessageTemplateManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/MessageTemplateManager.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain.Interfaces;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace JosephGuadagno.Broadcasting.Managers;
+
+public class MessageTemplateManager : IMessageTemplateManager
+{
+    private readonly IMessageTemplateDataStore _messageTemplateDataStore;
+    private readonly IMemoryCache _cache;
+
+    private const string CacheKeyAll = "MessageTemplate_All";
+    private static string CacheKeyItem(int platformId, string messageType) => $"MessageTemplate_{platformId}_{messageType}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public MessageTemplateManager(IMessageTemplateDataStore messageTemplateDataStore, IMemoryCache cache)
+    {
+        _messageTemplateDataStore = messageTemplateDataStore;
+        _cache = cache;
+    }
+
+    public async Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = CacheKeyItem(socialMediaPlatformId, messageType);
+        if (_cache.TryGetValue(cacheKey, out MessageTemplate? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _messageTemplateDataStore.GetAsync(socialMediaPlatformId, messageType, cancellationToken);
+        if (result is not null)
+        {
+            _cache.Set(cacheKey, result, CacheOptions);
+        }
+        return result;
+    }
+
+    public async Task<List<MessageTemplate>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cache.TryGetValue(CacheKeyAll, out List<MessageTemplate>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _messageTemplateDataStore.GetAllAsync(cancellationToken);
+        _cache.Set(CacheKeyAll, result, CacheOptions);
+        return result;
+    }
+
+    public async Task<PagedResult<MessageTemplate>> GetAllAsync(int page, int pageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default)
+    {
+        var all = await GetAllAsync(cancellationToken);
+        return ApplyFilterSortPage(all, ownerOid: null, page, pageSize, sortBy, sortDescending, filter);
+    }
+
+    public async Task<PagedResult<MessageTemplate>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default)
+    {
+        var all = await GetAllAsync(cancellationToken);
+        return ApplyFilterSortPage(all, ownerOid: ownerEntraOid, page, pageSize, sortBy, sortDescending, filter);
+    }
+
+    public async Task<MessageTemplate?> UpdateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default)
+    {
+        var result = await _messageTemplateDataStore.UpdateAsync(messageTemplate, cancellationToken);
+        if (result is not null)
+        {
+            InvalidateListCaches();
+            _cache.Remove(CacheKeyItem(messageTemplate.SocialMediaPlatformId, messageTemplate.MessageType));
+        }
+        return result;
+    }
+
+    private void InvalidateListCaches()
+    {
+        _cache.Remove(CacheKeyAll);
+    }
+
+    private static PagedResult<MessageTemplate> ApplyFilterSortPage(
+        List<MessageTemplate> source,
+        string? ownerOid,
+        int page,
+        int pageSize,
+        string sortBy,
+        bool sortDescending,
+        string? filter)
+    {
+        IEnumerable<MessageTemplate> query = source;
+
+        if (ownerOid is not null)
+        {
+            query = query.Where(t => t.CreatedByEntraOid == ownerOid);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            query = query.Where(t =>
+                t.MessageType.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                (t.Template != null && t.Template.Contains(filter, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        query = sortBy.ToLowerInvariant() switch
+        {
+            "messagetype" => sortDescending
+                ? query.OrderByDescending(t => t.MessageType)
+                : query.OrderBy(t => t.MessageType),
+            _ => sortDescending
+                ? query.OrderByDescending(t => t.MessageType)
+                : query.OrderBy(t => t.MessageType)
+        };
+
+        var totalCount = query.Count();
+        var items = query.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        return new PagedResult<MessageTemplate> { Items = items, TotalCount = totalCount };
+    }
+}


### PR DESCRIPTION
## Summary

Adds IMemoryCache caching to a new MessageTemplateManager, following the SocialMediaPlatformManager gold-standard pattern.

**Before:** MessageTemplatesController injected IMessageTemplateDataStore directly — every request hit the database.

**After:** Controller injects IMessageTemplateManager. The manager caches the full template list with a 5-minute absolute expiry and invalidates on update.

## Changes

- **Domain/Interfaces/IMessageTemplateManager.cs** (new) — interface with GetAsync, GetAllAsync (2 overloads with filter/sort/page), and UpdateAsync
- **Managers/MessageTemplateManager.cs** (new) — IMemoryCache implementation
  - Full list cached at MessageTemplate_All
  - Individual items cached at MessageTemplate_{platformId}_{messageType}
  - ApplyFilterSortPage helper for in-memory filter/sort/pagination
  - InvalidateListCaches() called on UpdateAsync
- **Api/Controllers/MessageTemplatesController.cs** — injects IMessageTemplateManager instead of IMessageTemplateDataStore
- **Api/Program.cs** — registers IMessageTemplateManager → MessageTemplateManager
- **Api.Tests/Controllers/MessageTemplatesControllerTests.cs** — mocks IMessageTemplateManager

## Testing

All 253 non-SyndicationFeedReader tests pass.

## References

Closes #936
Part of #78