### PR TITLE
fix(#945): update LinkedInController to use service layer

### DIFF
--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -4,6 +4,16 @@
 
 Tank (QA Engineer) builds comprehensive test coverage across unit, integration, security, and regression test categories using xUnit, FluentAssertions, and Moq. Primary focus: ensuring backend API contracts work correctly, authorization/RBAC logic is enforced, ownership isolation prevents data leaks, and authentication flows are secure. Key test patterns include: mocking external services (HttpClientFactory via Moq), testing async operations with Task.Delay and verification, ownership isolation regression tests (verify User A cannot access User B's resources), and RBAC authorization tests (verify Viewers cannot POST, Admins can manage users). Tank works closely with Trinity (API endpoint contracts), Switch (Web-layer integration tests), and Neo (security test patterns). Established pattern: write tests before implementation (TDD), test both happy path and error cases, use descriptive test names like `GetEngagements_WhenUserIsContributor_ShouldReturnOwnEngagementsOnly`, mock external dependencies, and verify authorization boundaries. Notable: Tank maintains ownership isolation test suite to prevent regressions as new features are added. Key decision: ownership tests go in integration test class alongside endpoint tests, not as separate security-only test file.
 
+## Recent Session: Issue #945 LinkedInController Test Coverage (2026-05-09)
+
+- **Work:** Added 4 new tests to `LinkedInControllerTests.cs` covering gaps in the existing 8 tests
+- **Result:** ✅ COMPLETE — 12/12 LinkedInController tests pass; 236/236 Web tests pass
+- **Tests Added:** `Index_WhenPlatformNotFound`, `Callback_WhenCallbackUrlMissing`, `Callback_WhenTokenResponseIsNull`, `Callback_WhenTokenHasRefreshExpiry`
+- **Commit:** `ec3c255` on branch `issue-945-linkedin-di-fix`
+- **Key Learning:** The Web project has its own `ISocialMediaPlatformService` (distinct from Domain's `ISocialMediaPlatformManager`); `LinkedInController` on this branch uses the Web-layer service. Test mocks must target `ISocialMediaPlatformService`.
+
+---
+
 ## Recent Session: Sprint 30 #897 ISocialMediaPublisher Interface Tests (2026-05-01)
 
 - **Work:** Completed comprehensive test coverage for ISocialMediaPublisher contract across all four platform managers

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/LinkedInControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/Controllers/LinkedInControllerTests.cs
@@ -17,6 +17,7 @@ using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Web.Controllers;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
 using JosephGuadagno.Broadcasting.Web.Models;
 using JosephGuadagno.Broadcasting.Web.Models.LinkedIn;
 
@@ -56,7 +57,7 @@ public class LinkedInControllerTests
     private const string TestOwnerOid = "test-owner-oid-12345";
 
     private readonly Mock<IUserOAuthTokenManager> _userOAuthTokenManager;
-    private readonly Mock<ISocialMediaPlatformManager> _socialMediaPlatformManager;
+    private readonly Mock<ISocialMediaPlatformService> _socialMediaPlatformService;
     private readonly LinkedInSettings _linkedInSettings;
     private readonly Mock<ILogger<LinkedInController>> _logger;
     private readonly SocialMediaPlatform _linkedInPlatform;
@@ -64,7 +65,7 @@ public class LinkedInControllerTests
     public LinkedInControllerTests()
     {
         _userOAuthTokenManager = new Mock<IUserOAuthTokenManager>();
-        _socialMediaPlatformManager = new Mock<ISocialMediaPlatformManager>();
+        _socialMediaPlatformService = new Mock<ISocialMediaPlatformService>();
         _linkedInSettings = new LinkedInSettings
         {
             ClientId = "test-client-id",
@@ -77,7 +78,7 @@ public class LinkedInControllerTests
         _linkedInPlatform = new SocialMediaPlatform { Id = 3, Name = "LinkedIn", IsActive = true };
 
         // Default: platform lookup returns LinkedIn
-        _socialMediaPlatformManager
+        _socialMediaPlatformService
             .Setup(m => m.GetByNameAsync("LinkedIn", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_linkedInPlatform);
     }
@@ -88,7 +89,7 @@ public class LinkedInControllerTests
         return new LinkedInController(
             httpClient,
             _userOAuthTokenManager.Object,
-            _socialMediaPlatformManager.Object,
+            _socialMediaPlatformService.Object,
             Options.Create(_linkedInSettings),
             _logger.Object);
     }
@@ -352,5 +353,179 @@ public class LinkedInControllerTests
         var authorizeAttribute = attributes.First() as AuthorizeAttribute;
         Assert.NotNull(authorizeAttribute);
         Assert.Equal(AuthorizationPolicyNames.RequireContributor, authorizeAttribute!.Policy);
+    }
+
+    [Fact]
+    public async Task Index_WhenPlatformNotFound_ShouldReturnViewWithHasTokenFalse()
+    {
+        // Arrange
+        _socialMediaPlatformService
+            .Setup(m => m.GetByNameAsync("LinkedIn", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SocialMediaPlatform?)null);
+
+        var controller = CreateController();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildAuthenticatedHttpContext()
+        };
+
+        // Act
+        var result = await controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SavedTokenInfo>(viewResult.Model);
+        Assert.False(model.HasToken);
+        _userOAuthTokenManager.Verify(
+            m => m.GetByUserAndPlatformAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Callback_WhenCallbackUrlMissing_ShouldReturnBadRequest()
+    {
+        // Arrange
+        const string stateValue = "matching-state";
+        var controller = CreateController();
+
+        var session = new TestSession();
+        session.Set("state", Encoding.UTF8.GetBytes(stateValue));
+
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
+        httpContext.Request.QueryString = new QueryString($"?code=auth-code&state={stateValue}");
+
+        var mockUrlHelper = new Mock<IUrlHelper>();
+        mockUrlHelper
+            .Setup(u => u.Action(It.IsAny<UrlActionContext>()))
+            .Returns((string?)null);
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        controller.Url = mockUrlHelper.Object;
+
+        // Act
+        var result = await controller.Callback();
+
+        // Assert
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Callback_WhenTokenResponseIsNull_ShouldReturnBadRequest()
+    {
+        // Arrange
+        const string stateValue = "valid-state";
+        const string authCode = "valid-auth-code";
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Loose);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("null", Encoding.UTF8, "application/json")
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var controller = CreateController(httpClient);
+
+        var session = new TestSession();
+        session.Set("state", Encoding.UTF8.GetBytes(stateValue));
+
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
+        httpContext.Request.QueryString = new QueryString($"?code={authCode}&state={stateValue}");
+
+        var mockUrlHelper = new Mock<IUrlHelper>();
+        mockUrlHelper
+            .Setup(u => u.Action(It.IsAny<UrlActionContext>()))
+            .Returns("https://myapp.example.com/LinkedIn/Callback");
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        controller.Url = mockUrlHelper.Object;
+
+        // Act
+        var result = await controller.Callback();
+
+        // Assert
+        Assert.IsType<BadRequestResult>(result);
+        _userOAuthTokenManager.Verify(
+            m => m.StoreOAuthCallbackTokenAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Callback_WhenTokenHasRefreshExpiry_ShouldStoreWithRefreshTokenExpiry()
+    {
+        // Arrange
+        const string stateValue = "valid-state";
+        const string authCode = "valid-auth-code";
+
+        var tokenResponse = new
+        {
+            access_token = "new-access-token",
+            expires_in = 5183944,
+            refresh_token = "new-refresh-token",
+            refresh_token_expires_in = 31536000,
+            scope = "openid profile email"
+        };
+        var tokenJson = JsonSerializer.Serialize(tokenResponse);
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Loose);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(tokenJson, Encoding.UTF8, "application/json")
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var controller = CreateController(httpClient);
+
+        var session = new TestSession();
+        session.Set("state", Encoding.UTF8.GetBytes(stateValue));
+
+        var httpContext = BuildAuthenticatedHttpContext(session: session);
+        httpContext.Request.QueryString = new QueryString($"?code={authCode}&state={stateValue}");
+
+        var mockUrlHelper = new Mock<IUrlHelper>();
+        mockUrlHelper
+            .Setup(u => u.Action(It.IsAny<UrlActionContext>()))
+            .Returns("https://myapp.example.com/LinkedIn/Callback");
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        controller.Url = mockUrlHelper.Object;
+
+        _userOAuthTokenManager
+            .Setup(m => m.StoreOAuthCallbackTokenAsync(
+                TestOwnerOid, 3,
+                "new-access-token",
+                "new-refresh-token",
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserOAuthToken?)null);
+
+        // Act
+        var result = await controller.Callback();
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirectResult.ActionName);
+
+        _userOAuthTokenManager.Verify(m => m.StoreOAuthCallbackTokenAsync(
+            TestOwnerOid, 3,
+            "new-access-token",
+            "new-refresh-token",
+            It.IsAny<DateTimeOffset>(),
+            It.Is<DateTimeOffset?>(d => d.HasValue), // refresh expiry must be set
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/LinkedInController.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Utilities;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
 using JosephGuadagno.Broadcasting.Web.Models;
 using JosephGuadagno.Broadcasting.Web.Models.LinkedIn;
 using Microsoft.AspNetCore.Authorization;
@@ -19,7 +20,7 @@ public class LinkedInController : Controller
 {
     private readonly HttpClient _httpClient;
     private readonly IUserOAuthTokenManager _userOAuthTokenManager;
-    private readonly ISocialMediaPlatformManager _socialMediaPlatformManager;
+    private readonly ISocialMediaPlatformService _socialMediaPlatformService;
     private readonly LinkedInSettings _linkedInSettings;
     private readonly ILogger<LinkedInController> _logger;
 
@@ -31,13 +32,13 @@ public class LinkedInController : Controller
     public LinkedInController(
         HttpClient httpClient,
         IUserOAuthTokenManager userOAuthTokenManager,
-        ISocialMediaPlatformManager socialMediaPlatformManager,
+        ISocialMediaPlatformService socialMediaPlatformService,
         IOptions<LinkedInSettings> linkedInSettingsOptions,
         ILogger<LinkedInController> logger)
     {
         _httpClient = httpClient;
         _userOAuthTokenManager = userOAuthTokenManager;
-        _socialMediaPlatformManager = socialMediaPlatformManager;
+        _socialMediaPlatformService = socialMediaPlatformService;
         _linkedInSettings = linkedInSettingsOptions.Value;
         _logger = logger;
     }
@@ -54,7 +55,7 @@ public class LinkedInController : Controller
             return View(new SavedTokenInfo { HasToken = false });
         }
 
-        var platform = await _socialMediaPlatformManager.GetByNameAsync("LinkedIn");
+        var platform = await _socialMediaPlatformService.GetByNameAsync("LinkedIn");
         if (platform is null)
         {
             _logger.LogWarning("LinkedIn platform not found in database");
@@ -156,7 +157,7 @@ public class LinkedInController : Controller
         var ownerOid = User.FindFirstValue("oid")
             ?? throw new InvalidOperationException("User OID claim is missing");
 
-        var platform = await _socialMediaPlatformManager.GetByNameAsync("LinkedIn", cancellationToken)
+        var platform = await _socialMediaPlatformService.GetByNameAsync("LinkedIn", cancellationToken)
             ?? throw new InvalidOperationException("LinkedIn platform not found");
 
         var accessTokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISocialMediaPlatformService.cs
@@ -43,4 +43,9 @@ public interface ISocialMediaPlatformService
     /// Deletes a social media platform via the API
     /// </summary>
     Task<bool> DeleteAsync(int id);
+
+    /// <summary>
+    /// Gets an active social media platform by its name (case-insensitive)
+    /// </summary>
+    Task<SocialMediaPlatform?> GetByNameAsync(string name, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -259,6 +259,7 @@ void ConfigureApplication(IServiceCollection services)
     services.AddSqlDataStores();
 
     services.TryAddScoped<IUserOAuthTokenManager, UserOAuthTokenManager>();
+    services.TryAddScoped<ISocialMediaPlatformManager, SocialMediaPlatformManager>();
     
     services.TryAddScoped<IEngagementService, EngagementService>();
     services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -259,7 +259,6 @@ void ConfigureApplication(IServiceCollection services)
     services.AddSqlDataStores();
 
     services.TryAddScoped<IUserOAuthTokenManager, UserOAuthTokenManager>();
-    services.TryAddScoped<ISocialMediaPlatformManager, SocialMediaPlatformManager>();
     
     services.TryAddScoped<IEngagementService, EngagementService>();
     services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();
@@ -269,7 +268,6 @@ void ConfigureApplication(IServiceCollection services)
     services.TryAddScoped<IUserCollectorFeedSourceService, UserCollectorFeedSourceService>();
     services.TryAddScoped<IUserCollectorYouTubeChannelService, UserCollectorYouTubeChannelService>();
     services.TryAddScoped<IMessageTemplateService, MessageTemplateService>();
-    services.TryAddScoped<ISocialMediaPlatformService, SocialMediaPlatformService>();
     services.TryAddScoped<IYouTubeSourceService, YouTubeSourceService>();
     services.TryAddScoped<ISyndicationFeedSourceService, SyndicationFeedSourceService>();
 

--- a/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/SocialMediaPlatformService.cs
@@ -98,4 +98,15 @@ public class SocialMediaPlatformService(IDownstreamApi apiClient, ILogger<Social
             response?.StatusCode, id);
         return false;
     }
+
+    /// <summary>
+    /// Gets an active social media platform by its name (case-insensitive).
+    /// Uses the filter parameter on the list endpoint and returns the first exact match.
+    /// </summary>
+    public async Task<SocialMediaPlatform?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var result = await GetAllAsync(page: 1, pageSize: 10, filter: name);
+        return result.Items.FirstOrDefault(p =>
+            string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #945

`LinkedInController` in the Web project was injecting `ISocialMediaPlatformManager` directly — a backend manager that belongs in the API/Functions layer, not the Web layer. The Web project communicates with the backend exclusively through the HTTP-client service layer.

## Root cause

The controller was written with the wrong dependency: `ISocialMediaPlatformManager` was injected to call `GetByNameAsync("LinkedIn")`. This required registering the manager (and its full SQL data-store chain) in the Web project's DI container, violating the service-layer boundary.

## Fix

- **`ISocialMediaPlatformService`** — added `GetByNameAsync(string name, CancellationToken)` to the interface.
- **`SocialMediaPlatformService`** — implemented `GetByNameAsync` by delegating to `GetAllAsync` with a name filter and returning the first exact match (case-insensitive). No new API endpoint required.
- **`LinkedInController`** — replaced `ISocialMediaPlatformManager` injection with `ISocialMediaPlatformService`.
- **`Program.cs` (Web)** — removed `ISocialMediaPlatformManager` registration and the duplicate `ISocialMediaPlatformService` registration.
- **`LinkedInControllerTests`** — updated all mocks from `ISocialMediaPlatformManager` to `ISocialMediaPlatformService`.

`IUserOAuthTokenManager` is intentionally retained: there is no API endpoint for per-user OAuth tokens, and the Web project already legitimately uses several managers without API counterparts (`IUserApprovalManager`, `IEmailTemplateManager`).

## Testing

- All 242+ tests pass (`dotnet test` with SyndicationFeedReader excluded).
- Build is clean with 0 errors.