### PR TITLE
feat(#979): add default message templates per publisher type

### DIFF
--- a/scripts/database/data-seed.sql
+++ b/scripts/database/data-seed.sql
@@ -454,99 +454,108 @@ INSERT INTO JJGNet.dbo.YouTubeItems (VideoId, Author, Title, ShortenedUrl, Tags,
 -- Seed default MessageTemplates
 -- 4 platforms x 5 message types = 20 templates
 -- IF NOT EXISTS guards make this idempotent.
+-- CreatedByEntraOid = N'' is the system-default sentinel.
 -- Scriban variables available in all templates:
 --   {{ title }}       - item title / engagement name / talk name
 --   {{ url }}         - shortened URL (if available) or full URL
 --   {{ description }} - comments/description (empty for feed/YouTube items)
 --   {{ tags }}        - comma-separated tag string (feed/YouTube only; empty for engagements/talks)
---   {{ image_url }}   - ScheduledItem.ImageUrl (nullable; not currently forwarded to queue payloads)
 -- =============================================
 
 DECLARE @SocialMediaPlatformId int;
 
 -- ----- Twitter (max ~280 chars) -----
 SET @SocialMediaPlatformId = (SELECT Id FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Twitter');
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'RandomPost', N'{{ title }} - {{ url }}', N'Default Twitter template for random/scheduled posts', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem', N'Blog Post: {{ title }} {{ url }}', N'Twitter template for new blog post announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewYouTubeItem', N'New video: {{ title }} {{ url }}', N'Twitter template for new YouTube video announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement', N'I''m speaking at {{ title }}! {{ url }}', N'Twitter template for new speaking engagement announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'ScheduledItem', N'{{ title }} {{ url }}', N'Twitter template for generic scheduled item broadcasts', @SeededOwnerEntraOid);
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'RandomPost' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'RandomPost', N'{{ title }} - {{ url }}', N'Default Twitter template for random/scheduled posts', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSyndicationFeedItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem', N'Blog Post: {{ title }} {{ url }}' + CHAR(10) + N'{{ tags }}', N'Twitter template for new blog post announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewYouTubeItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewYouTubeItem', N'New video: {{ title }} {{ url }}' + CHAR(10) + N'{{ tags }}', N'Twitter template for new YouTube video announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSpeakingEngagement' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement', N'I''m speaking at {{ title }}! {{ url }}', N'Twitter template for new speaking engagement announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'ScheduledItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'ScheduledItem', N'{{ title }} {{ url }}', N'Twitter template for generic scheduled item broadcasts', N'');
 
 -- ----- Facebook (max ~2000 chars) -----
 SET @SocialMediaPlatformId = (SELECT Id FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'Facebook');
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'RandomPost',
-    N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
-    N'Default Facebook template for random/scheduled posts', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem',
-    N'ICYMI: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
-    N'Facebook template for new blog post announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)    VALUES (@SocialMediaPlatformId, N'NewYouTubeItem',
-    N'New video: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Watch now: {{ url }}',
-    N'Facebook template for new YouTube video announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement',
-    N'I''m speaking at {{ title }}!' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
-    N'Facebook template for new speaking engagement announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'ScheduledItem',
-    N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
-    N'Facebook template for generic scheduled item broadcasts', @SeededOwnerEntraOid);
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'RandomPost' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'RandomPost',
+        N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
+        N'Default Facebook template for random/scheduled posts', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSyndicationFeedItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem',
+        N'ICYMI: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Tags: {{ tags }}' + CHAR(10) + N'{{ url }}',
+        N'Facebook template for new blog post announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewYouTubeItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewYouTubeItem',
+        N'New video: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Tags: {{ tags }}' + CHAR(10) + N'Watch now: {{ url }}',
+        N'Facebook template for new YouTube video announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSpeakingEngagement' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement',
+        N'I''m speaking at {{ title }}!' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
+        N'Facebook template for new speaking engagement announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'ScheduledItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'ScheduledItem',
+        N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
+        N'Facebook template for generic scheduled item broadcasts', N'');
 
 -- ----- LinkedIn (professional tone) -----
 SET @SocialMediaPlatformId = (SELECT Id FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'LinkedIn');
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'RandomPost',
-    N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
-    N'Default LinkedIn template for random/scheduled posts', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem',
-    N'New blog post: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Read more: {{ url }}',
-    N'LinkedIn template for new blog post announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewYouTubeItem',
-    N'New video: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Watch: {{ url }}',
-    N'LinkedIn template for new YouTube video announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement',
-    N'I am excited to announce I will be speaking at {{ title }}.' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Learn more: {{ url }}',
-    N'LinkedIn template for new speaking engagement announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'ScheduledItem',
-    N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
-    N'LinkedIn template for generic scheduled item broadcasts', @SeededOwnerEntraOid);
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'RandomPost' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'RandomPost',
+        N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
+        N'Default LinkedIn template for random/scheduled posts', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSyndicationFeedItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem',
+        N'New blog post: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Tags: {{ tags }}' + CHAR(10) + N'Read more: {{ url }}',
+        N'LinkedIn template for new blog post announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewYouTubeItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewYouTubeItem',
+        N'New video: {{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Tags: {{ tags }}' + CHAR(10) + N'Watch: {{ url }}',
+        N'LinkedIn template for new YouTube video announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSpeakingEngagement' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement',
+        N'I am excited to announce I will be speaking at {{ title }}.' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'Learn more: {{ url }}',
+        N'LinkedIn template for new speaking engagement announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'ScheduledItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'ScheduledItem',
+        N'{{ title }}' + CHAR(10) + CHAR(10) + N'{{ description }}' + CHAR(10) + CHAR(10) + N'{{ url }}',
+        N'LinkedIn template for generic scheduled item broadcasts', N'');
 
 -- ----- Bluesky (casual tone, max ~300 chars) -----
 SET @SocialMediaPlatformId = (SELECT Id FROM JJGNet.dbo.SocialMediaPlatforms WHERE Name = N'BlueSky');
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'RandomPost', N'{{ title }} - {{ url }}', N'Default Bluesky template for random/scheduled posts', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem', N'Blog Post: {{ title }} {{ url }}', N'Bluesky template for new blog post announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewYouTubeItem', N'New video: {{ title }} {{ url }}', N'Bluesky template for new YouTube video announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement', N'Speaking at {{ title }}! {{ url }}', N'Bluesky template for new speaking engagement announcements', @SeededOwnerEntraOid);
-
-INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
-VALUES (@SocialMediaPlatformId, N'ScheduledItem', N'{{ title }} {{ url }}', N'Bluesky template for generic scheduled item broadcasts', @SeededOwnerEntraOid);
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'RandomPost' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'RandomPost', N'✨ {{ title }} - {{ url }}', N'Default Bluesky template for random/scheduled posts', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSyndicationFeedItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSyndicationFeedItem',
+        N'📝 New blog post: {{ title }}' + CHAR(10) + N'{{ tags }}' + CHAR(10) + N'{{ url }}',
+        N'Bluesky template for new blog post announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewYouTubeItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewYouTubeItem',
+        N'🎬 New video: {{ title }}' + CHAR(10) + N'{{ tags }}' + CHAR(10) + N'{{ url }}',
+        N'Bluesky template for new YouTube video announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'NewSpeakingEngagement' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'NewSpeakingEngagement', N'🎤 Speaking at {{ title }}! {{ url }}', N'Bluesky template for new speaking engagement announcements', N'');
+IF NOT EXISTS (SELECT 1 FROM JJGNet.dbo.MessageTemplates WHERE SocialMediaPlatformId = @SocialMediaPlatformId AND MessageType = N'ScheduledItem' AND CreatedByEntraOid = N'')
+    INSERT INTO JJGNet.dbo.MessageTemplates (SocialMediaPlatformId, MessageType, Template, Description, CreatedByEntraOid)
+    VALUES (@SocialMediaPlatformId, N'ScheduledItem', N'{{ title }} {{ url }}', N'Bluesky template for generic scheduled item broadcasts', N'');

