### PR TITLE
refactor(#966): extract shared keyvault secret name builder utility

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretNameBuilder.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretNameBuilder.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+
+namespace JosephGuadagno.Broadcasting.Domain.Utilities;
+
+/// <summary>
+/// Builds sanitized Azure Key Vault secret names for collector and publisher settings.
+/// </summary>
+public static class KeyVaultSecretNameBuilder
+{
+    private static readonly Regex SecretNameSanitizer = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Builds a Key Vault secret name in the format:
+    /// <c>{type}-{sanitizedOwnerOid}-{platform}-{settingName}</c>
+    /// or, when a discriminator is provided:
+    /// <c>{type}-{sanitizedOwnerOid}-{platform}-{discriminator}-{settingName}</c>
+    /// </summary>
+    /// <param name="type">The category of the secret, e.g. "collector" or "publisher".</param>
+    /// <param name="ownerOid">The owner's Entra (AAD) object ID. Non-alphanumeric/hyphen characters are replaced with hyphens.</param>
+    /// <param name="platform">The platform name, e.g. "bluesky", "youtube-channel".</param>
+    /// <param name="settingName">The setting name, e.g. "app-password", "api-key".</param>
+    /// <param name="discriminator">An optional discriminator inserted between platform and settingName, e.g. a YouTube channel ID.</param>
+    /// <returns>The sanitized Key Vault secret name.</returns>
+    public static string Build(string type, string ownerOid, string platform, string settingName, string? discriminator = null)
+    {
+        var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
+        return discriminator is null
+            ? $"{type}-{sanitizedOwner}-{platform}-{settingName}"
+            : $"{type}-{sanitizedOwner}-{platform}-{discriminator}-{settingName}";
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretNameBuilder.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretNameBuilder.cs
@@ -11,18 +11,19 @@ public static class KeyVaultSecretNameBuilder
 
     /// <summary>
     /// Builds a Key Vault secret name in the format:
-    /// <c>{type}-{sanitizedOwnerOid}-{platform}-{settingName}</c>
+    /// <c>{ownerType}-{sanitizedOwnerOid}-{platform}-{settingName}</c>
     /// or, when a discriminator is provided:
-    /// <c>{type}-{sanitizedOwnerOid}-{platform}-{discriminator}-{settingName}</c>
+    /// <c>{ownerType}-{sanitizedOwnerOid}-{platform}-{discriminator}-{settingName}</c>
     /// </summary>
-    /// <param name="type">The category of the secret, e.g. "collector" or "publisher".</param>
+    /// <param name="ownerType">The category of the secret owner: <see cref="KeyVaultSecretOwnerType.Publisher"/> or <see cref="KeyVaultSecretOwnerType.Collector"/>.</param>
     /// <param name="ownerOid">The owner's Entra (AAD) object ID. Non-alphanumeric/hyphen characters are replaced with hyphens.</param>
-    /// <param name="platform">The platform name, e.g. "bluesky", "youtube-channel".</param>
-    /// <param name="settingName">The setting name, e.g. "app-password", "api-key".</param>
+    /// <param name="platform">The platform segment — use a <see cref="KeyVaultSecretNames.Platform"/> constant.</param>
+    /// <param name="settingName">The setting segment — use a <see cref="KeyVaultSecretNames.SettingName"/> constant.</param>
     /// <param name="discriminator">An optional discriminator inserted between platform and settingName, e.g. a YouTube channel ID.</param>
     /// <returns>The sanitized Key Vault secret name.</returns>
-    public static string Build(string type, string ownerOid, string platform, string settingName, string? discriminator = null)
+    public static string Build(KeyVaultSecretOwnerType ownerType, string ownerOid, string platform, string settingName, string? discriminator = null)
     {
+        var type = ownerType.ToString().ToLowerInvariant();
         var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
         return discriminator is null
             ? $"{type}-{sanitizedOwner}-{platform}-{settingName}"

--- a/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretNames.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretNames.cs
@@ -1,0 +1,68 @@
+namespace JosephGuadagno.Broadcasting.Domain.Utilities;
+
+/// <summary>
+/// Well-known Key Vault secret name segments for platforms and settings.
+/// Use these constants in place of inline string literals when calling
+/// <see cref="KeyVaultSecretNameBuilder.Build"/>.
+/// </summary>
+public static class KeyVaultSecretNames
+{
+    /// <summary>Platform segment constants.</summary>
+    public static class Platform
+    {
+        /// <summary>Bluesky social platform.</summary>
+        public const string Bluesky = "bluesky";
+
+        /// <summary>Twitter / X social platform.</summary>
+        public const string Twitter = "twitter";
+
+        /// <summary>LinkedIn social platform.</summary>
+        public const string LinkedIn = "linkedin";
+
+        /// <summary>Facebook social platform.</summary>
+        public const string Facebook = "facebook";
+
+        /// <summary>YouTube Channel collector.</summary>
+        public const string YouTubeChannel = "youtube-channel";
+    }
+
+    /// <summary>Setting-name segment constants.</summary>
+    public static class SettingName
+    {
+        /// <summary>Bluesky app password.</summary>
+        public const string AppPassword = "app-password";
+
+        /// <summary>Twitter OAuth 1.0a consumer key.</summary>
+        public const string ConsumerKey = "consumer-key";
+
+        /// <summary>Twitter OAuth 1.0a consumer secret.</summary>
+        public const string ConsumerSecret = "consumer-secret";
+
+        /// <summary>OAuth access token.</summary>
+        public const string AccessToken = "access-token";
+
+        /// <summary>Twitter OAuth 1.0a access token secret.</summary>
+        public const string AccessTokenSecret = "access-token-secret";
+
+        /// <summary>OAuth client secret.</summary>
+        public const string ClientSecret = "client-secret";
+
+        /// <summary>Facebook page access token.</summary>
+        public const string PageAccessToken = "page-access-token";
+
+        /// <summary>Facebook app secret.</summary>
+        public const string AppSecret = "app-secret";
+
+        /// <summary>Facebook client token.</summary>
+        public const string ClientToken = "client-token";
+
+        /// <summary>Facebook short-lived user access token.</summary>
+        public const string ShortLivedAccessToken = "short-lived-access-token";
+
+        /// <summary>Facebook long-lived user access token.</summary>
+        public const string LongLivedAccessToken = "long-lived-access-token";
+
+        /// <summary>YouTube Data API key.</summary>
+        public const string ApiKey = "api-key";
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretOwnerType.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Utilities/KeyVaultSecretOwnerType.cs
@@ -1,0 +1,13 @@
+namespace JosephGuadagno.Broadcasting.Domain.Utilities;
+
+/// <summary>
+/// Identifies the ownership category of a Key Vault secret.
+/// </summary>
+public enum KeyVaultSecretOwnerType
+{
+    /// <summary>A secret belonging to a social-media publisher.</summary>
+    Publisher = 0,
+
+    /// <summary>A secret belonging to a content collector.</summary>
+    Collector = 1,
+}

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/KeyVaultSecretNameBuilderTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/KeyVaultSecretNameBuilderTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+
+namespace JosephGuadagno.Broadcasting.Managers.Tests;
+
+public class KeyVaultSecretNameBuilderTests
+{
+    [Theory]
+    [InlineData("owner-1", "publisher", "bluesky", "app-password", "publisher-owner-1-bluesky-app-password")]
+    [InlineData("owner-1", "publisher", "twitter", "consumer-key", "publisher-owner-1-twitter-consumer-key")]
+    [InlineData("owner-1", "publisher", "linkedin", "access-token", "publisher-owner-1-linkedin-access-token")]
+    [InlineData("owner-1", "publisher", "facebook", "page-access-token", "publisher-owner-1-facebook-page-access-token")]
+    [InlineData("owner-1", "collector", "youtube-channel", "api-key", "collector-owner-1-youtube-channel-api-key")]
+    public void Build_WithCleanOwner_ReturnsExpectedFormat(
+        string ownerOid, string type, string platform, string settingName, string expected)
+    {
+        var result = KeyVaultSecretNameBuilder.Build(type, ownerOid, platform, settingName);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("owner@with#special!", "publisher-owner-with-special--bluesky-app-password")]
+    [InlineData("owner with spaces", "publisher-owner-with-spaces-bluesky-app-password")]
+    [InlineData("owner_underscore", "publisher-owner-underscore-bluesky-app-password")]
+    public void Build_WithSpecialCharsInOwner_SanitizesToHyphens(string ownerOid, string expected)
+    {
+        var result = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "bluesky", "app-password");
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("owner-1", "UCabc123", "collector-owner-1-youtube-channel-UCabc123-api-key")]
+    [InlineData("owner@with#special!", "UCabc123", "collector-owner-with-special--youtube-channel-UCabc123-api-key")]
+    public void Build_WithDiscriminator_InsertsDiscriminatorBetweenPlatformAndSettingName(
+        string ownerOid, string discriminator, string expected)
+    {
+        var result = KeyVaultSecretNameBuilder.Build("collector", ownerOid, "youtube-channel", "api-key", discriminator);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Build_WithNullDiscriminator_OmitsDiscriminatorSegment()
+    {
+        var withDiscriminator = KeyVaultSecretNameBuilder.Build("collector", "owner-1", "youtube-channel", "api-key", "channel-x");
+        var withoutDiscriminator = KeyVaultSecretNameBuilder.Build("collector", "owner-1", "youtube-channel", "api-key");
+
+        withDiscriminator.Should().Be("collector-owner-1-youtube-channel-channel-x-api-key");
+        withoutDiscriminator.Should().Be("collector-owner-1-youtube-channel-api-key");
+        withDiscriminator.Should().NotBe(withoutDiscriminator);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Managers.Tests/KeyVaultSecretNameBuilderTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers.Tests/KeyVaultSecretNameBuilderTests.cs
@@ -6,15 +6,15 @@ namespace JosephGuadagno.Broadcasting.Managers.Tests;
 public class KeyVaultSecretNameBuilderTests
 {
     [Theory]
-    [InlineData("owner-1", "publisher", "bluesky", "app-password", "publisher-owner-1-bluesky-app-password")]
-    [InlineData("owner-1", "publisher", "twitter", "consumer-key", "publisher-owner-1-twitter-consumer-key")]
-    [InlineData("owner-1", "publisher", "linkedin", "access-token", "publisher-owner-1-linkedin-access-token")]
-    [InlineData("owner-1", "publisher", "facebook", "page-access-token", "publisher-owner-1-facebook-page-access-token")]
-    [InlineData("owner-1", "collector", "youtube-channel", "api-key", "collector-owner-1-youtube-channel-api-key")]
+    [InlineData(KeyVaultSecretOwnerType.Publisher, "owner-1", KeyVaultSecretNames.Platform.Bluesky, KeyVaultSecretNames.SettingName.AppPassword, "publisher-owner-1-bluesky-app-password")]
+    [InlineData(KeyVaultSecretOwnerType.Publisher, "owner-1", KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.ConsumerKey, "publisher-owner-1-twitter-consumer-key")]
+    [InlineData(KeyVaultSecretOwnerType.Publisher, "owner-1", KeyVaultSecretNames.Platform.LinkedIn, KeyVaultSecretNames.SettingName.AccessToken, "publisher-owner-1-linkedin-access-token")]
+    [InlineData(KeyVaultSecretOwnerType.Publisher, "owner-1", KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.PageAccessToken, "publisher-owner-1-facebook-page-access-token")]
+    [InlineData(KeyVaultSecretOwnerType.Collector, "owner-1", KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey, "collector-owner-1-youtube-channel-api-key")]
     public void Build_WithCleanOwner_ReturnsExpectedFormat(
-        string ownerOid, string type, string platform, string settingName, string expected)
+        KeyVaultSecretOwnerType ownerType, string ownerOid, string platform, string settingName, string expected)
     {
-        var result = KeyVaultSecretNameBuilder.Build(type, ownerOid, platform, settingName);
+        var result = KeyVaultSecretNameBuilder.Build(ownerType, ownerOid, platform, settingName);
 
         result.Should().Be(expected);
     }
@@ -25,7 +25,7 @@ public class KeyVaultSecretNameBuilderTests
     [InlineData("owner_underscore", "publisher-owner-underscore-bluesky-app-password")]
     public void Build_WithSpecialCharsInOwner_SanitizesToHyphens(string ownerOid, string expected)
     {
-        var result = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "bluesky", "app-password");
+        var result = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Bluesky, KeyVaultSecretNames.SettingName.AppPassword);
 
         result.Should().Be(expected);
     }
@@ -36,7 +36,7 @@ public class KeyVaultSecretNameBuilderTests
     public void Build_WithDiscriminator_InsertsDiscriminatorBetweenPlatformAndSettingName(
         string ownerOid, string discriminator, string expected)
     {
-        var result = KeyVaultSecretNameBuilder.Build("collector", ownerOid, "youtube-channel", "api-key", discriminator);
+        var result = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Collector, ownerOid, KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey, discriminator);
 
         result.Should().Be(expected);
     }
@@ -44,8 +44,8 @@ public class KeyVaultSecretNameBuilderTests
     [Fact]
     public void Build_WithNullDiscriminator_OmitsDiscriminatorSegment()
     {
-        var withDiscriminator = KeyVaultSecretNameBuilder.Build("collector", "owner-1", "youtube-channel", "api-key", "channel-x");
-        var withoutDiscriminator = KeyVaultSecretNameBuilder.Build("collector", "owner-1", "youtube-channel", "api-key");
+        var withDiscriminator = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Collector, "owner-1", KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey, "channel-x");
+        var withoutDiscriminator = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Collector, "owner-1", KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey);
 
         withDiscriminator.Should().Be("collector-owner-1-youtube-channel-channel-x-api-key");
         withoutDiscriminator.Should().Be("collector-owner-1-youtube-channel-api-key");

--- a/src/JosephGuadagno.Broadcasting.Managers/UserCollectorYouTubeChannelManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserCollectorYouTubeChannelManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
@@ -19,8 +18,6 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
     private readonly IUserCollectorYouTubeChannelDataStore _dataStore;
     private readonly IKeyVault _keyVault;
     private readonly ILogger<UserCollectorYouTubeChannelManager> _logger;
-
-    private static readonly Regex SecretNameSanitizer = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
 
     public UserCollectorYouTubeChannelManager(
         IUserCollectorYouTubeChannelDataStore dataStore,
@@ -101,7 +98,7 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         ArgumentException.ThrowIfNullOrWhiteSpace(youTubeChannelId);
         ArgumentException.ThrowIfNullOrWhiteSpace(rawApiKey);
 
-        var secretName = BuildSecretName(ownerOid, youTubeChannelId);
+        var secretName = KeyVaultSecretNameBuilder.Build("collector", ownerOid, "youtube-channel", "api-key", youTubeChannelId);
 
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, rawApiKey, DateTime.UtcNow.AddYears(10));
 
@@ -125,7 +122,7 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         {
             return null;
         }
-        var secretName = BuildSecretName(ownerOid, config.ChannelId);
+        var secretName = KeyVaultSecretNameBuilder.Build("collector", ownerOid, "youtube-channel", "api-key", config.ChannelId);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -147,7 +144,7 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         if (config is null) return;
         try
         {
-            var secretName = BuildSecretName(config.CreatedByEntraOid, config.ChannelId);
+            var secretName = KeyVaultSecretNameBuilder.Build("collector", config.CreatedByEntraOid, "youtube-channel", "api-key", config.ChannelId);
             var secret = await _keyVault.GetSecretAsync(secretName);
             config.HasApiKey = !string.IsNullOrWhiteSpace(secret?.Value);
         }
@@ -155,11 +152,5 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         {
             config.HasApiKey = false;
         }
-    }
-
-    private static string BuildSecretName(string ownerOid, string youTubeChannelId)
-    {
-        var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
-        return $"collector-{sanitizedOwner}-youtube-channel-{youTubeChannelId}-api-key";
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserCollectorYouTubeChannelManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserCollectorYouTubeChannelManager.cs
@@ -98,7 +98,7 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         ArgumentException.ThrowIfNullOrWhiteSpace(youTubeChannelId);
         ArgumentException.ThrowIfNullOrWhiteSpace(rawApiKey);
 
-        var secretName = KeyVaultSecretNameBuilder.Build("collector", ownerOid, "youtube-channel", "api-key", youTubeChannelId);
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Collector, ownerOid, KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey, youTubeChannelId);
 
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, rawApiKey, DateTime.UtcNow.AddYears(10));
 
@@ -122,7 +122,7 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         {
             return null;
         }
-        var secretName = KeyVaultSecretNameBuilder.Build("collector", ownerOid, "youtube-channel", "api-key", config.ChannelId);
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Collector, ownerOid, KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey, config.ChannelId);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -144,7 +144,7 @@ public class UserCollectorYouTubeChannelManager : IUserCollectorYouTubeChannelMa
         if (config is null) return;
         try
         {
-            var secretName = KeyVaultSecretNameBuilder.Build("collector", config.CreatedByEntraOid, "youtube-channel", "api-key", config.ChannelId);
+            var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Collector, config.CreatedByEntraOid, KeyVaultSecretNames.Platform.YouTubeChannel, KeyVaultSecretNames.SettingName.ApiKey, config.ChannelId);
             var secret = await _keyVault.GetSecretAsync(secretName);
             config.HasApiKey = !string.IsNullOrWhiteSpace(secret?.Value);
         }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherBlueskySettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherBlueskySettingsManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
