### PR TITLE
fix(#930): replace deprecated AspNetCore.HealthChecks.AzureStorage package

### DIFF
--- a/src/JosephGuadagno.Broadcasting.ServiceDefaults/Extensions.cs
+++ b/src/JosephGuadagno.Broadcasting.ServiceDefaults/Extensions.cs
@@ -1,4 +1,5 @@
 using Azure.Data.Tables;
+using Azure.Storage.Queues;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -120,7 +121,7 @@ public static class Extensions
         if (!string.IsNullOrWhiteSpace(storageConn))
         {
             hcBuilder.AddAzureQueueStorage(
-                connectionString: storageConn,
+                clientFactory: _ => new QueueServiceClient(storageConn),
                 name: "azurestorage",
                 failureStatus: HealthStatus.Unhealthy,
                 tags: ["storage", "ready"]);

--- a/src/JosephGuadagno.Broadcasting.ServiceDefaults/JosephGuadagno.Broadcasting.ServiceDefaults.csproj
+++ b/src/JosephGuadagno.Broadcasting.ServiceDefaults/JosephGuadagno.Broadcasting.ServiceDefaults.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.AzureStorage" Version="7.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Data.Tables" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Queues" Version="9.0.0" />
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.0" />


### PR DESCRIPTION
## Summary

Replaces the deprecated `AspNetCore.HealthChecks.AzureStorage` NuGet package with the specific Azure Storage health check packages.

Closes #930

## Changes

### `JosephGuadagno.Broadcasting.ServiceDefaults`

**Packages:**
- Removed: `AspNetCore.HealthChecks.AzureStorage` (v7.0.0) — deprecated
- Added: `AspNetCore.HealthChecks.Azure.Storage.Queues` (v9.0.0)
- Already present: `AspNetCore.HealthChecks.Azure.Data.Tables` (v9.0.0) — no change needed

**`Extensions.cs`:**
- Added `using Azure.Storage.Queues;`
- Updated `AddAzureQueueStorage(...)` call: the new package no longer accepts a `connectionString` parameter. It now requires a `QueueServiceClient` instance via `clientFactory`. Updated to:
  ```csharp
  hcBuilder.AddAzureQueueStorage(
      clientFactory: _ => new QueueServiceClient(storageConn),
      name: "azurestorage",
      failureStatus: HealthStatus.Unhealthy,
      tags: ["storage", "ready"]);
  ```
- `AddAzureTable(...)` already used `clientFactory` — no change needed.
- `AspNetCore.HealthChecks.Azure.Storage.Blobs` was not added — there are no blob health checks in this codebase.

## Testing

```
dotnet build .\src\ --no-restore --configuration Release
dotnet test .\src\ --no-build --verbosity normal --configuration Release
```

Build succeeded. All tests pass (0 failures).