--- a/scripts/database/table-create.sql
+++ b/scripts/database/table-create.sql
@@ -185,8 +185,8 @@ create table dbo.MessageTemplates
     MessageType   nvarchar(50)  not null,
     Template      nvarchar(max) not null,
     Description   nvarchar(500) null,
-    CreatedByEntraOid nvarchar(36) null,
-    constraint PK_MessageTemplates primary key (SocialMediaPlatformId, MessageType)
+    CreatedByEntraOid nvarchar(36) not null default '',
+    constraint PK_MessageTemplates primary key (SocialMediaPlatformId, MessageType, CreatedByEntraOid)
 )
 go
 

--- a/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Api.Tests/Controllers/MessageTemplatesControllerTests.cs
@@ -59,23 +59,21 @@ public class MessageTemplatesControllerTests
     };
 
     // -------------------------------------------------------------------------
-    // Security: GetAsync — non-owner returns 403
+    // Security: GetAsync — user with no template gets 404 (not Forbid)
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task GetAsync_WhenNonOwner_ReturnsForbid()
+    public async Task GetAsync_WhenUserHasNoTemplate_ReturnsNotFound()
     {
-        // Arrange
-        // Template is owned by "owner-oid-12345"; the calling user has a different OID.
+        // Arrange — the user has no template; 3-arg GetAsync returns null
         var platform = BuildPlatform();
-        var template = BuildTemplate(oid: "owner-oid-12345");
 
         _socialMediaPlatformManagerMock
             .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
             .ReturnsAsync(platform);
         _messageTemplateManagerMock
-            .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(template);
+            .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MessageTemplate?)null);
 
         var sut = CreateSut(ownerOid: "non-owner-oid-99999");
 
@@ -83,30 +81,29 @@ public class MessageTemplatesControllerTests
         var result = await sut.GetAsync("TestPlatform", "RandomPost");
 
         // Assert