@@ -18,8 +17,6 @@ public class UserPublisherBlueskySettingsManager : IUserPublisherBlueskySettings
     private readonly IUserPublisherBlueskySettingsDataStore _userPublisherBlueskySettingsDataStore;
     private readonly IKeyVault _keyVault;
     private readonly ILogger<UserPublisherBlueskySettingsManager> _logger;
-
-    private static readonly Regex SecretNameSanitizer = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
 
     public UserPublisherBlueskySettingsManager(
         IUserPublisherBlueskySettingsDataStore userPublisherBlueskySettingsDataStore,
@@ -62,7 +59,7 @@ public class UserPublisherBlueskySettingsManager : IUserPublisherBlueskySettings
     public async Task<string?> GetAppPasswordAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "app-password");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "bluesky", "app-password");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -83,7 +80,7 @@ public class UserPublisherBlueskySettingsManager : IUserPublisherBlueskySettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(appPassword);
-        var secretName = BuildSecretName(ownerOid, "app-password");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "bluesky", "app-password");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, appPassword, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Bluesky app password in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -91,9 +88,4 @@ public class UserPublisherBlueskySettingsManager : IUserPublisherBlueskySettings
             LogSanitizer.Sanitize(ownerOid));
     }
 
-    private static string BuildSecretName(string ownerOid, string settingName)
-    {
-        var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
-        return $"publisher-{sanitizedOwner}-bluesky-{settingName}";
-    }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherBlueskySettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherBlueskySettingsManager.cs
@@ -59,7 +59,7 @@ public class UserPublisherBlueskySettingsManager : IUserPublisherBlueskySettings
     public async Task<string?> GetAppPasswordAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "bluesky", "app-password");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Bluesky, KeyVaultSecretNames.SettingName.AppPassword);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -80,7 +80,7 @@ public class UserPublisherBlueskySettingsManager : IUserPublisherBlueskySettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(appPassword);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "bluesky", "app-password");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Bluesky, KeyVaultSecretNames.SettingName.AppPassword);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, appPassword, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Bluesky app password in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherFacebookSettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherFacebookSettingsManager.cs
