### PR TITLE
chore(squad): fix PR comment posting pattern in all 12 agent charters (#942)

### DIFF
--- a/.squad/agents/cypher/charter.md
+++ b/.squad/agents/cypher/charter.md
@@ -58,24 +58,63 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use `@'...'@` (single-quoted) — PowerShell treats everything inside as **literal text**.
+
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
+
+#### Posting a PR/issue comment (copy this exactly):
 
 ```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+# SINGLE-QUOTED here-string — backticks are safe here
+$body = @'
+Your comment with `code` and **markdown** here.
+Multi-line is fine. Backticks work.
+'@
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+#### Editing an existing comment:
+
+```powershell
+$body = @'
+Updated content here.
+'@
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+#### Creating/updating a PR body:
+
+```powershell
+$body = @'
+## Summary
+PR description with `code` and **markdown**.
+'@
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+# For new PR:
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\gh-pr.json" --base main
+# For existing PR:
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+#### Self-check BEFORE posting (non-optional):
+
+```powershell
+# Check for \word\ patterns — these are always wrong
+$body | Select-String -Pattern '\\[A-Za-z]' | ForEach-Object { Write-Warning "FIX: $_" }
+```
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, `@"..."@` for any content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/ghost/charter.md
+++ b/.squad/agents/ghost/charter.md
@@ -70,24 +70,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/link/charter.md
+++ b/.squad/agents/link/charter.md
@@ -68,24 +68,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/morpheus/charter.md
+++ b/.squad/agents/morpheus/charter.md
@@ -41,24 +41,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Model
 

--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -45,24 +45,63 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use `@'...'@` (single-quoted) — PowerShell treats everything inside as **literal text**.
+
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
+
+#### Posting a PR/issue comment (copy this exactly):
 
 ```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+# SINGLE-QUOTED here-string — backticks are safe here
+$body = @'
+Your comment with `code` and **markdown** here.
+Multi-line is fine. Backticks work.
+'@
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+#### Editing an existing comment:
+
+```powershell
+$body = @'
+Updated content here.
+'@
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+#### Creating/updating a PR body:
+
+```powershell
+$body = @'
+## Summary
+PR description with `code` and **markdown**.
+'@
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+# For new PR:
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\gh-pr.json" --base main
+# For existing PR:
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+#### Self-check BEFORE posting (non-optional):
+
+```powershell
+# Check for \word\ patterns — these are always wrong
+$body | Select-String -Pattern '\\[A-Za-z]' | ForEach-Object { Write-Warning "FIX: $_" }
+```
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, `@"..."@` for any content containing backticks.
 
 ## Model
 

--- a/.squad/agents/oracle/charter.md
+++ b/.squad/agents/oracle/charter.md
@@ -57,24 +57,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -55,24 +55,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with `backticks` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -80,24 +80,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/sparks/charter.md
+++ b/.squad/agents/sparks/charter.md
@@ -71,24 +71,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with `backticks` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/switch/charter.md
+++ b/.squad/agents/switch/charter.md
@@ -57,24 +57,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -77,24 +77,40 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use single-quoted `@'` / `'@` — PowerShell treats everything inside as **literal text**.
 
-```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with ``backticks`` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+**Posting a comment** — copy this exactly, substitute `ISSUE_OR_PR_NUMBER`:
+```
+$body = [the content between single-quote markers as a single-quoted here-string]
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+**Editing a comment** — substitute `COMMENT_ID`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+**Creating/updating PR body** — substitute `PR_NUMBER`:
+```
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+**Self-check BEFORE posting:** `$body | Select-String -Pattern '\\[A-Za-z]'` — if this matches, fix the `\word\` instances to backtick-word-backtick before posting.
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, or double-quoted `@"` here-strings for content containing backticks.
 
 ## Voice
 

--- a/.squad/agents/trinity/charter.md
+++ b/.squad/agents/trinity/charter.md
@@ -41,24 +41,63 @@ When writing GitHub issue bodies, PR descriptions, or PR review comments:
 - Fenced code blocks use triple backticks with a language hint: ` ```csharp `
 - **Self-check before posting:** scan your draft for `\word\` patterns — replace every instance with `` `word` `` before submitting
 
-### ⚠️ PR Creation — MANDATORY (chronic violation, 20+ occurrences)
+### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS (chronic violation, 30+ occurrences)
 
-**NEVER** pass the PR body inline to `gh pr create --body "..."` — PowerShell mangles backticks and produces `\text\` garbage. **ALWAYS** write the body to a temp file first:
+**Root cause of every malformed comment:** `@"..."@` (double-quoted here-string) — PowerShell interprets backticks inside it, turning `` `false` `` into `\false\`. Always use `@'...'@` (single-quoted) — PowerShell treats everything inside as **literal text**.
+
+**`python3` is NOT available on this machine. Use `ConvertTo-Json`.**
+
+#### Posting a PR/issue comment (copy this exactly):
 
 ```powershell
-# Write body to temp file
-$prBody = @"
-## Summary
-Your PR description with `backticks` and **markdown** here...
-"@
-$prBody | Set-Content "$env:TEMP\pr-body.md"
+# SINGLE-QUOTED here-string — backticks are safe here
+$body = @'
+Your comment with `code` and **markdown** here.
+Multi-line is fine. Backticks work.
+'@
 
-# Create PR using the file
-gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\pr-body.md" --base main
-Remove-Item "$env:TEMP\pr-body.md" -Force
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/ISSUE_OR_PR_NUMBER/comments --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
 ```
 
-Same rule for `gh pr edit`: use `gh api repos/.../pulls/{N} -X PATCH --input <tmpfile>`, never `--body` inline.
+#### Editing an existing comment:
+
+```powershell
+$body = @'
+Updated content here.
+'@
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-comment.json" -Encoding UTF8
+gh api repos/jguadagno/jjgnet-broadcast/issues/comments/COMMENT_ID -X PATCH --input "$env:TEMP\gh-comment.json"
+Remove-Item "$env:TEMP\gh-comment.json" -Force
+```
+
+#### Creating/updating a PR body:
+
+```powershell
+$body = @'
+## Summary
+PR description with `code` and **markdown**.
+'@
+$json = [PSCustomObject]@{ body = $body } | ConvertTo-Json -Depth 1
+$json | Set-Content "$env:TEMP\gh-pr.json" -Encoding UTF8
+# For new PR:
+gh pr create --title "feat(#N): ..." --body-file "$env:TEMP\gh-pr.json" --base main
+# For existing PR:
+gh api repos/jguadagno/jjgnet-broadcast/pulls/PR_NUMBER -X PATCH --input "$env:TEMP\gh-pr.json"
+Remove-Item "$env:TEMP\gh-pr.json" -Force
+```
+
+#### Self-check BEFORE posting (non-optional):
+
+```powershell
+# Check for \word\ patterns — these are always wrong
+$body | Select-String -Pattern '\\[A-Za-z]' | ForEach-Object { Write-Warning "FIX: $_" }
+```
+
+**NEVER use:** `gh pr review --body "..."`, `gh pr comment --body "..."`, `gh pr create --body "..."`, `@"..."@` for any content containing backticks.
 
 ## Model
 


### PR DESCRIPTION
## Summary

Fixes the chronic malformed-comment problem by updating all 12 agent charters to use single-quoted PowerShell here-strings.

## Root Cause

`@"..."@` (double-quoted) causes PowerShell to interpret backticks as escape characters, turning `` `word` `` into `\word\` in GitHub comments. `@'...'@` (single-quoted) treats content as completely literal.

Also replaces `python3` JSON encoding (not available on this machine) with `[PSCustomObject] | ConvertTo-Json`.

## Changes

All 12 agent charters updated:
- **Section replaced:** `### ⚠️ PR Creation — MANDATORY` → `### ⚠️ GitHub Comment/PR Posting — MANDATORY EXACT COMMANDS`
- Added canonical commands for posting comments, editing comments, and updating PR bodies
- Added self-check command: `$body | Select-String -Pattern '\\[A-Za-z]'`

Agents: neo, trinity, cypher, morpheus, oracle, scribe, switch, tank, ghost, link, ralph, sparks

## Testing

No code changes — `.squad/` charter files only. No build or test run required.

Closes #942