-        result.Result.Should().BeOfType<ForbidResult>();
+        result.Result.Should().BeOfType<NotFoundResult>();
         _messageTemplateManagerMock.Verify(
-            m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()),
+            m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     // -------------------------------------------------------------------------
-    // Security: UpdateAsync — non-owner returns 403
+    // Security: UpdateAsync — user with no template gets 404 (not Forbid)
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task UpdateAsync_WhenNonOwner_ReturnsForbid()
+    public async Task UpdateAsync_WhenUserHasNoTemplate_ReturnsNotFound()
     {
         // Arrange
         var platform = BuildPlatform();
-        var template = BuildTemplate(oid: "owner-oid-12345");
         var request = new MessageTemplateRequest { Template = "Updated {{ title }}!" };
 
         _socialMediaPlatformManagerMock
             .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
             .ReturnsAsync(platform);
         _messageTemplateManagerMock
-            .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(template);
+            .Setup(m => m.GetAsync(platform.Id, "RandomPost", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MessageTemplate?)null);
 
         var sut = CreateSut(ownerOid: "non-owner-oid-99999");
 
@@ -114,10 +111,131 @@ public class MessageTemplatesControllerTests
         var result = await sut.UpdateAsync("TestPlatform", "RandomPost", request);
 
         // Assert
-        result.Result.Should().BeOfType<ForbidResult>();
+        result.Result.Should().BeOfType<NotFoundResult>();
         _messageTemplateManagerMock.Verify(
             m => m.UpdateAsync(It.IsAny<MessageTemplate>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // -------------------------------------------------------------------------
+    // GetDefaultAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetDefaultAsync_WhenDefaultExists_ReturnsOk()
+    {
+        // Arrange
+        var platform = BuildPlatform();
+        var defaultTemplate = BuildTemplate(oid: ""); // system default
+
+        _socialMediaPlatformManagerMock
+            .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platform);
+        _messageTemplateManagerMock
+            .Setup(m => m.GetAsync(platform.Id, "RandomPost", "", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(defaultTemplate);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetDefaultAsync("TestPlatform", "RandomPost");
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value!.MessageType.Should().Be("RandomPost");
+    }
+
+    [Fact]
+    public async Task GetDefaultAsync_WhenPlatformNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _socialMediaPlatformManagerMock
+            .Setup(m => m.GetByNameAsync("UnknownPlatform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SocialMediaPlatform?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetDefaultAsync("UnknownPlatform", "RandomPost");
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // -------------------------------------------------------------------------
+    // GetAllDefaultsAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAllDefaultsAsync_ReturnsOkWithDefaults()
+    {
+        // Arrange
+        var defaults = new List<MessageTemplate>
+        {
+            BuildTemplate(oid: ""),
+            new() { SocialMediaPlatformId = 1, MessageType = "NewPost", Template = "{{ title }}", CreatedByEntraOid = "" }
+        };
+        _messageTemplateManagerMock
+            .Setup(m => m.GetAllDefaultsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(defaults);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetAllDefaultsAsync();
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = okResult.Value.Should().BeAssignableTo<IEnumerable<MessageTemplateResponse>>().Subject;
+        items.Should().HaveCount(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // CreateAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateAsync_WhenValid_ReturnsCreatedAtAction()
+    {
+        // Arrange
+        var platform = BuildPlatform();
+        var request = new MessageTemplateRequest { Template = "{{ title }} {{ url }}" };
+        var created = BuildTemplate(oid: "owner-oid-12345");
+
+        _socialMediaPlatformManagerMock
+            .Setup(m => m.GetByNameAsync("TestPlatform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platform);
+        _messageTemplateManagerMock
+            .Setup(m => m.CreateAsync(It.IsAny<MessageTemplate>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(created);
+
+        var sut = CreateSut(ownerOid: "owner-oid-12345");
+
+        // Act
+        var result = await sut.CreateAsync("TestPlatform", "RandomPost", request);
+
+        // Assert
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        _messageTemplateManagerMock.Verify(
+            m => m.CreateAsync(It.IsAny<MessageTemplate>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenPlatformNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _socialMediaPlatformManagerMock
+            .Setup(m => m.GetByNameAsync("UnknownPlatform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SocialMediaPlatform?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.CreateAsync("UnknownPlatform", "RandomPost", new MessageTemplateRequest { Template = "x" });
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundResult>();
     }
 
     // -------------------------------------------------------------------------

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
@@ -86,7 +86,7 @@ public class MessageTemplatesController : ControllerBase
     }
 
     /// <summary>
-    /// Gets a message template by platform and message type
+    /// Gets a message template by platform and message type for the current user
     /// </summary>
     /// <param name="platform">The platform name</param>
     /// <param name="messageType">The message type</param>
@@ -107,20 +107,118 @@ public class MessageTemplatesController : ControllerBase
             _logger.LogWarning("Social media platform not found: {Platform}", LogSanitizer.Sanitize(platform));
             return NotFound();
         }
-        
-        var template = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType);
+
+        var ownerOid = User.IsSiteAdministrator()
+            ? MessageTemplates.SystemOwnerEntraOid
+            : User.GetOwnerOid();
+        var template = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType, ownerOid);
         if (template is null)
         {
-            _logger.LogWarning("MessageTemplate not found for PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
+            _logger.LogWarning("MessageTemplate not found for PlatformId={PlatformId}, MessageType={MessageType}, OwnerOid={OwnerOid}",
+                socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType), LogSanitizer.Sanitize(ownerOid));
             return NotFound();
         }
 
-        if (!User.IsSiteAdministrator() && template.CreatedByEntraOid != User.GetOwnerOid())
+        return _mapper.Map<MessageTemplateResponse>(template);
+    }
+
+    /// <summary>
+    /// Gets the system default template for a platform and message type
+    /// </summary>
+    /// <param name="platform">The platform name</param>
+    /// <param name="messageType">The message type</param>
+    /// <returns>A <see cref="MessageTemplateResponse"/></returns>
+    /// <response code="200">If the item was found</response>
+    /// <response code="404">If the item was not found</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet("defaults/{platform}/{messageType}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(MessageTemplateResponse))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<MessageTemplateResponse>> GetDefaultAsync(string platform, string messageType)
+    {
+        var socialMediaPlatform = await _socialMediaPlatformManager.GetByNameAsync(platform);
+        if (socialMediaPlatform is null)
         {
-            return Forbid();
+            _logger.LogWarning("Social media platform not found: {Platform}", LogSanitizer.Sanitize(platform));
+            return NotFound();
+        }
+
+        var template = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType, MessageTemplates.SystemOwnerEntraOid);
+        if (template is null)
+        {
+            return NotFound();
         }
 
         return _mapper.Map<MessageTemplateResponse>(template);
+    }
+
+    /// <summary>
+    /// Gets all system default message templates
+    /// </summary>
+    /// <returns>A list of system default <see cref="MessageTemplateResponse"/> items</returns>
+    /// <response code="200">If the call was successful</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpGet("defaults")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireViewer)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<MessageTemplateResponse>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<IEnumerable<MessageTemplateResponse>>> GetAllDefaultsAsync()
+    {
+        var templates = await _messageTemplateManager.GetAllDefaultsAsync();
+        return Ok(_mapper.Map<List<MessageTemplateResponse>>(templates));
+    }
+
+    /// <summary>
+    /// Creates a new user-owned message template (cloned or custom)
+    /// </summary>
+    /// <param name="platform">The platform name</param>
+    /// <param name="messageType">The message type</param>
+    /// <param name="request">The message template data</param>
+    /// <returns>The created <see cref="MessageTemplateResponse"/></returns>
+    /// <response code="201">If the item was created</response>
+    /// <response code="400">If the model is invalid</response>
+    /// <response code="404">If the platform was not found</response>
+    /// <response code="401">If the current user was unauthorized to access this endpoint</response>
+    [HttpPost("{platform}/{messageType}")]
+    [Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(MessageTemplateResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<MessageTemplateResponse>> CreateAsync(string platform, string messageType,
+        [FromBody] MessageTemplateRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var socialMediaPlatform = await _socialMediaPlatformManager.GetByNameAsync(platform);
+        if (socialMediaPlatform is null)
+        {
+            _logger.LogWarning("Social media platform not found: {Platform}", LogSanitizer.Sanitize(platform));
+            return NotFound();
+        }
+
+        var messageTemplate = _mapper.Map<MessageTemplate>(request);
+        messageTemplate.SocialMediaPlatformId = socialMediaPlatform.Id;
+        messageTemplate.MessageType = messageType;
+        messageTemplate.CreatedByEntraOid = User.GetOwnerOid();
+
+        var created = await _messageTemplateManager.CreateAsync(messageTemplate);
+        if (created is null)
+        {
+            _logger.LogWarning("MessageTemplate create failed: PlatformId={PlatformId}, MessageType={MessageType}",
+                socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
+            return BadRequest();
+        }
+
+        _logger.LogInformation("MessageTemplate created for Platform={Platform}, MessageType={MessageType}",
+            LogSanitizer.Sanitize(platform), LogSanitizer.Sanitize(messageType));
+        return CreatedAtAction(nameof(GetAsync), new { platform, messageType },
+            _mapper.Map<MessageTemplateResponse>(created));
     }
 
     /// <summary>
@@ -156,22 +254,18 @@ public class MessageTemplatesController : ControllerBase
             return NotFound();
         }
 
-        var existing = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType);
+        var ownerOid = User.GetOwnerOid();
+        var existing = await _messageTemplateManager.GetAsync(socialMediaPlatform.Id, messageType, ownerOid);
         if (existing is null)
         {
             _logger.LogWarning("MessageTemplate not found for update: PlatformId={PlatformId}, MessageType={MessageType}", socialMediaPlatform.Id, LogSanitizer.Sanitize(messageType));
             return NotFound();
         }
 
-        if (!User.IsSiteAdministrator() && existing.CreatedByEntraOid != User.GetOwnerOid())
-        {
-            return Forbid();
-        }
-
         var messageTemplate = _mapper.Map<MessageTemplate>(request);
         messageTemplate.SocialMediaPlatformId = socialMediaPlatform.Id;
         messageTemplate.MessageType = messageType;
-        messageTemplate.CreatedByEntraOid = existing.CreatedByEntraOid;
+        messageTemplate.CreatedByEntraOid = ownerOid;
         var updated = await _messageTemplateManager.UpdateAsync(messageTemplate);
         if (updated is null)
         {

--- a/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Api/Controllers/MessageTemplatesController.cs
@@ -182,6 +182,7 @@ public class MessageTemplatesController : ControllerBase
     /// <response code="404">If the platform was not found</response>
     /// <response code="401">If the current user was unauthorized to access this endpoint</response>
     [HttpPost("{platform}/{messageType}")]
+    [IgnoreAntiforgeryToken]
     [Authorize(Policy = AuthorizationPolicyNames.RequireContributor)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(MessageTemplateResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/MessageTemplateDataStoreTests.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql.Tests/MessageTemplateDataStoreTests.cs
@@ -55,7 +55,7 @@ public class MessageTemplateDataStoreTests : IDisposable
         string messageType,
         string template = "{{ title }} - {{ url }}",
         string? description = null,
-        string? ownerOid = null) => new()
+        string ownerOid = "") => new()
     {
         SocialMediaPlatformId = platformId,
         MessageType = messageType,
@@ -244,5 +244,145 @@ public class MessageTemplateDataStoreTests : IDisposable
         Assert.Equal(3, result.TotalCount);
         Assert.Equal(2, result.Items.Count);
         Assert.All(result.Items, template => Assert.Equal("owner-1", template.CreatedByEntraOid));
+    }
+
+    // -------------------------------------------------------------------------
+    // GetAsync (3-arg)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAsync_WithOwnerOid_ReturnsMatchingTemplate()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        _context.MessageTemplates.AddRange(
+            CreateMessageTemplate(twitterId, "RandomPost", "system template", ownerOid: ""),
+            CreateMessageTemplate(twitterId, "RandomPost", "user template", ownerOid: "user-oid-1"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAsync(twitterId, "RandomPost", "user-oid-1");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("user template", result.Template);
+        Assert.Equal("user-oid-1", result.CreatedByEntraOid);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithOwnerOid_WhenNotFound_ReturnsNull()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        _context.MessageTemplates.Add(CreateMessageTemplate(twitterId, "RandomPost", ownerOid: ""));
+        await _context.SaveChangesAsync();
+
+        // Act — looking for user-owned, but only system default exists
+        var result = await _dataStore.GetAsync(twitterId, "RandomPost", "user-oid-1");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // GetAllDefaultsAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAllDefaultsAsync_ReturnsOnlySystemDefaults()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        var facebookId = await GetOrCreatePlatformIdAsync("Facebook");
+        _context.MessageTemplates.AddRange(
+            CreateMessageTemplate(twitterId, "RandomPost", ownerOid: ""),
+            CreateMessageTemplate(facebookId, "NewPost", ownerOid: ""),
+            CreateMessageTemplate(twitterId, "RandomPost", ownerOid: "user-oid-1"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllDefaultsAsync();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.All(result, t => Assert.Equal("", t.CreatedByEntraOid));
+    }
+
+    [Fact]
+    public async Task GetAllDefaultsAsync_WhenNoneExist_ReturnsEmptyList()
+    {
+        // Arrange — only user-owned templates
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        _context.MessageTemplates.Add(CreateMessageTemplate(twitterId, "RandomPost", ownerOid: "user-oid-1"));
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _dataStore.GetAllDefaultsAsync();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // CreateAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateAsync_PersistsNewTemplate()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        var domainTemplate = new Domain.Models.MessageTemplate
+        {
+            SocialMediaPlatformId = twitterId,
+            MessageType = "RandomPost",
+            Template = "New {{ title }} {{ url }}",
+            CreatedByEntraOid = "user-oid-1"
+        };
+
+        // Act
+        var result = await _dataStore.CreateAsync(domainTemplate);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("New {{ title }} {{ url }}", result.Template);
+        Assert.Equal("user-oid-1", result.CreatedByEntraOid);
+        var stored = await _dataStore.GetAsync(twitterId, "RandomPost", "user-oid-1");
+        Assert.NotNull(stored);
+        Assert.Equal("New {{ title }} {{ url }}", stored.Template);
+    }
+
+    // -------------------------------------------------------------------------
+    // UpdateAsync with triplet key
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateAsync_UpdatesOnlyMatchingOwnerTemplate()
+    {
+        // Arrange
+        var twitterId = await GetOrCreatePlatformIdAsync("Twitter");
+        _context.MessageTemplates.AddRange(
+            CreateMessageTemplate(twitterId, "RandomPost", "system tpl", ownerOid: ""),
+            CreateMessageTemplate(twitterId, "RandomPost", "user tpl", ownerOid: "user-oid-1"));
+        await _context.SaveChangesAsync();
+
+        var update = new Domain.Models.MessageTemplate
+        {
+            SocialMediaPlatformId = twitterId,
+            MessageType = "RandomPost",
+            Template = "updated user tpl",
+            CreatedByEntraOid = "user-oid-1"
+        };
+
+        // Act
+        var result = await _dataStore.UpdateAsync(update);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("updated user tpl", result.Template);
+        // System default must remain unchanged
+        var systemDefault = await _dataStore.GetAsync(twitterId, "RandomPost", "");
+        Assert.NotNull(systemDefault);
+        Assert.Equal("system tpl", systemDefault.Template);
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/BroadcastingContext.cs
@@ -304,7 +304,7 @@ public partial class BroadcastingContext(DbContextOptions<BroadcastingContext> o
 
         modelBuilder.Entity<MessageTemplate>(entity =>
         {
-            entity.HasKey(e => new { e.SocialMediaPlatformId, e.MessageType })
+            entity.HasKey(e => new { e.SocialMediaPlatformId, e.MessageType, e.CreatedByEntraOid })
                 .HasName("PK_MessageTemplates");
 
             entity.Property(e => e.SocialMediaPlatformId)
@@ -321,7 +321,9 @@ public partial class BroadcastingContext(DbContextOptions<BroadcastingContext> o
                 .HasMaxLength(500);
 
             entity.Property(e => e.CreatedByEntraOid)
-                .HasMaxLength(36);
+                .HasMaxLength(36)
+                .IsRequired()
+                .HasDefaultValue(string.Empty);
 
             entity.HasOne(e => e.SocialMediaPlatform)
                 .WithMany()

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/MessageTemplateDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/MessageTemplateDataStore.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -6,13 +7,39 @@ namespace JosephGuadagno.Broadcasting.Data.Sql;
 
 public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, IMapper mapper) : IMessageTemplateDataStore
 {
-    public async Task<Domain.Models.MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default)
+    public Task<Domain.Models.MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default)
+        => GetAsync(socialMediaPlatformId, messageType, MessageTemplates.SystemOwnerEntraOid, cancellationToken);
+
+    public async Task<Domain.Models.MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, string ownerEntraOid, CancellationToken cancellationToken = default)
     {
         var dbMessageTemplate = await broadcastingContext.MessageTemplates
             .AsNoTracking()
             .Include(mt => mt.SocialMediaPlatform)
-            .FirstOrDefaultAsync(mt => mt.SocialMediaPlatformId == socialMediaPlatformId && mt.MessageType == messageType, cancellationToken);
+            .FirstOrDefaultAsync(mt =>
+                mt.SocialMediaPlatformId == socialMediaPlatformId &&
+                mt.MessageType == messageType &&
+                mt.CreatedByEntraOid == ownerEntraOid,
+                cancellationToken);
         return dbMessageTemplate is null ? null : mapper.Map<Domain.Models.MessageTemplate>(dbMessageTemplate);
+    }
+
+    public async Task<List<Domain.Models.MessageTemplate>> GetAllDefaultsAsync(CancellationToken cancellationToken = default)
+    {
+        var dbItems = await broadcastingContext.MessageTemplates
+            .AsNoTracking()
+            .Include(mt => mt.SocialMediaPlatform)
+            .Where(mt => mt.CreatedByEntraOid == MessageTemplates.SystemOwnerEntraOid)
+            .ToListAsync(cancellationToken);
+        return mapper.Map<List<Domain.Models.MessageTemplate>>(dbItems);
+    }
+
+    public async Task<Domain.Models.MessageTemplate?> CreateAsync(Domain.Models.MessageTemplate messageTemplate, CancellationToken cancellationToken = default)
+    {
+        var dbEntity = mapper.Map<Models.MessageTemplate>(messageTemplate);
+        broadcastingContext.MessageTemplates.Add(dbEntity);
+        await broadcastingContext.SaveChangesAsync(cancellationToken);
+        await broadcastingContext.Entry(dbEntity).Reference(mt => mt.SocialMediaPlatform).LoadAsync(cancellationToken);
+        return mapper.Map<Domain.Models.MessageTemplate>(dbEntity);
     }
 
     public async Task<List<Domain.Models.MessageTemplate>> GetAllAsync(CancellationToken cancellationToken = default)
@@ -36,9 +63,14 @@ public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, I
 
     public async Task<Domain.Models.MessageTemplate?> UpdateAsync(Domain.Models.MessageTemplate messageTemplate, CancellationToken cancellationToken = default)
     {
+        var ownerOid = messageTemplate.CreatedByEntraOid;
         var existing = await broadcastingContext.MessageTemplates
             .Include(mt => mt.SocialMediaPlatform)
-            .FirstOrDefaultAsync(mt => mt.SocialMediaPlatformId == messageTemplate.SocialMediaPlatformId && mt.MessageType == messageTemplate.MessageType, cancellationToken);
+            .FirstOrDefaultAsync(mt =>
+                mt.SocialMediaPlatformId == messageTemplate.SocialMediaPlatformId &&
+                mt.MessageType == messageTemplate.MessageType &&
+                mt.CreatedByEntraOid == ownerOid,
+                cancellationToken);
         if (existing is null) return null;
 
         existing.Template = messageTemplate.Template;
@@ -91,24 +123,7 @@ public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, I
             .AsNoTracking()
             .Include(mt => mt.SocialMediaPlatform);
 
-        if (!string.IsNullOrWhiteSpace(filter))
-        {
-            var lowerFilter = filter.ToLowerInvariant();
-            query = query.Where(mt => mt.MessageType.ToLower().Contains(lowerFilter));
-        }
-
-        var sortByLower = sortBy?.ToLowerInvariant();
-        if (sortByLower == nameof(Models.MessageTemplate.SocialMediaPlatformId).ToLowerInvariant().Replace("socialmedia", "").Replace("id", "id"))
-        {
-            query = sortDescending ? query.OrderByDescending(mt => mt.SocialMediaPlatformId) : query.OrderBy(mt => mt.SocialMediaPlatformId);
-        }
-        else
-        {
-            query = sortDescending
-                ? query.OrderByDescending(mt => mt.MessageType).ThenByDescending(mt => mt.SocialMediaPlatformId)
-                : query.OrderBy(mt => mt.MessageType).ThenBy(mt => mt.SocialMediaPlatformId);
-        }
-
+        query = ApplyFilterAndSort(query, filter, sortBy, sortDescending);
         var totalCount = await query.CountAsync(cancellationToken);
         var dbItems = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
         return new Domain.Models.PagedResult<Domain.Models.MessageTemplate>
@@ -125,24 +140,7 @@ public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, I
             .Include(mt => mt.SocialMediaPlatform)
             .Where(mt => mt.CreatedByEntraOid == ownerEntraOid);
 
-        if (!string.IsNullOrWhiteSpace(filter))
-        {
-            var lowerFilter = filter.ToLowerInvariant();
-            query = query.Where(mt => mt.MessageType.ToLower().Contains(lowerFilter));
-        }
-
-        var sortByLower = sortBy?.ToLowerInvariant();
-        if (sortByLower == nameof(Models.MessageTemplate.SocialMediaPlatformId).ToLowerInvariant().Replace("socialmedia", "").Replace("id", "id"))
-        {
-            query = sortDescending ? query.OrderByDescending(mt => mt.SocialMediaPlatformId) : query.OrderBy(mt => mt.SocialMediaPlatformId);
-        }
-        else
-        {
-            query = sortDescending
-                ? query.OrderByDescending(mt => mt.MessageType).ThenByDescending(mt => mt.SocialMediaPlatformId)
-                : query.OrderBy(mt => mt.MessageType).ThenBy(mt => mt.SocialMediaPlatformId);
-        }
-
+        query = ApplyFilterAndSort(query, filter, sortBy, sortDescending);
         var totalCount = await query.CountAsync(cancellationToken);
         var dbItems = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
         return new Domain.Models.PagedResult<Domain.Models.MessageTemplate>
@@ -150,5 +148,26 @@ public class MessageTemplateDataStore(BroadcastingContext broadcastingContext, I
             Items = mapper.Map<List<Domain.Models.MessageTemplate>>(dbItems),
             TotalCount = totalCount
         };
+    }
+
+    private static IQueryable<Models.MessageTemplate> ApplyFilterAndSort(
+        IQueryable<Models.MessageTemplate> query,
+        string? filter,
+        string sortBy,
+        bool sortDescending)
+    {
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            var lowerFilter = filter.ToLowerInvariant();
+            query = query.Where(mt => mt.MessageType.ToLower().Contains(lowerFilter));
+        }
+
+        query = sortBy?.ToLowerInvariant() == "socialmediaplatformid"
+            ? (sortDescending ? query.OrderByDescending(mt => mt.SocialMediaPlatformId) : query.OrderBy(mt => mt.SocialMediaPlatformId))
+            : (sortDescending
+                ? query.OrderByDescending(mt => mt.MessageType).ThenByDescending(mt => mt.SocialMediaPlatformId)
+                : query.OrderBy(mt => mt.MessageType).ThenBy(mt => mt.SocialMediaPlatformId));
+
+        return query;
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Data.Sql/Models/MessageTemplate.cs
+++ b/src/JosephGuadagno.Broadcasting.Data.Sql/Models/MessageTemplate.cs
@@ -15,7 +15,8 @@ public partial class MessageTemplate
 
     public string? Description { get; set; }
 
-    public string? CreatedByEntraOid { get; set; }
+    /// <summary>The Entra OID of the owner. Empty string is the system-default sentinel.</summary>
+    public string CreatedByEntraOid { get; set; } = string.Empty;
 
     public virtual SocialMediaPlatform? SocialMediaPlatform { get; set; }
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Constants/MessageTemplates.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Constants/MessageTemplates.cs
@@ -10,6 +10,11 @@ public static class MessageTemplates
         public const string Bluesky = "Bluesky";
     }
 
+    /// <summary>
+    /// The system sentinel OID used for default/system-owned templates (empty string).
+    /// </summary>
+    public const string SystemOwnerEntraOid = "";
+
     public static class MessageTypes
     {
         public const string RandomPost = "RandomPost";

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateDataStore.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateDataStore.cs
@@ -4,9 +4,14 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 
 public interface IMessageTemplateDataStore
 {
+    /// <summary>Gets the system-default template (CreatedByEntraOid = "").</summary>
     Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default);
+    /// <summary>Gets a template owned by a specific user (or system default when ownerEntraOid is "").</summary>
+    Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, string ownerEntraOid, CancellationToken cancellationToken = default);
     Task<List<MessageTemplate>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<MessageTemplate?> UpdateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default);
+    Task<MessageTemplate?> CreateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default);
+    Task<List<MessageTemplate>> GetAllDefaultsAsync(CancellationToken cancellationToken = default);
     
     Task<List<MessageTemplate>> GetAllAsync(string ownerEntraOid, CancellationToken cancellationToken = default);
     Task<PagedResult<MessageTemplate>> GetAllAsync(int page, int pageSize, CancellationToken cancellationToken = default);

--- a/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Interfaces/IMessageTemplateManager.cs
@@ -4,9 +4,14 @@ namespace JosephGuadagno.Broadcasting.Domain.Interfaces;
 
 public interface IMessageTemplateManager
 {
+    /// <summary>Gets the system-default template (delegates to ownerEntraOid = "").</summary>
     Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default);
+    /// <summary>Gets a template by triplet key (platform, messageType, ownerEntraOid).</summary>
+    Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, string ownerEntraOid, CancellationToken cancellationToken = default);
     Task<List<MessageTemplate>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<MessageTemplate?> UpdateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default);
+    Task<MessageTemplate?> CreateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default);
+    Task<List<MessageTemplate>> GetAllDefaultsAsync(CancellationToken cancellationToken = default);
     Task<PagedResult<MessageTemplate>> GetAllAsync(int page, int pageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default);
     Task<PagedResult<MessageTemplate>> GetAllAsync(string ownerEntraOid, int page, int pageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null, CancellationToken cancellationToken = default);
 }

--- a/src/JosephGuadagno.Broadcasting.Domain/Models/MessageTemplate.cs
+++ b/src/JosephGuadagno.Broadcasting.Domain/Models/MessageTemplate.cs
@@ -35,7 +35,8 @@ public class MessageTemplate
     public string Platform { get; set; } = string.Empty;
 
     /// <summary>
-    /// The Entra Object ID of the user who created this message template
+    /// The Entra Object ID of the user who created this message template.
+    /// Empty string is the system sentinel for default/system-owned templates.
     /// </summary>
-    public string? CreatedByEntraOid { get; set; }
+    public string CreatedByEntraOid { get; set; } = string.Empty;
 }

--- a/src/JosephGuadagno.Broadcasting.Managers/MessageTemplateManager.cs
+++ b/src/JosephGuadagno.Broadcasting.Managers/MessageTemplateManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JosephGuadagno.Broadcasting.Domain.Constants;
 using JosephGuadagno.Broadcasting.Domain.Interfaces;
 using JosephGuadagno.Broadcasting.Domain.Models;
 using Microsoft.Extensions.Caching.Memory;
@@ -13,23 +14,55 @@ public class MessageTemplateManager(IMessageTemplateDataStore messageTemplateDat
 	: IMessageTemplateManager
 {
 	private const string CacheKeyAll = "MessageTemplate_All";
-    private static string CacheKeyItem(int platformId, string messageType) => $"MessageTemplate_{platformId}_{messageType}";
+    private const string CacheKeyDefaults = "MessageTemplate_Defaults";
+    private static string CacheKeyItem(int platformId, string messageType, string ownerOid)
+        => $"MessageTemplate_{platformId}_{messageType}_{ownerOid}";
 
     private static readonly MemoryCacheEntryOptions CacheOptions =
         new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
 
-    public async Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, CancellationToken cancellationToken = default)
+        => GetAsync(socialMediaPlatformId, messageType, MessageTemplates.SystemOwnerEntraOid, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<MessageTemplate?> GetAsync(int socialMediaPlatformId, string messageType, string ownerEntraOid, CancellationToken cancellationToken = default)
     {
-        var cacheKey = CacheKeyItem(socialMediaPlatformId, messageType);
+        var cacheKey = CacheKeyItem(socialMediaPlatformId, messageType, ownerEntraOid);
         if (cache.TryGetValue(cacheKey, out MessageTemplate? cached) && cached is not null)
         {
             return cached;
         }
 
-        var result = await messageTemplateDataStore.GetAsync(socialMediaPlatformId, messageType, cancellationToken);
+        var result = await messageTemplateDataStore.GetAsync(socialMediaPlatformId, messageType, ownerEntraOid, cancellationToken);
         if (result is not null)
         {
             cache.Set(cacheKey, result, CacheOptions);
+        }
+        return result;
+    }
+
+    public async Task<List<MessageTemplate>> GetAllDefaultsAsync(CancellationToken cancellationToken = default)
+    {
+        if (cache.TryGetValue(CacheKeyDefaults, out List<MessageTemplate>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var result = await messageTemplateDataStore.GetAllDefaultsAsync(cancellationToken);
+        cache.Set(CacheKeyDefaults, result, CacheOptions);
+        return result;
+    }
+
+    public async Task<MessageTemplate?> CreateAsync(MessageTemplate messageTemplate, CancellationToken cancellationToken = default)
+    {
+        var result = await messageTemplateDataStore.CreateAsync(messageTemplate, cancellationToken);
+        if (result is not null)
+        {
+            InvalidateListCaches();
+            cache.Set(
+                CacheKeyItem(messageTemplate.SocialMediaPlatformId, messageTemplate.MessageType, messageTemplate.CreatedByEntraOid),
+                result, CacheOptions);
         }
         return result;
     }
@@ -64,7 +97,7 @@ public class MessageTemplateManager(IMessageTemplateDataStore messageTemplateDat
         if (result is not null)
         {
             InvalidateListCaches();
-            cache.Remove(CacheKeyItem(messageTemplate.SocialMediaPlatformId, messageTemplate.MessageType));
+            cache.Remove(CacheKeyItem(messageTemplate.SocialMediaPlatformId, messageTemplate.MessageType, messageTemplate.CreatedByEntraOid));
         }
         return result;
     }
@@ -72,6 +105,7 @@ public class MessageTemplateManager(IMessageTemplateDataStore messageTemplateDat
     private void InvalidateListCaches()
     {
         cache.Remove(CacheKeyAll);
+        cache.Remove(CacheKeyDefaults);
     }
 
     private static PagedResult<MessageTemplate> ApplyFilterSortPage(

--- a/src/JosephGuadagno.Broadcasting.Web/Controllers/MessageTemplatesController.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Controllers/MessageTemplatesController.cs
@@ -57,6 +57,17 @@ public class MessageTemplatesController : Controller
             ? allViewModels
             : allViewModels.Where(t => t.Platform == selectedPlatform).ToList();
 
+        // Compute which system defaults the user hasn't yet claimed
+        var userTemplateKeys = new HashSet<(string Platform, string MessageType)>(
+            allViewModels.Select(t => (t.Platform, t.MessageType)));
+        var defaultTemplates = await _messageTemplateService.GetAllDefaultsAsync();
+        var availableDefaults = (defaultTemplates ?? [])
+            .Select(d => _mapper.Map<MessageTemplateViewModel>(d))
+            .Where(d => !userTemplateKeys.Contains((d.Platform, d.MessageType)))
+            .OrderBy(d => d.Platform)
+            .ThenBy(d => d.MessageType)
+            .ToList();
+
         ViewBag.Page = page;
         ViewBag.PageSize = 100;
         ViewBag.TotalCount = filteredViewModels.Count;
@@ -68,6 +79,7 @@ public class MessageTemplatesController : Controller
         ViewBag.Filter = filter;
         ViewBag.Platforms = platforms;
         ViewBag.SelectedPlatform = selectedPlatform;
+        ViewBag.AvailableDefaults = availableDefaults;
 
         return View(filteredViewModels);
     }
@@ -89,7 +101,7 @@ public class MessageTemplatesController : Controller
         if (!User.IsInRole(RoleNames.SiteAdministrator))
         {
             var currentUserOid = User.FindFirstValue(ApplicationClaimTypes.EntraObjectId);
-            if (currentUserOid == null || template.CreatedByEntraOid == null || template.CreatedByEntraOid != currentUserOid)
+            if (currentUserOid == null || template.CreatedByEntraOid != currentUserOid)
             {
                 TempData["ErrorMessage"] = "You do not have permission to edit this message template.";
                 return RedirectToAction("Index");
@@ -123,6 +135,60 @@ public class MessageTemplatesController : Controller
         }
 
         TempData["SuccessMessage"] = "Message template saved successfully.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Shows the create form for a message template, pre-populated from the system default.
+    /// </summary>
+    /// <param name="platform">The platform name</param>
+    /// <param name="messageType">The message type</param>
+    [HttpGet]
+    public async Task<IActionResult> Create(string platform, string messageType)
+    {
+        var defaultTemplate = await _messageTemplateService.GetDefaultAsync(platform, messageType);
+        MessageTemplateViewModel viewModel;
+        if (defaultTemplate is not null)
+        {
+            viewModel = _mapper.Map<MessageTemplateViewModel>(defaultTemplate);
+        }
+        else
+        {
+            viewModel = new MessageTemplateViewModel
+            {
+                Platform = platform,
+                MessageType = messageType,
+                Template = string.Empty,
+                Description = string.Empty
+            };
+        }
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Creates a new user-owned message template.
+    /// </summary>
+    /// <param name="model">The message template view model</param>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(MessageTemplateViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(model);
+        }
+
+        var template = _mapper.Map<Domain.Models.MessageTemplate>(model);
+        var saved = await _messageTemplateService.CreateAsync(model.Platform, template);
+        if (saved is null)
+        {
+            _logger.LogWarning("Failed to create MessageTemplate for Platform={Platform}, MessageType={MessageType}",
+                LogSanitizer.Sanitize(model.Platform), LogSanitizer.Sanitize(model.MessageType));
+            ModelState.AddModelError(string.Empty, "Failed to create the message template.");
+            return View(model);
+        }
+
+        TempData["SuccessMessage"] = "Message template created successfully.";
         return RedirectToAction(nameof(Index));
     }
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Interfaces/IMessageTemplateService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Interfaces/IMessageTemplateService.cs
@@ -6,6 +6,9 @@ namespace JosephGuadagno.Broadcasting.Web.Interfaces;
 public interface IMessageTemplateService
 {
     Task<PagedResult<MessageTemplate>?> GetAllAsync(int? page = Pagination.DefaultPage, int? pageSize = Pagination.DefaultPageSize, string sortBy = "messagetype", bool sortDescending = false, string? filter = null);
+    Task<MessageTemplate?> GetDefaultAsync(string platform, string messageType);
+    Task<List<MessageTemplate>?> GetAllDefaultsAsync();
     Task<MessageTemplate?> GetAsync(string platform, string messageType);
+    Task<MessageTemplate?> CreateAsync(string platform, MessageTemplate messageTemplate);
     Task<MessageTemplate?> UpdateAsync(string platform, MessageTemplate messageTemplate);
 }

--- a/src/JosephGuadagno.Broadcasting.Web/Models/MissingTemplateKey.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Models/MissingTemplateKey.cs
@@ -1,0 +1,7 @@
+namespace JosephGuadagno.Broadcasting.Web.Models;
+
+/// <summary>
+/// Identifies a (platform × message-type) combination that is required for the current user
+/// but does not yet have a message template.
+/// </summary>
+public sealed record MissingTemplateKey(string Platform, string MessageType);

--- a/src/JosephGuadagno.Broadcasting.Web/Services/MessageTemplateService.cs
+++ b/src/JosephGuadagno.Broadcasting.Web/Services/MessageTemplateService.cs
@@ -52,6 +52,41 @@ public class MessageTemplateService(IDownstreamApi apiClient) : IMessageTemplate
     }
 
     /// <summary>
+    /// Gets the system default template for a platform and message type
+    /// </summary>
+    public async Task<MessageTemplate?> GetDefaultAsync(string platform, string messageType)
+    {
+        return await apiClient.GetOptionalForUserAsync<MessageTemplate>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{MessageTemplateBaseUrl}/defaults/{platform}/{messageType}";
+        });
+    }
+
+    /// <summary>
+    /// Gets all system default message templates
+    /// </summary>
+    public async Task<List<MessageTemplate>?> GetAllDefaultsAsync()
+    {
+        var result = await apiClient.GetOptionalForUserAsync<List<MessageTemplate>>(ApiServiceName, options =>
+        {
+            options.RelativePath = $"{MessageTemplateBaseUrl}/defaults";
+        });
+        return result;
+    }
+
+    /// <summary>
+    /// Creates a new user-owned message template
+    /// </summary>
+    public async Task<MessageTemplate?> CreateAsync(string platform, MessageTemplate messageTemplate)
+    {
+        return await apiClient.PostForUserAsync<MessageTemplate, MessageTemplate>(ApiServiceName, messageTemplate, options =>
+        {
+            options.RelativePath = $"{MessageTemplateBaseUrl}/{platform}/{messageTemplate.MessageType}";
+        });
+    }
+
+
+    /// <summary>
     /// Updates a message template
     /// </summary>
     public async Task<MessageTemplate?> UpdateAsync(string platform, MessageTemplate messageTemplate)

--- a/src/JosephGuadagno.Broadcasting.Web/Views/MessageTemplates/Create.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/MessageTemplates/Create.cshtml
@@ -1,0 +1,109 @@
+@model JosephGuadagno.Broadcasting.Web.Models.MessageTemplateViewModel
+
+@{
+    ViewData["Title"] = $"Create Template — {Model.Platform} / {Model.MessageType}";
+}
+
+<h1>Create Message Template</h1>
+<p class="lead">
+    Create a personalized <a href="https://scriban.github.io/docs/" target="_blank" rel="noopener">Scriban</a> template
+    for <strong>@Model.MessageType</strong> posts on <strong>@Model.Platform</strong>.
+    The form is pre-populated with the system default — customize it to your liking and save.
+</p>
+
+<div class="row g-4">
+    <div class="col-lg-8">
+        <form asp-action="Create" method="post">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <input type="hidden" asp-for="Platform" />
+            <input type="hidden" asp-for="MessageType" />
+
+            <div class="mb-3">
+                <label class="form-label">Platform</label>
+                <input type="text" class="form-control" value="@Model.Platform" readonly />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Message Type</label>
+                <input type="text" class="form-control" value="@Model.MessageType" readonly />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Description" class="form-label">Description</label>
+                <input asp-for="Description" type="text" class="form-control"
+                       placeholder="Optional description of this template" autocomplete="off" aria-describedby="val-Description" />
+                <span id="val-Description" asp-validation-for="Description" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="Template" class="form-label">Template</label>
+                <textarea asp-for="Template" class="form-control" rows="6"
+                          style="font-family: monospace; font-size: 0.9em;"
+                          placeholder="e.g. {{ title }} {{ url }} {{ tags }}" autocomplete="off" aria-describedby="val-Template"></textarea>
+                <span id="val-Template" asp-validation-for="Template" class="text-danger"></span>
+                <div class="form-text">Use Scriban syntax. See variable reference panel →</div>
+            </div>
+
+            <button type="submit" class="btn btn-success">
+                <i class="bi bi-plus-circle me-2"></i>Create
+            </button>
+            <a asp-action="Index" asp-controller="MessageTemplates" class="btn btn-outline-secondary ms-2">
+                <i class="bi bi-x-circle me-1"></i>Cancel
+            </a>
+        </form>
+    </div>
+
+    <div class="col-lg-4">
+        <div class="card border-info">
+            <div class="card-header bg-info bg-opacity-10">
+                <i class="bi bi-info-circle me-1"></i><strong>Scriban Variable Reference</strong>
+            </div>
+            <div class="card-body">
+                <p class="card-text small text-muted mb-2">
+                    The following variables are available in all templates. Not all variables are populated for every
+                    item type — unused variables render as empty string.
+                </p>
+                <table class="table table-sm table-borderless mb-2">
+                    <thead>
+                    <tr>
+                        <th>Variable</th>
+                        <th>Description</th>
+                    </tr>
+                    </thead>
+                    <tbody style="font-family: monospace; font-size: 0.85em;">
+                    <tr>
+                        <td>{{ "{{" }} title {{ "}}" }}</td>
+                        <td class="text-muted" style="font-family: sans-serif; font-size: 0.8em;">Post title or name</td>
+                    </tr>
+                    <tr>
+                        <td>{{ "{{" }} url {{ "}}" }}</td>
+                        <td class="text-muted" style="font-family: sans-serif; font-size: 0.8em;">Shortened URL (or full URL)</td>
+                    </tr>
+                    <tr>
+                        <td>{{ "{{" }} description {{ "}}" }}</td>
+                        <td class="text-muted" style="font-family: sans-serif; font-size: 0.8em;">Comments / description</td>
+                    </tr>
+                    <tr>
+                        <td>{{ "{{" }} tags {{ "}}" }}</td>
+                        <td class="text-muted" style="font-family: sans-serif; font-size: 0.8em;">Tags string (e.g. #dotnet)</td>
+                    </tr>
+                    <tr>
+                        <td>{{ "{{" }} image_url {{ "}}" }}</td>
+                        <td class="text-muted" style="font-family: sans-serif; font-size: 0.8em;">Optional image URL</td>
+                    </tr>
+                    </tbody>
+                </table>
+                <p class="card-text small text-muted">
+                    <strong>Variable availability by item type:</strong><br />
+                    <em>Syndication Feed / YouTube:</em> title, url, tags, image_url<br />
+                    <em>Engagement:</em> title, url, description, image_url<br />
+                    <em>Talk:</em> title, url, description, image_url
+                </p>
+                <p class="card-text small text-muted mb-0">
+                    <strong>Example:</strong><br />
+                    <code>{{ "{{" }} title {{ "}}" }} {{ "{{" }} url {{ "}}" }} {{ "{{" }} tags {{ "}}" }}</code>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/src/JosephGuadagno.Broadcasting.Web/Views/MessageTemplates/Index.cshtml
+++ b/src/JosephGuadagno.Broadcasting.Web/Views/MessageTemplates/Index.cshtml
@@ -91,6 +91,48 @@
     </table>
 }
 
+
+@{
+    var availableDefaults = ViewBag.AvailableDefaults as List<JosephGuadagno.Broadcasting.Web.Models.MessageTemplateViewModel>;
+}
+@if (availableDefaults is { Count: > 0 })
+{
+    <hr class="mt-5" />
+    <h2 class="mt-4 mb-2"><i class="bi bi-stars me-2"></i>Available Default Templates</h2>
+    <p class="text-muted">These system-provided templates don't have a personal version yet. Click <strong>Use Default</strong> to create your own copy.</p>
+    <table class="table table-striped table-hover table-bordered">
+        <thead>
+        <tr>
+            <th scope="col" class="col-2">Platform</th>
+            <th scope="col" class="col-2">Message Type</th>
+            <th scope="col" class="col-3">Description</th>
+            <th scope="col">Template</th>
+            <th scope="col" class="col-1 text-end">&nbsp;</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var def in availableDefaults)
+        {
+            var truncated = def.Template.Length > 80 ? def.Template.Substring(0, 80) + "…" : def.Template;
+            <tr>
+                <td>@def.Platform</td>
+                <td>@def.MessageType</td>
+                <td>@def.Description</td>
+                <td><span title="@def.Template" data-bs-toggle="tooltip" data-bs-placement="top">@truncated</span></td>
+                <td class="text-end">
+                    <a asp-action="Create" asp-controller="MessageTemplates"
+                       asp-route-platform="@def.Platform"
+                       asp-route-messageType="@def.MessageType"
+                       class="btn btn-outline-success btn-sm">
+                        <i class="bi bi-plus-circle me-1"></i>Use Default
+                    </a>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
 <partial name="_PaginationPartial" />
 
 @section Scripts {


### PR DESCRIPTION
## Summary

Implements Issue #979 - provide system-level default Scriban templates for each platform x message-type combination, and let users adopt a default with a single click.

## Changes

### Database
- MessageTemplates PK changed to `(SocialMediaPlatformId, MessageType, CreatedByEntraOid)`; `CreatedByEntraOid nvarchar(36) not null default ''`
- Empty string `''` is the system-default sentinel (`MessageTemplates.SystemOwnerEntraOid`)
- Seed: 20 `IF NOT EXISTS`-guarded system defaults (Bluesky, Twitter, LinkedIn, Facebook x 5 message types)

### Domain / Data / Manager
- Added `GetAsync` (3-arg), `CreateAsync`, `GetAllDefaultsAsync` to DataStore/Manager/Service interfaces
- `GetAsync` (2-arg) delegates to 3-arg with `SystemOwnerEntraOid` — backward-compatible for Functions/publishers
- Cache keys now include `ownerOid`; separate `CacheKeyDefaults` list cache
- `UpdateAsync` looks up by triplet (platformId, messageType, ownerOid)

### API
- `GET /messagetemplates/{platform}/{messageType}` — now returns user's own template (404 if missing, no Forbid)
- `GET /messagetemplates/defaults` — all system defaults
- `GET /messagetemplates/defaults/{platform}/{messageType}` — one system default
- `POST /messagetemplates/{platform}/{messageType}` — create user-owned template

### Web
- Index: Available Defaults section shows system templates not yet claimed by the user, with Use Default buttons
- Create GET/POST: pre-populate from system default, save as user-owned copy
- Edit: removed stale nullable check on `CreatedByEntraOid`

### Tests
- Renamed `WhenNonOwner_ReturnsForbid` tests to `WhenUserHasNoTemplate_ReturnsNotFound` (behavior change)
- Added API tests: `GetDefaultAsync`, `GetAllDefaultsAsync`, `CreateAsync`
- Fixed `CreateMessageTemplate` helper (`string ownerOid = ""`)
- Added DataStore tests: 3-arg `GetAsync`, `CreateAsync`, `GetAllDefaultsAsync`, `UpdateAsync` triplet

## Production migration

Manual DB migration required — see Issue #983 for step-by-step instructions.

Closes #979