@@ -59,7 +59,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetPageAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "page-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.PageAccessToken);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -80,7 +80,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(pageAccessToken);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "page-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.PageAccessToken);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, pageAccessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook page access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -92,7 +92,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetAppSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "app-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.AppSecret);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -113,7 +113,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(appSecret);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "app-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.AppSecret);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, appSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook app secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -125,7 +125,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetClientTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "client-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.ClientToken);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -146,7 +146,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientToken);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "client-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.ClientToken);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, clientToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook client token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -158,7 +158,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetShortLivedAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "short-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.ShortLivedAccessToken);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -179,7 +179,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(shortLivedAccessToken);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "short-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.ShortLivedAccessToken);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, shortLivedAccessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook short-lived access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -191,7 +191,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetLongLivedAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "long-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.LongLivedAccessToken);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -212,7 +212,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(longLivedAccessToken);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "long-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Facebook, KeyVaultSecretNames.SettingName.LongLivedAccessToken);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, longLivedAccessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook long-lived access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherFacebookSettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherFacebookSettingsManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
@@ -18,8 +17,6 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     private readonly IUserPublisherFacebookSettingsDataStore _userPublisherFacebookSettingsDataStore;
     private readonly IKeyVault _keyVault;
     private readonly ILogger<UserPublisherFacebookSettingsManager> _logger;
