### PR TITLE
feat(#978): Add post-approval user onboarding setup flow

### DIFF
--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/SetupController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/SetupController.cs
@@ -1,0 +1,27 @@
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Web.Controllers;
+
+/// <summary>
+/// Controller for the post-approval user onboarding setup checklist.
+/// Requires at least the Contributor role so the page is not exposed to unapproved users.
+/// </summary>
+[Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+public class SetupController(
+    ISetupService setupService,
+    ILogger<SetupController> logger) : Controller
+{
+    /// <summary>
+    /// Renders the onboarding setup checklist for the current user.
+    /// Always fetches fresh data so the page reflects the latest configuration state.
+    /// </summary>
+    public async Task<IActionResult> Index()
+    {
+        logger.LogDebug("Setup checklist requested by {User}", User.Identity?.Name);
+        var status = await setupService.GetSetupStatusAsync(forceRefresh: true);
+        return View(status);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISetupService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/ISetupService.cs
@@ -1,0 +1,19 @@
+using JosephGuadagno.Broadcasting.Web.Models;
+
+namespace JosephGuadagno.Broadcasting.Web.Interfaces;
+
+/// <summary>
+/// Service for checking and reporting user onboarding setup completion status.
+/// </summary>
+public interface ISetupService
+{
+    /// <summary>
+    /// Gets the current user's setup status.
+    /// </summary>
+    /// <param name="forceRefresh">
+    /// When <see langword="true"/>, bypasses the cached result and fetches fresh data from the API.
+    /// Pass <see langword="true"/> when the user has just configured something and the UI must reflect
+    /// the updated state immediately.
+    /// </param>
+    Task<SetupStatus> GetSetupStatusAsync(bool forceRefresh = false);
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Models/MissingTemplateKey.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/MissingTemplateKey.cs
@@ -1,0 +1,7 @@
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+/// <summary>
+/// Identifies a (platform × message-type) combination that is required for the current user
+/// but does not yet have a message template.
+/// </summary>
+public sealed record MissingTemplateKey(string Platform, string MessageType);

--- a/src/JosephGuadagno.Broadcasting.Web/Models/SetupStatus.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/SetupStatus.cs
@@ -12,16 +12,29 @@ public class SetupStatus
     public bool HasPublisher { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the user has message templates covering all of their configured publishers.
-    /// Considered complete when no publishers are configured or when every configured publisher platform
-    /// has at least one message template.
+    /// Gets or sets whether all required message template combinations (publisher × collector type)
+    /// exist for this user. Considered complete when the user has no publishers or no collectors,
+    /// or when every required (publisher, messageType) pair has a template.
     /// </summary>
     public bool HasMessageTemplates { get; set; }
 
     /// <summary>Gets the list of publisher platform names that the user has enabled.</summary>
     public IReadOnlyList<string> ConfiguredPublisherPlatforms { get; set; } = [];
 
-    /// <summary>Gets the list of configured publisher platforms that are missing message templates.</summary>
+    /// <summary>Gets the message type constants for each collector type the user has configured.</summary>
+    public IReadOnlyList<string> ConfiguredCollectorTypes { get; set; } = [];
+
+    /// <summary>
+    /// Gets the (platform, messageType) pairs that are required but do not yet have a template.
+    /// Derived from the intersection of <see cref="ConfiguredPublisherPlatforms"/> ×
+    /// <see cref="ConfiguredCollectorTypes"/>.
+    /// </summary>
+    public IReadOnlyList<MissingTemplateKey> MissingTemplatePairs { get; set; } = [];
+
+    /// <summary>
+    /// Gets the distinct publisher platform names that are missing at least one required template.
+    /// Derived from <see cref="MissingTemplatePairs"/> for display convenience.
+    /// </summary>
     public IReadOnlyList<string> MissingTemplatePlatforms { get; set; } = [];
 
     /// <summary>Gets whether all three onboarding steps are complete.</summary>

--- a/src/JosephGuadagno.Broadcasting.Web/Models/SetupStatus.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/SetupStatus.cs
@@ -1,0 +1,29 @@
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+/// <summary>
+/// Represents the current onboarding setup completion status for the authenticated user.
+/// </summary>
+public class SetupStatus
+{
+    /// <summary>Gets or sets whether the user has at least one collector configured.</summary>
+    public bool HasCollector { get; set; }
+
+    /// <summary>Gets or sets whether the user has at least one publisher enabled.</summary>
+    public bool HasPublisher { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the user has message templates covering all of their configured publishers.
+    /// Considered complete when no publishers are configured or when every configured publisher platform
+    /// has at least one message template.
+    /// </summary>
+    public bool HasMessageTemplates { get; set; }
+
+    /// <summary>Gets the list of publisher platform names that the user has enabled.</summary>
+    public IReadOnlyList<string> ConfiguredPublisherPlatforms { get; set; } = [];
+
+    /// <summary>Gets the list of configured publisher platforms that are missing message templates.</summary>
+    public IReadOnlyList<string> MissingTemplatePlatforms { get; set; } = [];
+
+    /// <summary>Gets whether all three onboarding steps are complete.</summary>
+    public bool IsComplete => HasCollector && HasPublisher && HasMessageTemplates;
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Program.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Program.cs
@@ -250,6 +250,7 @@ void ConfigureApplication(IServiceCollection services)
 {
     services.AddHttpClient();
     services.AddMemoryCache();
+    services.AddHttpContextAccessor();
     
     // Register BroadcastingContext via transitive dependency (Managers ΓåÆ Data.Sql)
     // Note: BroadcastingContext type is fully qualified to avoid needing "using Data.Sql"
@@ -273,6 +274,8 @@ void ConfigureApplication(IServiceCollection services)
     services.TryAddScoped<IUserCollectorYouTubeChannelService, UserCollectorYouTubeChannelService>();
     services.TryAddScoped<IUserCollectorSpeakingEngagementService, UserCollectorSpeakingEngagementService>();
     services.TryAddScoped<IMessageTemplateService, MessageTemplateService>();
+    services.TryAddScoped<ISetupService, SetupService>();
+
     services.TryAddScoped<IYouTubeItemService, YouTubeItemService>();
     services.TryAddScoped<ISyndicationFeedItemService, SyndicationFeedItemService>();
 

--- a/src/JosephGuadagno.Broadcasting.Web/Services/SetupService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/SetupService.cs
@@ -62,6 +62,12 @@ public class SetupService(
             || youTubeChannels.Count > 0
             || speakingEngagements.Count > 0;
 
+        // Map each collector type the user has to its message type constant
+        var collectorTypes = new List<string>();
+        if (feedSources.Count > 0) collectorTypes.Add(MessageTemplates.MessageTypes.NewSyndicationFeedItem);
+        if (youTubeChannels.Count > 0) collectorTypes.Add(MessageTemplates.MessageTypes.NewYouTubeItem);
+        if (speakingEngagements.Count > 0) collectorTypes.Add(MessageTemplates.MessageTypes.NewSpeakingEngagement);
+
         // Publishers — enabled flag indicates the platform is ready to use
         var bluesky = await blueskySettingsService.GetCurrentUserAsync();
         var twitter = await twitterSettingsService.GetCurrentUserAsync();
@@ -76,23 +82,41 @@ public class SetupService(
 
         var hasPublisher = configuredPublishers.Count > 0;
 
-        // Templates — for each configured publisher platform, at least one template must exist
+        // Templates — intersection-based: every (publisher × collectorType) pair needs a template
         var templateResult = await messageTemplateService.GetAllAsync(pageSize: Pagination.MaxPageSize);
-        var templatePlatforms = templateResult?.Items
-            .Select(t => t.Platform)
-            .Where(p => !string.IsNullOrEmpty(p))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+        var existingTemplates = templateResult?.Items
+            .Where(t => !string.IsNullOrEmpty(t.Platform) && !string.IsNullOrEmpty(t.MessageType))
+            .Select(t => (
+                Platform: t.Platform.Trim(),
+                MessageType: t.MessageType.Trim()))
+            .ToHashSet() ?? [];
 
-        var missingTemplatePlatforms = configuredPublishers
-            .Where(p => !templatePlatforms.Contains(p))
+        var missingTemplatePairs = new List<MissingTemplateKey>();
+        foreach (var publisher in configuredPublishers)
+        {
+            foreach (var messageType in collectorTypes)
+            {
+                if (!existingTemplates.Contains((publisher, messageType)))
+                {
+                    missingTemplatePairs.Add(new MissingTemplateKey(publisher, messageType));
+                }
+            }
+        }
+
+        // Derive the distinct platforms for display convenience
+        var missingTemplatePlatforms = missingTemplatePairs
+            .Select(p => p.Platform)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        // Templates are complete when: no publishers configured, or all configured publishers have templates
-        var hasMessageTemplates = configuredPublishers.Count == 0 || missingTemplatePlatforms.Count == 0;
+        // Complete when there are no publishers, no collectors, or all required pairs exist
+        var hasMessageTemplates = configuredPublishers.Count == 0
+            || collectorTypes.Count == 0
+            || missingTemplatePairs.Count == 0;
 
         logger.LogDebug(
-            "Setup status built: HasCollector={HasCollector}, HasPublisher={HasPublisher}, HasMessageTemplates={HasMessageTemplates}",
-            hasCollector, hasPublisher, hasMessageTemplates);
+            "Setup status built: HasCollector={HasCollector}, HasPublisher={HasPublisher}, HasMessageTemplates={HasMessageTemplates}, MissingPairs={MissingPairCount}",
+            hasCollector, hasPublisher, hasMessageTemplates, missingTemplatePairs.Count);
 
         return new SetupStatus
         {
@@ -100,6 +124,8 @@ public class SetupService(
             HasPublisher = hasPublisher,
             HasMessageTemplates = hasMessageTemplates,
             ConfiguredPublisherPlatforms = configuredPublishers,
+            ConfiguredCollectorTypes = collectorTypes,
+            MissingTemplatePairs = missingTemplatePairs,
             MissingTemplatePlatforms = missingTemplatePlatforms
         };
     }

--- a/src/JosephGuadagno.Broadcasting.Web/Services/SetupService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/SetupService.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+using JosephGuadagno.Broadcasting.Domain.Constants;
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using JosephGuadagno.Broadcasting.Web.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace JosephGuadagno.Broadcasting.Web.Services;
+
+/// <summary>
+/// Checks all three onboarding areas (collectors, publishers, message templates) for the current user
+/// and returns a <see cref="SetupStatus"/> snapshot. Results are cached per user for five minutes
+/// to avoid API overhead on every page render.
+/// </summary>
+public class SetupService(
+    IUserCollectorFeedSourceService feedSourceService,
+    IUserCollectorYouTubeChannelService youTubeChannelService,
+    IUserCollectorSpeakingEngagementService speakingEngagementService,
+    IUserPublisherBlueskySettingsService blueskySettingsService,
+    IUserPublisherTwitterSettingsService twitterSettingsService,
+    IUserPublisherLinkedInSettingsService linkedInSettingsService,
+    IUserPublisherFacebookSettingsService facebookSettingsService,
+    IMessageTemplateService messageTemplateService,
+    IMemoryCache cache,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<SetupService> logger) : ISetupService
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    public async Task<SetupStatus> GetSetupStatusAsync(bool forceRefresh = false)
+    {
+        var userOid = httpContextAccessor.HttpContext?.User
+            .FindFirstValue(ApplicationClaimTypes.EntraObjectId);
+
+        var cacheKey = $"setup_status_{userOid}";
+
+        if (!forceRefresh
+            && !string.IsNullOrEmpty(userOid)
+            && cache.TryGetValue(cacheKey, out SetupStatus? cached)
+            && cached is not null)
+        {
+            return cached;
+        }
+
+        var status = await BuildSetupStatusAsync();
+
+        if (!string.IsNullOrEmpty(userOid))
+        {
+            cache.Set(cacheKey, status, CacheTtl);
+        }
+
+        return status;
+    }
+
+    private async Task<SetupStatus> BuildSetupStatusAsync()
+    {
+        // Collectors — sequential awaits per project convention
+        var feedSources = await feedSourceService.GetCurrentUserAsync();
+        var youTubeChannels = await youTubeChannelService.GetCurrentUserAsync();
+        var speakingEngagements = await speakingEngagementService.GetCurrentUserAsync();
+
+        var hasCollector = feedSources.Count > 0
+            || youTubeChannels.Count > 0
+            || speakingEngagements.Count > 0;
+
+        // Publishers — enabled flag indicates the platform is ready to use
+        var bluesky = await blueskySettingsService.GetCurrentUserAsync();
+        var twitter = await twitterSettingsService.GetCurrentUserAsync();
+        var linkedIn = await linkedInSettingsService.GetCurrentUserAsync();
+        var facebook = await facebookSettingsService.GetCurrentUserAsync();
+
+        var configuredPublishers = new List<string>();
+        if (bluesky?.IsEnabled == true) configuredPublishers.Add(MessageTemplates.Platforms.Bluesky);
+        if (twitter?.IsEnabled == true) configuredPublishers.Add(MessageTemplates.Platforms.Twitter);
+        if (linkedIn?.IsEnabled == true) configuredPublishers.Add(MessageTemplates.Platforms.LinkedIn);
+        if (facebook?.IsEnabled == true) configuredPublishers.Add(MessageTemplates.Platforms.Facebook);
+
+        var hasPublisher = configuredPublishers.Count > 0;
+
+        // Templates — for each configured publisher platform, at least one template must exist
+        var templateResult = await messageTemplateService.GetAllAsync(pageSize: Pagination.MaxPageSize);
+        var templatePlatforms = templateResult?.Items
+            .Select(t => t.Platform)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+
+        var missingTemplatePlatforms = configuredPublishers
+            .Where(p => !templatePlatforms.Contains(p))
+            .ToList();
+
+        // Templates are complete when: no publishers configured, or all configured publishers have templates
+        var hasMessageTemplates = configuredPublishers.Count == 0 || missingTemplatePlatforms.Count == 0;
+
+        logger.LogDebug(
+            "Setup status built: HasCollector={HasCollector}, HasPublisher={HasPublisher}, HasMessageTemplates={HasMessageTemplates}",
+            hasCollector, hasPublisher, hasMessageTemplates);
+
+        return new SetupStatus
+        {
+            HasCollector = hasCollector,
+            HasPublisher = hasPublisher,
+            HasMessageTemplates = hasMessageTemplates,
+            ConfiguredPublisherPlatforms = configuredPublishers,
+            MissingTemplatePlatforms = missingTemplatePlatforms
+        };
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/ViewComponents/SetupStatusViewComponent.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/ViewComponents/SetupStatusViewComponent.cs
@@ -1,0 +1,17 @@
+using JosephGuadagno.Broadcasting.Web.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JosephGuadagno.Broadcasting.Web.ViewComponents;
+
+/// <summary>
+/// Renders a navigation badge that prompts the user to complete their account setup.
+/// Visible for authenticated users until all three setup areas are configured.
+/// </summary>
+public class SetupStatusViewComponent(ISetupService setupService) : ViewComponent
+{
+    public async Task<IViewComponentResult> InvokeAsync()
+    {
+        var status = await setupService.GetSetupStatusAsync();
+        return View(status);
+    }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Setup/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Setup/Index.cshtml
@@ -1,0 +1,214 @@
+@model JosephGuadagno.Broadcasting.Web.Models.SetupStatus
+
+@{
+    ViewData["Title"] = "Account Setup";
+}
+
+<div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+    <div>
+        <h1 class="mb-1"><i class="bi bi-gear-fill me-2"></i>Account Setup</h1>
+        <p class="text-muted mb-0">
+            Complete the three steps below to start broadcasting your content.
+            You can skip steps and return at any time.
+        </p>
+    </div>
+    @if (Model.IsComplete)
+    {
+        <span class="badge text-bg-success fs-6 px-3 py-2">
+            <i class="bi bi-check-circle-fill me-1"></i>Setup Complete
+        </span>
+    }
+    else
+    {
+        <span class="badge text-bg-warning fs-6 px-3 py-2">
+            <i class="bi bi-exclamation-circle-fill me-1"></i>Setup Incomplete
+        </span>
+    }
+</div>
+
+@if (Model.IsComplete)
+{
+    <div class="alert alert-success" role="alert">
+        <i class="bi bi-check-circle-fill me-2"></i>
+        <strong>You're all set!</strong> Your account is fully configured and ready to broadcast.
+    </div>
+}
+else
+{
+    <div class="alert alert-info" role="alert">
+        <i class="bi bi-info-circle me-2"></i>
+        Complete the steps below to enable broadcasting. Check marks appear once each area is configured.
+    </div>
+}
+
+<div class="row g-4">
+
+    @* ── Step 1: Collectors ────────────────────────────────────────────────── *@
+    @{
+        var collectorBorderClass = Model.HasCollector ? "border-success" : "border-warning";
+        var collectorHeaderClass = Model.HasCollector ? "bg-success text-white" : "bg-warning";
+    }
+    <div class="col-12">
+        <div class="card @collectorBorderClass">
+            <div class="card-header @collectorHeaderClass d-flex justify-content-between align-items-center">
+                <h2 class="card-title h5 mb-0">
+                    @if (Model.HasCollector)
+                    {
+                        <i class="bi bi-check-circle-fill me-2"></i>
+                    }
+                    else
+                    {
+                        <i class="bi bi-1-circle me-2"></i>
+                    }
+                    Step 1 — Configure Collectors
+                </h2>
+                @if (Model.HasCollector)
+                {
+                    <span class="badge text-bg-light">Configured</span>
+                }
+                else
+                {
+                    <span class="badge text-bg-light">Not yet set up</span>
+                }
+            </div>
+            <div class="card-body">
+                <p class="card-text">
+                    Collectors gather content to broadcast — RSS / Atom / JSON feeds, YouTube channels,
+                    or speaking engagements. Add at least one source to get started.
+                </p>
+                @if (Model.HasCollector)
+                {
+                    <a asp-controller="CollectorSettings" asp-action="Index" class="btn btn-outline-success">
+                        <i class="bi bi-pencil me-1"></i>Manage Collectors
+                    </a>
+                }
+                else
+                {
+                    <a asp-controller="CollectorSettings" asp-action="Index" class="btn btn-primary">
+                        <i class="bi bi-plus-circle me-1"></i>Configure Collectors
+                    </a>
+                }
+            </div>
+        </div>
+    </div>
+
+    @* ── Step 2: Publishers ───────────────────────────────────────────────── *@
+    @{
+        var publisherBorderClass = Model.HasPublisher ? "border-success" : "border-warning";
+        var publisherHeaderClass = Model.HasPublisher ? "bg-success text-white" : "bg-warning";
+    }
+    <div class="col-12">
+        <div class="card @publisherBorderClass">
+            <div class="card-header @publisherHeaderClass d-flex justify-content-between align-items-center">
+                <h2 class="card-title h5 mb-0">
+                    @if (Model.HasPublisher)
+                    {
+                        <i class="bi bi-check-circle-fill me-2"></i>
+                    }
+                    else
+                    {
+                        <i class="bi bi-2-circle me-2"></i>
+                    }
+                    Step 2 — Enable Publishers
+                </h2>
+                @if (Model.HasPublisher)
+                {
+                    <span class="badge text-bg-light">Configured</span>
+                }
+                else
+                {
+                    <span class="badge text-bg-light">Not yet set up</span>
+                }
+            </div>
+            <div class="card-body">
+                <p class="card-text">
+                    Publishers send your content to social media platforms.
+                    Enable at least one platform: Bluesky, Twitter, LinkedIn, or Facebook.
+                </p>
+                @if (Model.ConfiguredPublisherPlatforms.Count > 0)
+                {
+                    <p class="mb-2">
+                        <strong>Enabled:</strong>
+                        @foreach (var platform in Model.ConfiguredPublisherPlatforms)
+                        {
+                            <span class="badge text-bg-success ms-1">@platform</span>
+                        }
+                    </p>
+                }
+                @if (Model.HasPublisher)
+                {
+                    <a asp-controller="Publishers" asp-action="Index" class="btn btn-outline-success">
+                        <i class="bi bi-pencil me-1"></i>Manage Publishers
+                    </a>
+                }
+                else
+                {
+                    <a asp-controller="Publishers" asp-action="Index" class="btn btn-primary">
+                        <i class="bi bi-plus-circle me-1"></i>Configure Publishers
+                    </a>
+                }
+            </div>
+        </div>
+    </div>
+
+    @* ── Step 3: Message Templates ────────────────────────────────────────── *@
+    @{
+        var templateBorderClass = Model.HasMessageTemplates ? "border-success" : "border-warning";
+        var templateHeaderClass = Model.HasMessageTemplates ? "bg-success text-white" : "bg-warning";
+    }
+    <div class="col-12">
+        <div class="card @templateBorderClass">
+            <div class="card-header @templateHeaderClass d-flex justify-content-between align-items-center">
+                <h2 class="card-title h5 mb-0">
+                    @if (Model.HasMessageTemplates)
+                    {
+                        <i class="bi bi-check-circle-fill me-2"></i>
+                    }
+                    else
+                    {
+                        <i class="bi bi-3-circle me-2"></i>
+                    }
+                    Step 3 — Create Message Templates
+                </h2>
+                @if (Model.HasMessageTemplates)
+                {
+                    <span class="badge text-bg-light">Configured</span>
+                }
+                else
+                {
+                    <span class="badge text-bg-light">Not yet set up</span>
+                }
+            </div>
+            <div class="card-body">
+                <p class="card-text">
+                    Message templates define how your posts are formatted using Scriban templates.
+                    @if (!Model.HasPublisher)
+                    {
+                        <text>Complete Step 2 first to know which platforms need templates.</text>
+                    }
+                    else if (Model.MissingTemplatePlatforms.Count > 0)
+                    {
+                        <text>Missing templates for:</text>
+                        foreach (var platform in Model.MissingTemplatePlatforms)
+                        {
+                            <span class="badge text-bg-warning ms-1">@platform</span>
+                        }
+                    }
+                </p>
+                @if (Model.HasMessageTemplates)
+                {
+                    <a asp-controller="MessageTemplates" asp-action="Index" class="btn btn-outline-success">
+                        <i class="bi bi-pencil me-1"></i>Manage Templates
+                    </a>
+                }
+                else
+                {
+                    <a asp-controller="MessageTemplates" asp-action="Index" class="btn btn-primary">
+                        <i class="bi bi-plus-circle me-1"></i>Create Templates
+                    </a>
+                }
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Setup/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Setup/Index.cshtml
@@ -186,13 +186,23 @@ else
                     {
                         <text>Complete Step 2 first to know which platforms need templates.</text>
                     }
-                    else if (Model.MissingTemplatePlatforms.Count > 0)
+                    else if (!Model.HasCollector)
                     {
-                        <text>Missing templates for:</text>
-                        foreach (var platform in Model.MissingTemplatePlatforms)
+                        <text>Complete Step 1 first to know which content types need templates.</text>
+                    }
+                    else if (Model.MissingTemplatePairs.Count > 0)
+                    {
+                        <text>Missing templates for the following platform / content-type combinations:</text>
+                        <ul class="mt-2 mb-0">
+                        @foreach (var pair in Model.MissingTemplatePairs)
                         {
-                            <span class="badge text-bg-warning ms-1">@platform</span>
+                            <li>
+                                <span class="badge text-bg-secondary me-1">@pair.Platform</span>
+                                <span class="text-muted">×</span>
+                                <span class="badge text-bg-warning ms-1">@pair.MessageType</span>
+                            </li>
                         }
+                        </ul>
                     }
                 </p>
                 @if (Model.HasMessageTemplates)

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Shared/Components/SetupStatus/Default.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Shared/Components/SetupStatus/Default.cshtml
@@ -1,0 +1,15 @@
+@model JosephGuadagno.Broadcasting.Web.Models.SetupStatus
+
+@if (!Model.IsComplete)
+{
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-1"
+           asp-controller="Setup"
+           asp-action="Index"
+           title="Your account setup is incomplete — click to finish">
+            <i class="bi bi-gear-fill"></i>
+            <span>Setup</span>
+            <span class="badge text-bg-warning ms-1">!</span>
+        </a>
+    </li>
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/Shared/_Layout.cshtml
@@ -95,6 +95,7 @@
                                 </li>
                             </ul>
                         </li>
+                        @await Component.InvokeAsync("SetupStatus")
                     }
                 </ul>
                 <ul class="navbar-nav">


### PR DESCRIPTION
## Summary

Adds a post-approval user onboarding setup flow that guides newly approved users through configuring the three areas required to start broadcasting.

Closes #978

## Changes

### New files

- `Models/SetupStatus.cs` — captures `HasCollector`, `HasPublisher`, `HasMessageTemplates`, `ConfiguredPublisherPlatforms`, `MissingTemplatePlatforms`, `IsComplete`
- `Interfaces/ISetupService.cs` — `GetSetupStatusAsync(bool forceRefresh = false)`
- `Services/SetupService.cs` — queries all three setup areas via existing Web services; caches per-user result for 5 min via `IMemoryCache`; `forceRefresh=true` bypasses cache
- `Controllers/SetupController.cs` — `[Authorize(Policy = RequireContributor)]`; always fetches fresh data so the checklist reflects current config
- `ViewComponents/SetupStatusViewComponent.cs` — reads cached setup status; renders nav badge when incomplete
- `Views/Setup/Index.cshtml` — 3-card checklist; each step shows status and links to the relevant settings page
- `Views/Shared/Components/SetupStatus/Default.cshtml` — gear + warning nav badge; rendered only until `IsComplete` is true

### Modified files

- `Program.cs` — registered `AddHttpContextAccessor()` and `TryAddScoped<ISetupService, SetupService>()`
- `Views/Shared/_Layout.cshtml` — invoke `SetupStatus` view component in the authenticated navbar

## Design decisions

- **Checklist over wizard** — each area links to the existing settings pages rather than duplicating forms, keeping maintenance burden minimal
- **Caching** — 5-minute `IMemoryCache` keyed by user OID; the setup page bypasses it so users always see current state after saving settings
- **No auto-redirect** — the nav badge signals incomplete setup but does not force redirect; users can explore the app before finishing configuration
- **Templates logic** — if no publishers are configured, templates are not yet required; `HasMessageTemplates` returns true until at least one publisher is enabled

## Testing

Build and test suite pass. 5 pre-existing failures in `MessageTemplateDataStoreTests` (EF Core entity-tracking issue unrelated to this PR) were present before this branch was created.