### PR TITLE
feat(#937): Add user-scoped IMemoryCache caching to EngagementManager, ScheduledItemManager, and UserPublisherSettingManager

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/EngagementManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/EngagementManagerTests.cs
@@ -4,6 +4,7 @@ using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers.Tests;
 
@@ -16,7 +17,8 @@ public class EngagementManagerTests
     {
         _repository = new Mock<IEngagementDataStore>();
         var logger = new Mock<ILogger<EngagementManager>>();
-        _engagementManager = new EngagementManager(_repository.Object, logger.Object);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        _engagementManager = new EngagementManager(_repository.Object, logger.Object, cache);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
@@ -206,6 +206,8 @@ public class ScheduledItemManagerTests
     public async Task SentScheduledItemAsync_WithIdOnly_ShouldCallRepositoryWithUtcNow()
     {
         // Arrange
+        var entity = new ScheduledItem { Id = 1 };
+        _repository.Setup(r => r.GetAsync(1, default)).ReturnsAsync(entity);
         _repository.Setup(r => r.SentScheduledItemAsync(1, It.IsAny<DateTimeOffset>())).ReturnsAsync(true);
 
         // Act
@@ -220,6 +222,8 @@ public class ScheduledItemManagerTests
     public async Task SentScheduledItemAsync_WithIdAndDate_ShouldCallRepository()
     {
         // Arrange
+        var entity = new ScheduledItem { Id = 1 };
+        _repository.Setup(r => r.GetAsync(1, default)).ReturnsAsync(entity);
         var sentOn = DateTimeOffset.UtcNow;
         _repository.Setup(r => r.SentScheduledItemAsync(1, sentOn)).ReturnsAsync(true);
 

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/ScheduledItemManagerTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using Microsoft.Extensions.Caching.Memory;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
@@ -13,7 +14,8 @@ public class ScheduledItemManagerTests
     public ScheduledItemManagerTests()
     {
         _repository = new Mock<IScheduledItemDataStore>();
-        _scheduledItemManager = new ScheduledItemManager(_repository.Object);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        _scheduledItemManager = new ScheduledItemManager(_repository.Object, cache);
     }
 
     [Fact]
@@ -244,3 +246,4 @@ public class ScheduledItemManagerTests
         _repository.Verify(r => r.GetOrphanedScheduledItemsAsync("owner-1", default), Times.Once);
     }
 }
+

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/UserPublisherSettingManagerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/UserPublisherSettingManagerTests.cs
@@ -13,7 +13,8 @@ public class UserPublisherSettingManagerTests
 
     public UserPublisherSettingManagerTests()
     {
-        _sut = new UserPublisherSettingManager(_dataStore.Object, _platformManager.Object);
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        _sut = new UserPublisherSettingManager(_dataStore.Object, _platformManager.Object, cache);
     }
 
     [Fact]

--- a/src/JosephGuadagno.Broadcasting.Managers/EngagementManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/EngagementManager.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 
@@ -14,11 +15,18 @@ public class EngagementManager: IEngagementManager
 {
     private readonly IEngagementDataStore _engagementDataStore;
     private readonly ILogger<EngagementManager> _logger;
+    private readonly IMemoryCache _cache;
 
-    public EngagementManager(IEngagementDataStore engagementDataStore, ILogger<EngagementManager> logger)
+    private static string CacheKeyAllByOwner(string ownerEntraOid) => $"Engagements_All_{ownerEntraOid}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public EngagementManager(IEngagementDataStore engagementDataStore, ILogger<EngagementManager> logger, IMemoryCache cache)
     {
         _engagementDataStore = engagementDataStore;
         _logger = logger;
+        _cache = cache;
     }
     
     public async Task<Engagement> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
@@ -48,6 +56,10 @@ public class EngagementManager: IEngagementManager
             _logger.LogError(ex, "Failed to save engagement {EngagementId} with name '{EngagementName}'", entity.Id, entity.Name);
             return OperationResult<Engagement>.Failure("An error occurred while saving the engagement", ex);
         }
+        finally
+        {
+            InvalidateUserCaches(entity.CreatedByEntraOid);
+        }
     }
     
     public async Task<List<Engagement>> GetAllAsync(CancellationToken cancellationToken = default)
@@ -57,16 +69,30 @@ public class EngagementManager: IEngagementManager
 
     public async Task<List<Engagement>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
     {
-        return await _engagementDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        var cacheKey = CacheKeyAllByOwner(ownerEntraOid);
+        if (_cache.TryGetValue(cacheKey, out List<Engagement>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _engagementDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        _cache.Set(cacheKey, result, CacheOptions);
+        return result;
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(Engagement entity, CancellationToken cancellationToken = default)
     {
+        InvalidateUserCaches(entity.CreatedByEntraOid);
         return await _engagementDataStore.DeleteAsync(entity, cancellationToken);
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(int primaryKey, CancellationToken cancellationToken = default)
     {
+        var entity = await _engagementDataStore.GetAsync(primaryKey, cancellationToken);
+        if (entity is not null)
+        {
+            InvalidateUserCaches(entity.CreatedByEntraOid);
+        }
         return await _engagementDataStore.DeleteAsync(primaryKey, cancellationToken);
     }
 
@@ -140,5 +166,13 @@ public class EngagementManager: IEngagementManager
     public async Task<PagedResult<Talk>> GetTalksForEngagementAsync(int engagementId, int page, int pageSize, CancellationToken cancellationToken = default)
     {
         return await _engagementDataStore.GetTalksForEngagementAsync(engagementId, page, pageSize, cancellationToken);
+    }
+
+    private void InvalidateUserCaches(string? ownerEntraOid)
+    {
+        if (!string.IsNullOrEmpty(ownerEntraOid))
+        {
+            _cache.Remove(CacheKeyAllByOwner(ownerEntraOid));
+        }
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/ScheduledItemManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/ScheduledItemManager.cs
@@ -104,7 +104,15 @@ public class ScheduledItemManager : IScheduledItemManager
 
     public async Task<bool> SentScheduledItemAsync(int primaryKey, DateTimeOffset sentOn, CancellationToken cancellationToken = default)
     {
-        return await _scheduledItemDataStore.SentScheduledItemAsync(primaryKey, sentOn, cancellationToken);
+        var entity = await _scheduledItemDataStore.GetAsync(primaryKey, cancellationToken);
+        if (entity is null) return false;
+
+        var result = await _scheduledItemDataStore.SentScheduledItemAsync(primaryKey, sentOn, cancellationToken);
+        if (result)
+        {
+            InvalidateUserCaches(entity.CreatedByEntraOid);
+        }
+        return result;
     }
 
     public async Task<List<ScheduledItem>> GetOrphanedScheduledItemsAsync(CancellationToken cancellationToken = default)

--- a/src/JosephGuadagno.Broadcasting.Managers/ScheduledItemManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/ScheduledItemManager.cs
@@ -6,26 +6,36 @@ using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers;
 
-public class ScheduledItemManager: IScheduledItemManager
+public class ScheduledItemManager : IScheduledItemManager
 {
     private readonly IScheduledItemDataStore _scheduledItemDataStore;
+    private readonly IMemoryCache _cache;
 
-    public ScheduledItemManager(IScheduledItemDataStore scheduledItemDataStore)
+    private static string CacheKeyAllByOwner(string ownerEntraOid) => $"ScheduledItems_All_{ownerEntraOid}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public ScheduledItemManager(IScheduledItemDataStore scheduledItemDataStore, IMemoryCache cache)
     {
         _scheduledItemDataStore = scheduledItemDataStore;
+        _cache = cache;
     }
-    
-    public async Task<ScheduledItem> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
+
+    public async Task<ScheduledItem?> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetAsync(primaryKey, cancellationToken);
     }
 
     public async Task<OperationResult<ScheduledItem>> SaveAsync(ScheduledItem entity, CancellationToken cancellationToken = default)
     {
-        return await _scheduledItemDataStore.SaveAsync(entity, cancellationToken);
+        var result = await _scheduledItemDataStore.SaveAsync(entity, cancellationToken);
+        InvalidateUserCaches(entity.CreatedByEntraOid);
+        return result;
     }
 
     public async Task<List<ScheduledItem>> GetAllAsync(CancellationToken cancellationToken = default)
@@ -35,16 +45,30 @@ public class ScheduledItemManager: IScheduledItemManager
 
     public async Task<List<ScheduledItem>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default)
     {
-        return await _scheduledItemDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        var cacheKey = CacheKeyAllByOwner(ownerEntraOid);
+        if (_cache.TryGetValue(cacheKey, out List<ScheduledItem>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await _scheduledItemDataStore.GetAllAsync(ownerEntraOid, cancellationToken);
+        _cache.Set(cacheKey, result, CacheOptions);
+        return result;
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(ScheduledItem entity, CancellationToken cancellationToken = default)
     {
+        InvalidateUserCaches(entity.CreatedByEntraOid);
         return await _scheduledItemDataStore.DeleteAsync(entity, cancellationToken);
     }
 
     public async Task<OperationResult<bool>> DeleteAsync(int primaryKey, CancellationToken cancellationToken = default)
     {
+        var entity = await _scheduledItemDataStore.GetAsync(primaryKey, cancellationToken);
+        if (entity is not null)
+        {
+            InvalidateUserCaches(entity.CreatedByEntraOid);
+        }
         return await _scheduledItemDataStore.DeleteAsync(primaryKey, cancellationToken);
     }
 
@@ -77,7 +101,7 @@ public class ScheduledItemManager: IScheduledItemManager
     {
         return await SentScheduledItemAsync(primaryKey, DateTimeOffset.UtcNow, cancellationToken);
     }
-    
+
     public async Task<bool> SentScheduledItemAsync(int primaryKey, DateTimeOffset sentOn, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.SentScheduledItemAsync(primaryKey, sentOn, cancellationToken);
@@ -94,7 +118,7 @@ public class ScheduledItemManager: IScheduledItemManager
         var items = await _scheduledItemDataStore.GetOrphanedScheduledItemsAsync(ownerEntraOid, cancellationToken);
         return items.ToList();
     }
-    
+
     public async Task<PagedResult<ScheduledItem>> GetAllAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetAllAsync(page, pageSize, cancellationToken);
@@ -104,7 +128,7 @@ public class ScheduledItemManager: IScheduledItemManager
     {
         return await _scheduledItemDataStore.GetAllAsync(ownerEntraOid, page, pageSize, cancellationToken);
     }
-    
+
     public async Task<PagedResult<ScheduledItem>> GetUnsentScheduledItemsAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetUnsentScheduledItemsAsync(page, pageSize, cancellationToken);
@@ -114,12 +138,12 @@ public class ScheduledItemManager: IScheduledItemManager
     {
         return await _scheduledItemDataStore.GetUnsentScheduledItemsAsync(ownerEntraOid, page, pageSize, cancellationToken);
     }
-    
+
     public async Task<PagedResult<ScheduledItem>> GetScheduledItemsToSendAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetScheduledItemsToSendAsync(page, pageSize, cancellationToken);
     }
-    
+
     public async Task<PagedResult<ScheduledItem>> GetScheduledItemsByCalendarMonthAsync(int year, int month, int page, int pageSize, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetScheduledItemsByCalendarMonthAsync(year, month, page, pageSize, cancellationToken);
@@ -129,7 +153,7 @@ public class ScheduledItemManager: IScheduledItemManager
     {
         return await _scheduledItemDataStore.GetScheduledItemsByCalendarMonthAsync(ownerEntraOid, year, month, page, pageSize, cancellationToken);
     }
-    
+
     public async Task<PagedResult<ScheduledItem>> GetOrphanedScheduledItemsAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetOrphanedScheduledItemsAsync(page, pageSize, cancellationToken);
@@ -148,5 +172,13 @@ public class ScheduledItemManager: IScheduledItemManager
     public async Task<PagedResult<ScheduledItem>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "sendondate", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetAllAsync(ownerEntraOid, page, pageSize, sortBy, sortDescending, filter, cancellationToken);
+    }
+
+    private void InvalidateUserCaches(string? ownerEntraOid)
+    {
+        if (!string.IsNullOrEmpty(ownerEntraOid))
+        {
+            _cache.Remove(CacheKeyAllByOwner(ownerEntraOid));
+        }
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/ScheduledItemManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/ScheduledItemManager.cs
@@ -26,7 +26,7 @@ public class ScheduledItemManager : IScheduledItemManager
         _cache = cache;
     }
 
-    public async Task<ScheduledItem?> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
+    public async Task<ScheduledItem> GetAsync(int primaryKey, CancellationToken cancellationToken = default)
     {
         return await _scheduledItemDataStore.GetAsync(primaryKey, cancellationToken);
     }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherSettingManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherSettingManager.cs
@@ -3,41 +3,68 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace JosephGuadagno.Broadcasting.Managers;
 
-public class UserPublisherSettingManager(
-    IUserPublisherSettingDataStore userPublisherSettingDataStore,
-    ISocialMediaPlatformManager socialMediaPlatformManager) : IUserPublisherSettingManager
+public class UserPublisherSettingManager : IUserPublisherSettingManager
 {
+    private readonly IUserPublisherSettingDataStore _userPublisherSettingDataStore;
+    private readonly ISocialMediaPlatformManager _socialMediaPlatformManager;
+    private readonly IMemoryCache _cache;
+
+    private static string CacheKeyAllByOwner(string ownerOid) => $"UserPublisherSettings_All_{ownerOid}";
+
+    private static readonly MemoryCacheEntryOptions CacheOptions =
+        new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+    public UserPublisherSettingManager(
+        IUserPublisherSettingDataStore userPublisherSettingDataStore,
+        ISocialMediaPlatformManager socialMediaPlatformManager,
+        IMemoryCache cache)
+    {
+        _userPublisherSettingDataStore = userPublisherSettingDataStore;
+        _socialMediaPlatformManager = socialMediaPlatformManager;
+        _cache = cache;
+    }
+
     public async Task<List<UserPublisherSetting>> GetByUserAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
-        var settings = await userPublisherSettingDataStore.GetByUserAsync(ownerOid, cancellationToken);
-        return settings.Select(ProjectForResponse).ToList();
+        var cacheKey = CacheKeyAllByOwner(ownerOid);
+        if (_cache.TryGetValue(cacheKey, out List<UserPublisherSetting>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var settings = await _userPublisherSettingDataStore.GetByUserAsync(ownerOid, cancellationToken);
+        var result = settings.Select(ProjectForResponse).ToList();
+        _cache.Set(cacheKey, result, CacheOptions);
+        return result;
     }
 
     public async Task<UserPublisherSetting?> GetByUserAndPlatformAsync(string ownerOid, int platformId, CancellationToken cancellationToken = default)
     {
-        var setting = await userPublisherSettingDataStore.GetByUserAndPlatformAsync(ownerOid, platformId, cancellationToken);
+        var setting = await _userPublisherSettingDataStore.GetByUserAndPlatformAsync(ownerOid, platformId, cancellationToken);
         return setting is null ? null : ProjectForResponse(setting);
     }
 
     public async Task<UserPublisherSetting?> SaveAsync(UserPublisherSettingUpdate setting, CancellationToken cancellationToken = default)
     {
-        var platform = await socialMediaPlatformManager.GetByIdAsync(setting.SocialMediaPlatformId, cancellationToken);
+        var platform = await _socialMediaPlatformManager.GetByIdAsync(setting.SocialMediaPlatformId, cancellationToken);
         if (platform is null)
         {
             return null;
         }
 
-        var existing = await userPublisherSettingDataStore.GetByUserAndPlatformAsync(
+        var existing = await _userPublisherSettingDataStore.GetByUserAndPlatformAsync(
             setting.CreatedByEntraOid,
             setting.SocialMediaPlatformId,
             cancellationToken);
 
-        var persisted = await userPublisherSettingDataStore.SaveAsync(
+        var persisted = await _userPublisherSettingDataStore.SaveAsync(
             new UserPublisherSetting
             {
                 Id = existing?.Id ?? 0,
@@ -51,22 +78,32 @@ public class UserPublisherSettingManager(
             },
             cancellationToken);
 
+        InvalidateUserCaches(setting.CreatedByEntraOid);
         return persisted is null ? null : ProjectForResponse(persisted);
     }
 
     public Task<bool> DeleteAsync(string ownerOid, int platformId, CancellationToken cancellationToken = default)
     {
-        return userPublisherSettingDataStore.DeleteAsync(ownerOid, platformId, cancellationToken);
+        InvalidateUserCaches(ownerOid);
+        return _userPublisherSettingDataStore.DeleteAsync(ownerOid, platformId, cancellationToken);
     }
 
     public async Task<PagedResult<UserPublisherSetting>> GetAllAsync(string ownerOid, int page, int pageSize, string sortBy = "platformname", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default)
     {
-        var pagedResult = await userPublisherSettingDataStore.GetAllAsync(ownerOid, page, pageSize, sortBy, sortDescending, filter, cancellationToken);
+        var pagedResult = await _userPublisherSettingDataStore.GetAllAsync(ownerOid, page, pageSize, sortBy, sortDescending, filter, cancellationToken);
         return new PagedResult<UserPublisherSetting>
         {
             Items = pagedResult.Items.Select(ProjectForResponse).ToList(),
             TotalCount = pagedResult.TotalCount
         };
+    }
+
+    private void InvalidateUserCaches(string? ownerOid)
+    {
+        if (!string.IsNullOrEmpty(ownerOid))
+        {
+            _cache.Remove(CacheKeyAllByOwner(ownerOid));
+        }
     }
 
     private static UserPublisherSetting ProjectForResponse(UserPublisherSetting setting)


### PR DESCRIPTION
## Summary

Implements Priority 2 user-scoped in-process caching for three managers as described in #937 (child of #78).

## Changes

### Managers
- **EngagementManager**: Added \IMemoryCache\ constructor parameter; \GetAllAsync(ownerEntraOid)\ reads/writes cache; \SaveAsync\ invalidates in \inally\ block; \DeleteAsync\ invalidates before delete.
- **ScheduledItemManager**: Added \IMemoryCache\ constructor parameter; \GetAllAsync(ownerEntraOid)\ reads/writes cache; \SaveAsync\ invalidates after persist; \DeleteAsync\ fetches entity first to get owner OID, then invalidates.
- **UserPublisherSettingManager**: Converted C# 12 primary constructor to explicit constructor to allow \IMemoryCache\ injection; \GetByUserAsync(ownerOid)\ caches projected results; \SaveAsync\/\DeleteAsync\ invalidate as appropriate.

### Tests
- Updated all three test constructors to pass a real \MemoryCache\ instance.

## Design
- Cache key pattern: \{Entity}_All_{ownerOid}\ (per-user scoping)
- 5-minute absolute expiry via shared static \MemoryCacheEntryOptions\
- Only non-paged \GetAll(ownerOid)\ is cached; paged overloads go straight to DB
- No \Program.cs\ changes needed — \AddMemoryCache()\ is already registered

Closes #937