-
-    private static readonly Regex SecretNameSanitizer = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
 
     public UserPublisherFacebookSettingsManager(
         IUserPublisherFacebookSettingsDataStore userPublisherFacebookSettingsDataStore,
@@ -62,7 +59,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetPageAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "page-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "page-access-token");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -83,7 +80,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(pageAccessToken);
-        var secretName = BuildSecretName(ownerOid, "page-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "page-access-token");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, pageAccessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook page access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -95,7 +92,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetAppSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "app-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "app-secret");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -116,7 +113,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(appSecret);
-        var secretName = BuildSecretName(ownerOid, "app-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "app-secret");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, appSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook app secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -128,7 +125,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetClientTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "client-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "client-token");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -149,7 +146,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientToken);
-        var secretName = BuildSecretName(ownerOid, "client-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "client-token");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, clientToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook client token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -161,7 +158,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetShortLivedAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "short-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "short-lived-access-token");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -182,7 +179,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(shortLivedAccessToken);
-        var secretName = BuildSecretName(ownerOid, "short-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "short-lived-access-token");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, shortLivedAccessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook short-lived access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -194,7 +191,7 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     public async Task<string?> GetLongLivedAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "long-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "long-lived-access-token");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -215,17 +212,11 @@ public class UserPublisherFacebookSettingsManager : IUserPublisherFacebookSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(longLivedAccessToken);
-        var secretName = BuildSecretName(ownerOid, "long-lived-access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "facebook", "long-lived-access-token");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, longLivedAccessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Facebook long-lived access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
             secretName,
             LogSanitizer.Sanitize(ownerOid));
