### PR TITLE
feat(#960): add Web layer for ScheduledItem collector and /Collectors route alias

### DIFF
--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -4,6 +4,16 @@
 
 Tank (QA Engineer) builds comprehensive test coverage across unit, integration, security, and regression test categories using xUnit, FluentAssertions, and Moq. Primary focus: ensuring backend API contracts work correctly, authorization/RBAC logic is enforced, ownership isolation prevents data leaks, and authentication flows are secure. Key test patterns include: mocking external services (HttpClientFactory via Moq), testing async operations with Task.Delay and verification, ownership isolation regression tests (verify User A cannot access User B's resources), and RBAC authorization tests (verify Viewers cannot POST, Admins can manage users). Tank works closely with Trinity (API endpoint contracts), Switch (Web-layer integration tests), and Neo (security test patterns). Established pattern: write tests before implementation (TDD), test both happy path and error cases, use descriptive test names like `GetEngagements_WhenUserIsContributor_ShouldReturnOwnEngagementsOnly`, mock external dependencies, and verify authorization boundaries. Notable: Tank maintains ownership isolation test suite to prevent regressions as new features are added. Key decision: ownership tests go in integration test class alongside endpoint tests, not as separate security-only test file.
 
+## Recent Session: Issue #969 — Collector Controllers in ControllerAuthorizationPolicyTests (2026-05-15)
+
+- **Work:** Added 5 Collector API controllers to `ControllerAuthorizationPolicyTests`
+- **Result:** ✅ COMPLETE — 157/157 tests pass; PR #970 opened; issue #969 commented
+- **Controllers Added:** `CollectorsController` (1 action), `CollectorYouTubeSettingsController` (5 actions), `CollectorFeedSourceSettingsController` (5 actions), `CollectorSpeakingEngagementSettingsController` (5 actions), `CollectorScheduledItemSettingsController` (3 actions)
+- **Pattern:** Each controller added to `ControllerTypes` (class-level `[Authorize]` check) and all public actions added to `ActionPolicies` with their exact policy (`RequireViewer` for GET, `RequireContributor` for POST/PUT/DELETE)
+- **Commit:** `40060071` on branch `issue-969-collector-authz-policy-tests`
+
+---
+
 ## Recent Session: Fix PublisherSettingsControllerTests Assertions (2026-05-15)
 
 - **Work:** Fixed 2 failing tests in `PublisherSettingsControllerTests.cs`

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -63,7 +63,15 @@ Fixed Neo's blocking `cs/log-forging` review finding: 3 `LogWarning` call sites 
 
 ## Learnings
 
-### Collector API Route Alignment — Issue #960 Phase 1 (2026-05-15)
+### Collector Web Layer — Issue #960 Phase 2 (2026-05-16)
+
+1. When adding route aliases to an MVC controller that uses conventional routing, switch to attribute routing with both `[Route("OldName")]` and `[Route("NewName")]` at class level. The `Index` action needs `[HttpGet("")]` and `[HttpGet("Index")]` to cover both bare path and explicit action URL.
+2. Single-row-per-user Web controllers: no `id` parameter needed — actions are parameterless (or take optional `ownerOid` for admin). The API handles the upsert internally.
+3. `UserCollectorScheduledItemService.SaveAsync` passes `item.CreatedByEntraOid` as `?ownerOid=` query param so the API can enforce ownership/admin checks.
+4. `WebMappingProfile` ViewModel→Domain maps for single-row models need `Id`, `CreatedByEntraOid`, `CreatedOn`, and `LastUpdatedOn` all ignored — the controller sets them explicitly before calling `SaveAsync`.
+5. Nullable ViewModel (`UserCollectorScheduledItemViewModel?`) is the right Index view model for single-row-per-user — renders "not configured" state without a separate sentinel value.
+
+
 
 1. When marking old controllers `[Obsolete]`, test files that instantiate them directly will generate CS0618 build warnings. Suppress with `#pragma warning disable CS0618` at file top with a comment explaining the intent (testing backward compat during migration).
 2. `IUserCollectorScheduledItemManager.GetByUserAsync` returns `Task<List<T>>` (not `Task<T?>`). For single-row-per-user patterns, call `GetByUserAsync` and take `.FirstOrDefault()` — do NOT assume a `GetSingleByUserAsync` method exists.

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/CollectorScheduledItemController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/CollectorScheduledItemController.cs
@@ -1,0 +1,167 @@
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using JosephGuadagno.Broadcasting.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace JosephGuadagno.Broadcasting.Web.Controllers;
+
+/// <summary>
+/// Controller for managing the per-user scheduled item collector configuration.
+/// Each user has at most one scheduled item configuration.
+/// </summary>
+[Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+public class CollectorScheduledItemController(
+    IUserCollectorScheduledItemService service,
+    ILogger<CollectorScheduledItemController> logger)
+    : Controller
+{
+    /// <summary>
+    /// Shows the current user's scheduled item configuration.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> Index()
+    {
+        var ownerOid = User.FindFirstValue(ApplicationClaimTypes.EntraObjectId);
+        if (string.IsNullOrWhiteSpace(ownerOid))
+        {
+            TempData["ErrorMessage"] = "Unable to resolve your account identifier.";
+            return RedirectToAction("Index", "Home");
+        }
+
+        var item = await service.GetAsync(ownerOid);
+        if (item is null)
+        {
+            return View((UserCollectorScheduledItemViewModel?)null);
+        }
+
+        var viewModel = new UserCollectorScheduledItemViewModel
+        {
+            DisplayName = item.DisplayName,
+            IsActive = item.IsActive,
+            CreatedOn = item.CreatedOn,
+            LastUpdatedOn = item.LastUpdatedOn
+        };
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Displays the edit/create form for the scheduled item configuration.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> Edit()
+    {
+        var ownerOid = User.FindFirstValue(ApplicationClaimTypes.EntraObjectId);
+        if (string.IsNullOrWhiteSpace(ownerOid))
+        {
+            TempData["ErrorMessage"] = "Unable to resolve your account identifier.";
+            return RedirectToAction("Index", "Home");
+        }
+
+        var item = await service.GetAsync(ownerOid);
+        var viewModel = item is not null
+            ? new UserCollectorScheduledItemViewModel
+            {
+                DisplayName = item.DisplayName,
+                IsActive = item.IsActive,
+                CreatedOn = item.CreatedOn,
+                LastUpdatedOn = item.LastUpdatedOn
+            }
+            : new UserCollectorScheduledItemViewModel();
+
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Creates or updates the scheduled item configuration for the current user.
+    /// </summary>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(UserCollectorScheduledItemViewModel viewModel)
+    {
+        if (!ModelState.IsValid) return View(viewModel);
+
+        var ownerOid = User.FindFirstValue(ApplicationClaimTypes.EntraObjectId);
+        if (string.IsNullOrWhiteSpace(ownerOid))
+        {
+            TempData["ErrorMessage"] = "Unable to resolve your account identifier.";
+            return RedirectToAction("Index", "Home");
+        }
+
+        var model = new UserCollectorScheduledItem
+        {
+            CreatedByEntraOid = ownerOid,
+            DisplayName = viewModel.DisplayName,
+            IsActive = viewModel.IsActive
+        };
+
+        var result = await service.SaveAsync(model);
+        if (result is null)
+        {
+            logger.LogWarning("Failed to save scheduled item config for user {OwnerOid}",
+                LogSanitizer.Sanitize(ownerOid));
+            ModelState.AddModelError(string.Empty, "Failed to save the scheduled item configuration.");
+            return View(viewModel);
+        }
+
+        TempData["SuccessMessage"] = "Scheduled item configuration saved successfully.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Shows the delete confirmation page.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> Delete()
+    {
+        var ownerOid = User.FindFirstValue(ApplicationClaimTypes.EntraObjectId);
+        if (string.IsNullOrWhiteSpace(ownerOid))
+        {
+            TempData["ErrorMessage"] = "Unable to resolve your account identifier.";
+            return RedirectToAction("Index", "Home");
+        }
+
+        var item = await service.GetAsync(ownerOid);
+        if (item is null) return NotFound();
+
+        var viewModel = new UserCollectorScheduledItemViewModel
+        {
+            DisplayName = item.DisplayName,
+            IsActive = item.IsActive,
+            CreatedOn = item.CreatedOn,
+            LastUpdatedOn = item.LastUpdatedOn
+        };
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Deletes the scheduled item configuration after confirmation.
+    /// </summary>
+    [HttpPost]
+    [ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed()
+    {
+        var ownerOid = User.FindFirstValue(ApplicationClaimTypes.EntraObjectId);
+        if (string.IsNullOrWhiteSpace(ownerOid))
+        {
+            TempData["ErrorMessage"] = "Unable to resolve your account identifier.";
+            return RedirectToAction("Index", "Home");
+        }
+
+        var result = await service.DeleteAsync(ownerOid);
+        if (result)
+        {
+            TempData["SuccessMessage"] = "Scheduled item configuration deleted successfully.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        logger.LogWarning("Failed to delete scheduled item config for user {OwnerOid}",
+            LogSanitizer.Sanitize(ownerOid));
+        TempData["ErrorMessage"] = "Failed to delete the scheduled item configuration.";
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/CollectorSettingsController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/CollectorSettingsController.cs
@@ -12,11 +12,14 @@ namespace JosephGuadagno.Broadcasting.Web.Controllers;
 /// Controller for per-user collector settings.
 /// </summary>
 [Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+[Route("CollectorSettings")]
+[Route("Collectors")]
 public class CollectorSettingsController : Controller
 {
     private readonly IUserCollectorFeedSourceService _feedSourceService;
     private readonly IUserCollectorYouTubeChannelService _youTubeChannelService;
     private readonly IUserCollectorSpeakingEngagementService _speakingEngagementService;
+    private readonly IUserCollectorScheduledItemService _scheduledItemService;
     private readonly IUserApprovalManager _userApprovalManager;
     private readonly ILogger<CollectorSettingsController> _logger;
 
@@ -24,17 +27,20 @@ public class CollectorSettingsController : Controller
         IUserCollectorFeedSourceService feedSourceService,
         IUserCollectorYouTubeChannelService youTubeChannelService,
         IUserCollectorSpeakingEngagementService speakingEngagementService,
+        IUserCollectorScheduledItemService scheduledItemService,
         IUserApprovalManager userApprovalManager,
         ILogger<CollectorSettingsController> logger)
     {
         _feedSourceService = feedSourceService;
         _youTubeChannelService = youTubeChannelService;
         _speakingEngagementService = speakingEngagementService;
+        _scheduledItemService = scheduledItemService;
         _userApprovalManager = userApprovalManager;
         _logger = logger;
     }
 
-    [HttpGet]
+    [HttpGet("")]
+    [HttpGet("Index")]
     public async Task<IActionResult> Index(string? userOid = null)
     {
         var resolution = await ResolveTargetUserAsync(userOid);
@@ -60,6 +66,8 @@ public class CollectorSettingsController : Controller
         var speakingEngagements = context.IsManagedBySiteAdmin
             ? await _speakingEngagementService.GetByUserAsync(context.TargetUserOid)
             : await _speakingEngagementService.GetCurrentUserAsync();
+
+        var scheduledItem = await _scheduledItemService.GetAsync(context.TargetUserOid);
 
         return new CollectorSettingsPageViewModel
         {
@@ -95,7 +103,17 @@ public class CollectorSettingsController : Controller
                 CreatedOn = se.CreatedOn,
                 LastUpdatedOn = se.LastUpdatedOn,
                 IsManagedBySiteAdmin = context.IsManagedBySiteAdmin
-            }).ToList()
+            }).ToList(),
+            ScheduledItem = scheduledItem is not null
+                ? new UserCollectorScheduledItemViewModel
+                {
+                    DisplayName = scheduledItem.DisplayName,
+                    IsActive = scheduledItem.IsActive,
+                    CreatedOn = scheduledItem.CreatedOn,
+                    LastUpdatedOn = scheduledItem.LastUpdatedOn,
+                    IsManagedBySiteAdmin = context.IsManagedBySiteAdmin
+                }
+                : null
         };
     }
 

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/IUserCollectorScheduledItemService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/IUserCollectorScheduledItemService.cs
@@ -1,0 +1,14 @@
+using JosephGuadagno.Broadcasting.Domain.Models;
+
+namespace JosephGuadagno.Broadcasting.Web.Interfaces;
+
+/// <summary>
+/// Service interface for interacting with the per-user scheduled item collector configuration in the API.
+/// Each user has at most one scheduled item configuration.
+/// </summary>
+public interface IUserCollectorScheduledItemService
+{
+    Task<UserCollectorScheduledItem?> GetAsync(string ownerOid);
+    Task<UserCollectorScheduledItem?> SaveAsync(UserCollectorScheduledItem item);
+    Task<bool> DeleteAsync(string ownerOid);
+}

--- a/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/MappingProfiles/WebMappingProfile.cs
@@ -94,5 +94,13 @@ public class WebMappingProfile: Profile
         CreateMap<Models.UserCollectorSpeakingEngagementViewModel, Domain.Models.UserCollectorSpeakingEngagement>()
             .ForMember(dest => dest.CreatedByEntraOid, opt => opt.Ignore());
 
+        CreateMap<Domain.Models.UserCollectorScheduledItem, Models.UserCollectorScheduledItemViewModel>()
+            .ForMember(dest => dest.IsManagedBySiteAdmin, opt => opt.Ignore());
+        CreateMap<Models.UserCollectorScheduledItemViewModel, Domain.Models.UserCollectorScheduledItem>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedByEntraOid, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedOn, opt => opt.Ignore())
+            .ForMember(dest => dest.LastUpdatedOn, opt => opt.Ignore());
+
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Models/CollectorSettingsPageViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/CollectorSettingsPageViewModel.cs
@@ -11,4 +11,5 @@ public class CollectorSettingsPageViewModel
     public List<UserCollectorFeedSourceViewModel> FeedSources { get; set; } = [];
     public List<UserCollectorYouTubeChannelViewModel> YouTubeChannels { get; set; } = [];
     public List<UserCollectorSpeakingEngagementViewModel> SpeakingEngagements { get; set; } = [];
+    public UserCollectorScheduledItemViewModel? ScheduledItem { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Models/UserCollectorScheduledItemViewModel.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/UserCollectorScheduledItemViewModel.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+/// <summary>
+/// View model for a per-user scheduled item collector configuration.
+/// </summary>
+public class UserCollectorScheduledItemViewModel
+{
+    [Required(ErrorMessage = "Display name is required.")]
+    [StringLength(255, ErrorMessage = "Display name cannot exceed 255 characters.")]
+    [Display(Name = "Display Name")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Display(Name = "Active")]
+    public bool IsActive { get; set; } = true;
+
+    public DateTimeOffset CreatedOn { get; set; }
+
+    public DateTimeOffset LastUpdatedOn { get; set; }
+
+    public bool IsManagedBySiteAdmin { get; set; }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -268,6 +268,7 @@ void ConfigureApplication(IServiceCollection services)
     services.TryAddScoped<IUserCollectorFeedSourceService, UserCollectorFeedSourceService>();
     services.TryAddScoped<IUserCollectorYouTubeChannelService, UserCollectorYouTubeChannelService>();
     services.TryAddScoped<IUserCollectorSpeakingEngagementService, UserCollectorSpeakingEngagementService>();
+    services.TryAddScoped<IUserCollectorScheduledItemService, UserCollectorScheduledItemService>();
     services.TryAddScoped<IMessageTemplateService, MessageTemplateService>();
     services.TryAddScoped<IYouTubeItemService, YouTubeItemService>();
     services.TryAddScoped<ISyndicationFeedItemService, SyndicationFeedItemService>();

--- a/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs
@@ -1,4 +1,5 @@
 using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
 using Microsoft.Identity.Abstractions;
 
@@ -38,7 +39,7 @@ public class UserCollectorScheduledItemService(
         {
             logger.LogWarning(
                 "Scheduled item save returned no content for owner {OwnerOid}",
-                item.CreatedByEntraOid);
+                LogSanitizer.Sanitize(item.CreatedByEntraOid));
         }
 
         return response;
@@ -60,7 +61,7 @@ public class UserCollectorScheduledItemService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to delete scheduled item config for owner {OwnerOid}", ownerOid);
+            logger.LogError(ex, "Failed to delete scheduled item config for owner {OwnerOid}", LogSanitizer.Sanitize(ownerOid));
             return false;
         }
     }

--- a/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs
@@ -1,0 +1,67 @@
+using JosephGuadagno.Broadcasting.Domain.Models;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using Microsoft.Identity.Abstractions;
+
+namespace JosephGuadagno.Broadcasting.Web.Services;
+
+/// <summary>
+/// Calls the per-user scheduled item collector configuration API endpoints.
+/// </summary>
+public class UserCollectorScheduledItemService(
+    IDownstreamApi apiClient,
+    ILogger<UserCollectorScheduledItemService> logger) : IUserCollectorScheduledItemService
+{
+    private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
+    private const string BaseUrl = "/Collectors/ScheduledItem/Settings";
+
+    public async Task<UserCollectorScheduledItem?> GetAsync(string ownerOid)
+    {
+        var response = await apiClient.GetForUserAsync<UserCollectorScheduledItem>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{BaseUrl}?ownerOid={Uri.EscapeDataString(ownerOid)}";
+        });
+
+        return response;
+    }
+
+    public async Task<UserCollectorScheduledItem?> SaveAsync(UserCollectorScheduledItem item)
+    {
+        var response = await apiClient.PutForUserAsync<UserCollectorScheduledItem, UserCollectorScheduledItem>(
+            ApiServiceName,
+            item,
+            options =>
+            {
+                options.RelativePath = $"{BaseUrl}?ownerOid={Uri.EscapeDataString(item.CreatedByEntraOid)}";
+            });
+
+        if (response is null)
+        {
+            logger.LogWarning(
+                "Scheduled item save returned no content for owner {OwnerOid}",
+                item.CreatedByEntraOid);
+        }
+
+        return response;
+    }
+
+    public async Task<bool> DeleteAsync(string ownerOid)
+    {
+        try
+        {
+            await apiClient.CallApiForUserAsync(
+                ApiServiceName,
+                options =>
+                {
+                    options.HttpMethod = HttpMethod.Delete.Method;
+                    options.RelativePath = $"{BaseUrl}?ownerOid={Uri.EscapeDataString(ownerOid)}";
+                });
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete scheduled item config for owner {OwnerOid}", ownerOid);
+            return false;
+        }
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/CollectorScheduledItem/Delete.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/CollectorScheduledItem/Delete.cshtml
@@ -1,0 +1,40 @@
+@model JosephGuadagno.Broadcasting.Web.Models.UserCollectorScheduledItemViewModel
+@{
+    ViewData["Title"] = "Delete Scheduled Item Configuration";
+}
+
+<div class="container">
+    <h1 class="display-4 mb-4 text-danger">Delete Scheduled Item Configuration</h1>
+
+    <div class="alert alert-warning" role="alert">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>
+        <strong>Warning:</strong> Are you sure you want to delete this configuration?
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <dl class="row">
+                <dt class="col-sm-3">Display Name</dt>
+                <dd class="col-sm-9">@Model.DisplayName</dd>
+
+                <dt class="col-sm-3">Active</dt>
+                <dd class="col-sm-9">@(Model.IsActive ? "Yes" : "No")</dd>
+
+                <dt class="col-sm-3">Created On</dt>
+                <dd class="col-sm-9">@Model.CreatedOn.ToString("F")</dd>
+
+                <dt class="col-sm-3">Last Updated</dt>
+                <dd class="col-sm-9">@Model.LastUpdatedOn.ToString("F")</dd>
+            </dl>
+        </div>
+    </div>
+
+    <form asp-action="Delete" asp-controller="CollectorScheduledItem" method="post" class="mt-3">
+        <button type="submit" class="btn btn-danger">
+            <i class="bi bi-trash me-1"></i>Yes, Delete
+        </button>
+        <a asp-action="Index" asp-controller="CollectorScheduledItem" class="btn btn-secondary ms-2">
+            <i class="bi bi-x-circle me-1"></i>Cancel
+        </a>
+    </form>
+</div>

--- a/src/JosephGuadagno.Broadcasting.Web/Views/CollectorScheduledItem/Edit.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/CollectorScheduledItem/Edit.cshtml
@@ -1,0 +1,49 @@
+@model JosephGuadagno.Broadcasting.Web.Models.UserCollectorScheduledItemViewModel
+@{
+    ViewData["Title"] = "Edit Scheduled Item Configuration";
+}
+
+<div class="container">
+    <h1 class="display-4 mb-4">Edit Scheduled Item Configuration</h1>
+
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @TempData["ErrorMessage"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <div class="card">
+        <div class="card-body">
+            <form asp-action="Edit" asp-controller="CollectorScheduledItem" method="post">
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+                <div class="mb-3">
+                    <label asp-for="DisplayName" class="form-label"></label>
+                    <input asp-for="DisplayName" class="form-control" />
+                    <span asp-validation-for="DisplayName" class="text-danger"></span>
+                    <div class="form-text">A friendly name for this scheduled item collector configuration.</div>
+                </div>
+
+                <div class="mb-3 form-check">
+                    <input asp-for="IsActive" class="form-check-input" />
+                    <label asp-for="IsActive" class="form-check-label">Active</label>
+                </div>
+
+                <div class="mt-4">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-floppy me-1"></i>Save
+                    </button>
+                    <a asp-action="Index" asp-controller="CollectorScheduledItem" class="btn btn-secondary ms-2">
+                        <i class="bi bi-x-circle me-1"></i>Cancel
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/CollectorScheduledItem/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/CollectorScheduledItem/Index.cshtml
@@ -1,0 +1,86 @@
+@model JosephGuadagno.Broadcasting.Web.Models.UserCollectorScheduledItemViewModel?
+@{
+    ViewData["Title"] = "Scheduled Item Collector";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1><i class="bi bi-calendar-check me-2"></i>Scheduled Item Collector</h1>
+</div>
+<p class="lead">
+    Configuration for the scheduled item collector. Only one configuration is allowed per user.
+</p>
+
+@if (TempData["SuccessMessage"] != null)
+{
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        @TempData["SuccessMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        @TempData["ErrorMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+@if (Model is null)
+{
+    <div class="card">
+        <div class="card-body">
+            <p class="text-muted mb-3">No scheduled item configuration found.</p>
+            @if (User.IsInRole(RoleNames.Contributor) ||
+                 User.IsInRole(RoleNames.Administrator) ||
+                 User.IsInRole(RoleNames.SiteAdministrator))
+            {
+                <a asp-action="Edit" asp-controller="CollectorScheduledItem" class="btn btn-primary">
+                    <i class="bi bi-plus-circle me-1"></i>Configure
+                </a>
+            }
+        </div>
+    </div>
+}
+else
+{
+    <div class="card">
+        <div class="card-body">
+            <dl class="row">
+                <dt class="col-sm-3">Display Name</dt>
+                <dd class="col-sm-9">@Model.DisplayName</dd>
+
+                <dt class="col-sm-3">Active</dt>
+                <dd class="col-sm-9">
+                    @if (Model.IsActive)
+                    {
+                        <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Active</span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-secondary"><i class="bi bi-x-circle me-1"></i>Inactive</span>
+                    }
+                </dd>
+
+                <dt class="col-sm-3">Created On</dt>
+                <dd class="col-sm-9">@Model.CreatedOn.ToString("F")</dd>
+
+                <dt class="col-sm-3">Last Updated</dt>
+                <dd class="col-sm-9">@Model.LastUpdatedOn.ToString("F")</dd>
+            </dl>
+        </div>
+    </div>
+
+    @if (User.IsInRole(RoleNames.Contributor) ||
+         User.IsInRole(RoleNames.Administrator) ||
+         User.IsInRole(RoleNames.SiteAdministrator))
+    {
+        <div class="mt-3">
+            <a asp-action="Edit" asp-controller="CollectorScheduledItem" class="btn btn-warning">
+                <i class="bi bi-pencil me-1"></i>Edit
+            </a>
+            <a asp-action="Delete" asp-controller="CollectorScheduledItem" class="btn btn-danger ms-2">
+                <i class="bi bi-trash me-1"></i>Delete
+            </a>
+        </div>
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/CollectorSettings/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/CollectorSettings/Index.cshtml
@@ -12,7 +12,7 @@
             <i class="bi bi-rss-fill me-2"></i>Collector Settings
         </h1>
         <p class="text-muted mb-0">
-            Configure the RSS/Atom/JSON feeds, YouTube channels, and speaking engagements to collect content from.
+            Configure the RSS/Atom/JSON feeds, YouTube channels, speaking engagements, and scheduled item collector.
         </p>
     </div>
 </div>
@@ -128,6 +128,59 @@
                                 </td>
                             </tr>
                         }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+<!-- Scheduled Item Collector Section -->
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="mb-0">
+            <i class="bi bi-calendar-check me-2"></i>Scheduled Item Collector
+        </h3>
+        @if (Model.ScheduledItem is null)
+        {
+            <a asp-controller="CollectorScheduledItem" asp-action="Edit" class="btn btn-primary">
+                <i class="bi bi-plus-circle me-1"></i>Configure
+            </a>
+        }
+    </div>
+    <div class="card-body">
+        @if (Model.ScheduledItem is null)
+        {
+            <p class="text-muted mb-0">No scheduled item configuration. Click "Configure" to set it up.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>Display Name</th>
+                            <th>Status</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>@Model.ScheduledItem.DisplayName</td>
+                            <td>
+                                <span class="badge @(Model.ScheduledItem.IsActive ? "text-bg-success" : "text-bg-secondary")">
+                                    @(Model.ScheduledItem.IsActive ? "Active" : "Inactive")
+                                </span>
+                            </td>
+                            <td>
+                                <a asp-controller="CollectorScheduledItem" asp-action="Edit" class="btn btn-sm btn-outline-primary">
+                                    <i class="bi bi-pencil"></i> Edit
+                                </a>
+                                <a asp-controller="CollectorScheduledItem" asp-action="Delete" class="btn btn-sm btn-outline-danger">
+                                    <i class="bi bi-trash"></i> Remove
+                                </a>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
## Summary

Completes Phase 2 (Web layer) for issue #960 — the ScheduledItem collector settings UI.

Phase 1 (API controllers) was merged in PR #968.

## Changes

### Route alias
- Added `[Route("Collectors")]` alongside `[Route("CollectorSettings")]` on `CollectorSettingsController` so `/Collectors` works as the dashboard URL without breaking `/CollectorSettings`.

### New service layer
- `IUserCollectorScheduledItemService` — interface with `GetAsync`, `SaveAsync`, `DeleteAsync`
- `UserCollectorScheduledItemService` — HTTP client wrapper calling `GET/PUT/DELETE /Collectors/ScheduledItem/Settings`
- Registered as scoped in `Program.cs`

### View model & mapping
- `UserCollectorScheduledItemViewModel` — `DisplayName`, `IsActive`, timestamps
- `WebMappingProfile` — bidirectional `UserCollectorScheduledItem ↔ UserCollectorScheduledItemViewModel`
- `CollectorSettingsPageViewModel.ScheduledItem` — nullable single-row property

### Controller & views
- `CollectorScheduledItemController` — `Index`, `Edit` (GET+POST), `Delete` (GET+POST)
  - All `[HttpPost]` methods have `[ValidateAntiForgeryToken]` ✅
  - `LogSanitizer.Sanitize()` on all user-controlled log args ✅
  - Edit POST upserts via `PUT /Collectors/ScheduledItem/Settings`
- `Views/CollectorScheduledItem/Index.cshtml` — shows config or "not configured" with Configure link
- `Views/CollectorScheduledItem/Edit.cshtml` — unified add/update form
- `Views/CollectorScheduledItem/Delete.cshtml` — confirmation page

### CollectorSettings dashboard
- `BuildPageViewModelAsync` now fetches and populates `ScheduledItem`
- `CollectorSettings/Index.cshtml` has a new "Scheduled Item Collector" card section

## Testing

Build: 0 errors, 0 warnings  
Tests: all passing (0 failures)

## References

- Phase 1 API: PR #968
- Closes #960

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>