### PR TITLE
fix(#976): handle missing scheduled item gracefully in GetAsync

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -145,3 +145,6 @@ Fixed Neo's blocking `cs/log-forging` review finding: 3 `LogWarning` call sites 
 1. NEVER use `gh pr create --body "..."` inline — PowerShell mangles backslashes. ALWAYS write body to file first.
 2. Before all GitHub output, scan for `\word\` patterns and replace with backticks.
 
+### GetForUserAsync<T> — 404 handling pattern (2026-05-17)
+
+Any Web service that calls `IDownstreamApi.GetForUserAsync<T>` for a **single nullable object** (not a collection) MUST wrap the call in `catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)` and return `null`. The API legitimately returns 404 for first-time users who have no configuration yet; without the catch the exception propagates and crashes the page. The controller already handles `null` gracefully. Log the 404 as `LogInformation` (not `LogWarning`) — it is expected, not an error. Always sanitize the OID via `LogSanitizer.Sanitize(ownerOid)`.

--- a/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using JosephGuadagno.Broadcasting.Domain.Utilities;
 using JosephGuadagno.Broadcasting.Web.Interfaces;
@@ -17,12 +18,20 @@ public class UserCollectorScheduledItemService(
 
     public async Task<UserCollectorScheduledItem?> GetAsync(string ownerOid)
     {
-        var response = await apiClient.GetForUserAsync<UserCollectorScheduledItem>(ApiServiceName, options =>
+        try
         {
-            options.RelativePath = $"{BaseUrl}?ownerOid={Uri.EscapeDataString(ownerOid)}";
-        });
-
-        return response;
+            return await apiClient.GetForUserAsync<UserCollectorScheduledItem>(ApiServiceName, options =>
+            {
+                options.RelativePath = $"{BaseUrl}?ownerOid={Uri.EscapeDataString(ownerOid)}";
+            });
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            logger.LogInformation(
+                "No scheduled item config found for owner {OwnerOid}",
+                LogSanitizer.Sanitize(ownerOid));
+            return null;
+        }
     }
 
     public async Task<UserCollectorScheduledItem?> SaveAsync(UserCollectorScheduledItem item)


### PR DESCRIPTION
## Summary

Fixes #976 — `Collectors/Settings/Index` crashes when no scheduled item collector configuration exists for the user.

## Root Cause

`CollectorScheduledItemSettingsController.GetAsync` (API) returns **HTTP 404** when no configuration exists for a user — this is correct and expected for first-time users. However, `IDownstreamApi.GetForUserAsync<T>` (from `Microsoft.Identity.Abstractions`) throws `HttpRequestException` on any non-2xx response. `UserCollectorScheduledItemService.GetAsync` had no catch block, so the 404 exception propagated through `CollectorSettingsController.BuildPageViewModelAsync` and crashed the page.

The controller already handles `null` gracefully (`scheduledItem is not null ? ... : null`), so the fix is purely in the service layer.

## Fix

Wrap the `GetForUserAsync` call in a `try/catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)` block and return `null`. A sanitized `LogInformation` call is also added so first-time users are observable in logs without noise.

This matches the established pattern used in `UserPublisherBlueskySettingsService.GetCurrentUserAsync` (and the other publisher services added in #963).

## Files Changed

- `src/JosephGuadagno.Broadcasting.Web/Services/UserCollectorScheduledItemService.cs`

## Testing

- `dotnet build .\src\ --configuration Release` — ✅ Build succeeded, 0 errors, 0 warnings