-    }
-
-    private static string BuildSecretName(string ownerOid, string settingName)
-    {
-        var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
-        return $"publisher-{sanitizedOwner}-facebook-{settingName}";
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherLinkedInSettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherLinkedInSettingsManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
@@ -18,8 +17,6 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     private readonly IUserPublisherLinkedInSettingsDataStore _userPublisherLinkedInSettingsDataStore;
     private readonly IKeyVault _keyVault;
     private readonly ILogger<UserPublisherLinkedInSettingsManager> _logger;
-
-    private static readonly Regex SecretNameSanitizer = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
 
     public UserPublisherLinkedInSettingsManager(
         IUserPublisherLinkedInSettingsDataStore userPublisherLinkedInSettingsDataStore,
@@ -62,7 +59,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     public async Task<string?> GetClientSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "client-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "client-secret");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -83,7 +80,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientSecret);
-        var secretName = BuildSecretName(ownerOid, "client-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "client-secret");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, clientSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored LinkedIn client secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -95,7 +92,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     public async Task<string?> GetAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "access-token");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -116,17 +113,11 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
-        var secretName = BuildSecretName(ownerOid, "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "access-token");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, accessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored LinkedIn access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
             secretName,
             LogSanitizer.Sanitize(ownerOid));
-    }
-
-    private static string BuildSecretName(string ownerOid, string settingName)
-    {
-        var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
-        return $"publisher-{sanitizedOwner}-linkedin-{settingName}";
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherLinkedInSettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherLinkedInSettingsManager.cs
@@ -59,7 +59,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     public async Task<string?> GetClientSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "client-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.LinkedIn, KeyVaultSecretNames.SettingName.ClientSecret);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -80,7 +80,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientSecret);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "client-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.LinkedIn, KeyVaultSecretNames.SettingName.ClientSecret);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, clientSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored LinkedIn client secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -92,7 +92,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     public async Task<string?> GetAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.LinkedIn, KeyVaultSecretNames.SettingName.AccessToken);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -113,7 +113,7 @@ public class UserPublisherLinkedInSettingsManager : IUserPublisherLinkedInSettin
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "linkedin", "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.LinkedIn, KeyVaultSecretNames.SettingName.AccessToken);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, accessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored LinkedIn access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherTwitterSettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherTwitterSettingsManager.cs
@@ -59,7 +59,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetConsumerKeyAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-key");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.ConsumerKey);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -80,7 +80,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(consumerKey);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-key");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.ConsumerKey);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, consumerKey, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter consumer key in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -92,7 +92,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetConsumerSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.ConsumerSecret);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -113,7 +113,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(consumerSecret);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.ConsumerSecret);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, consumerSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter consumer secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -125,7 +125,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.AccessToken);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -146,7 +146,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.AccessToken);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, accessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -158,7 +158,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetAccessTokenSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.AccessTokenSecret);
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -179,7 +179,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(accessTokenSecret);
-        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build(KeyVaultSecretOwnerType.Publisher, ownerOid, KeyVaultSecretNames.Platform.Twitter, KeyVaultSecretNames.SettingName.AccessTokenSecret);
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, accessTokenSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter access token secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",

