### PR TITLE
fix(#945): register ISocialMediaPlatformManager in Web DI container

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -259,6 +259,7 @@ void ConfigureApplication(IServiceCollection services)
     services.AddSqlDataStores();
 
     services.TryAddScoped<IUserOAuthTokenManager, UserOAuthTokenManager>();
+    services.TryAddScoped<ISocialMediaPlatformManager, SocialMediaPlatformManager>();
     
     services.TryAddScoped<IEngagementService, EngagementService>();
     services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();


### PR DESCRIPTION
## Summary

Closes #945

`LinkedInController` injects `ISocialMediaPlatformManager` but the Web project's DI container never registered the service. This caused an `InvalidOperationException` on startup whenever a user navigated to `/LinkedIn`.

## Root Cause

`Program.cs` (`ConfigureApplication`) registered `IUserOAuthTokenManager` and all Web services, but `ISocialMediaPlatformManager` was omitted. At runtime the DI container cannot resolve the controller constructor and throws.

## Fix

Added one line to `ConfigureApplication` in `src/JosephGuadagno.Broadcasting.Web/Program.cs`:

```csharp
services.TryAddScoped<ISocialMediaPlatformManager, SocialMediaPlatformManager>();
```

This follows the identical pattern already used for `IUserOAuthTokenManager` immediately above it. No project reference changes were required — the Web project already has a `<ProjectReference>` to `JosephGuadagno.Broadcasting.Managers`.

## Testing

```
dotnet build .\src\ --no-restore --configuration Release
dotnet test .\src\ --no-build --verbosity normal --configuration Release
```

Build: 0 errors, 43 warnings (pre-existing).
Tests: 158 passed, 0 failed.