### PR TITLE
fix: update collector web service base URLs to match refactored API routes

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorFeedSourceService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorFeedSourceService.cs
@@ -13,7 +13,7 @@ public class UserCollectorFeedSourceService(
     ILogger<UserCollectorFeedSourceService> logger) : IUserCollectorFeedSourceService
 {
     private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
-    private const string FeedSourceBaseUrl = "/UserCollectorFeedSources";
+    private const string FeedSourceBaseUrl = "/Collectors/FeedSource/Settings";
 
     public async Task<List<UserCollectorFeedSource>> GetCurrentUserAsync()
     {

--- a/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorSpeakingEngagementService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorSpeakingEngagementService.cs
@@ -13,7 +13,7 @@ public class UserCollectorSpeakingEngagementService(
     ILogger<UserCollectorSpeakingEngagementService> logger) : IUserCollectorSpeakingEngagementService
 {
     private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
-    private const string BaseUrl = "/UserCollectorSpeakingEngagements";
+    private const string BaseUrl = "/Collectors/SpeakingEngagement/Settings";
 
     public async Task<List<UserCollectorSpeakingEngagement>> GetCurrentUserAsync()
     {

--- a/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorYouTubeChannelService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorYouTubeChannelService.cs
@@ -13,7 +13,7 @@ public class UserCollectorYouTubeChannelService(
     ILogger<UserCollectorYouTubeChannelService> logger) : IUserCollectorYouTubeChannelService
 {
     private const string ApiServiceName = "JosephGuadagnoBroadcastingApi";
-    private const string YouTubeChannelBaseUrl = "/UserCollectorYouTubeChannels";
+    private const string YouTubeChannelBaseUrl = "/Collectors/YouTube/Settings";
 
     public async Task<List<UserCollectorYouTubeChannel>> GetCurrentUserAsync()
     {


### PR DESCRIPTION
## Summary

After the collector API route refactor (issue #960), the API controllers were moved from `/UserCollector*` routes to the new `/Collectors/{name}/Settings` hierarchy. Three Web service files still had the old base URL constants, causing every CRUD call from the Web layer to return 404.

## Root cause

Three `private const string` base URL constants were stale:

| File | Old value | New value |
|------|-----------|-----------|
| `UserCollectorYouTubeChannelService.cs` | `/UserCollectorYouTubeChannels` | `/Collectors/YouTube/Settings` |
| `UserCollectorFeedSourceService.cs` | `/UserCollectorFeedSources` | `/Collectors/FeedSource/Settings` |
| `UserCollectorSpeakingEngagementService.cs` | `/UserCollectorSpeakingEngagements` | `/Collectors/SpeakingEngagement/Settings` |

## Changes

- `src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorYouTubeChannelService.cs` — updated `YouTubeChannelBaseUrl`
- `src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorFeedSourceService.cs` — updated `FeedSourceBaseUrl`
- `src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorSpeakingEngagementService.cs` — updated `BaseUrl`

## Verification

- Build: 0 errors, 0 warnings
- Tests: all passing

Closes #973