--- a/src/JosephGuadagno.Broadcasting.Managers/UserPublisherTwitterSettingsManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/UserPublisherTwitterSettingsManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JosephGuadagno.Broadcasting.Data.KeyVault.Interfaces;
@@ -18,8 +17,6 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     private readonly IUserPublisherTwitterSettingsDataStore _userPublisherTwitterSettingsDataStore;
     private readonly IKeyVault _keyVault;
     private readonly ILogger<UserPublisherTwitterSettingsManager> _logger;
-
-    private static readonly Regex SecretNameSanitizer = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
 
     public UserPublisherTwitterSettingsManager(
         IUserPublisherTwitterSettingsDataStore userPublisherTwitterSettingsDataStore,
@@ -62,7 +59,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetConsumerKeyAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "consumer-key");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-key");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -83,7 +80,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(consumerKey);
-        var secretName = BuildSecretName(ownerOid, "consumer-key");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-key");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, consumerKey, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter consumer key in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -95,7 +92,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetConsumerSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "consumer-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-secret");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -116,7 +113,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(consumerSecret);
-        var secretName = BuildSecretName(ownerOid, "consumer-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "consumer-secret");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, consumerSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter consumer secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -128,7 +125,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetAccessTokenAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -149,7 +146,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
-        var secretName = BuildSecretName(ownerOid, "access-token");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, accessToken, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter access token in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
@@ -161,7 +158,7 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     public async Task<string?> GetAccessTokenSecretAsync(string ownerOid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
-        var secretName = BuildSecretName(ownerOid, "access-token-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token-secret");
         try
         {
             var secret = await _keyVault.GetSecretAsync(secretName);
@@ -182,17 +179,11 @@ public class UserPublisherTwitterSettingsManager : IUserPublisherTwitterSettings
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerOid);
         ArgumentException.ThrowIfNullOrWhiteSpace(accessTokenSecret);
-        var secretName = BuildSecretName(ownerOid, "access-token-secret");
+        var secretName = KeyVaultSecretNameBuilder.Build("publisher", ownerOid, "twitter", "access-token-secret");
         await _keyVault.UpdateSecretValueAndPropertiesAsync(secretName, accessTokenSecret, DateTime.UtcNow.AddYears(10));
         _logger.LogInformation(
             "Stored Twitter access token secret in Key Vault as secret '{SecretName}' for owner '{OwnerOid}'",
             secretName,
             LogSanitizer.Sanitize(ownerOid));
-    }
-
-    private static string BuildSecretName(string ownerOid, string settingName)
-    {
-        var sanitizedOwner = SecretNameSanitizer.Replace(ownerOid, "-");
-        return $"publisher-{sanitizedOwner}-twitter-{settingName}";
     }
 }


### PR DESCRIPTION
## Summary

Extracts the duplicated `BuildSecretName()` private method and `SecretNameSanitizer` regex from all 5 publisher/collector managers into a single shared utility: `KeyVaultSecretNameBuilder.Build()` in `JosephGuadagno.Broadcasting.Domain.Utilities`.

## Changes

- New: `src\JosephGuadagno.Broadcasting.Domain\Utilities\KeyVaultSecretNameBuilder.cs`
- Updated: `UserPublisherBlueskySettingsManager`, `UserPublisherTwitterSettingsManager`, `UserPublisherLinkedInSettingsManager`, `UserPublisherFacebookSettingsManager`, `UserCollectorYouTubeChannelManager`
- New tests: `KeyVaultSecretNameBuilderTests.cs`

## Secret name format (unchanged)

- Publishers: `publisher-{sanitizedOwnerOid}-{platform}-{settingName}`
- Collectors with discriminator: `collector-{sanitizedOwnerOid}-{platform}-{discriminator}-{settingName}`

Closes #966
