### PR TITLE
chore(deps): combine all Dependabot dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.x'
           dotnet-quality: 'preview'
@@ -137,7 +137,7 @@ jobs:
         with:
           languages: csharp
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.x'
           dotnet-quality: 'preview'

--- a/.github/workflows/main_api-jjgnet-broadcast.yml
+++ b/.github/workflows/main_api-jjgnet-broadcast.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.x'
 

--- a/.github/workflows/main_jjgnet-broadcast.yml
+++ b/.github/workflows/main_jjgnet-broadcast.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Set up the .NET SDK
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/main_web-jjgnet-broadcast.yml
+++ b/.github/workflows/main_web-jjgnet-broadcast.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.x'
 

--- a/src/JosephGuadagno.Broadcasting.Api/JosephGuadagno.Broadcasting.Api.csproj
+++ b/src/JosephGuadagno.Broadcasting.Api/JosephGuadagno.Broadcasting.Api.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.6" />
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.14" />

--- a/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions.Tests/JosephGuadagno.Broadcasting.Functions.Tests.csproj
@@ -37,7 +37,7 @@
         <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
         <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
         <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />

--- a/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.4.6" />
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.6" />
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />

--- a/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
@@ -77,7 +77,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.6.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="Scriban" Version="7.2.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />

--- a/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
+++ b/src/JosephGuadagno.Broadcasting.Functions/JosephGuadagno.Broadcasting.Functions.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.4.6" />
     <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.3.5" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />

--- a/src/JosephGuadagno.Broadcasting.Managers.Bluesky/JosephGuadagno.Broadcasting.Managers.Bluesky.csproj
+++ b/src/JosephGuadagno.Broadcasting.Managers.Bluesky/JosephGuadagno.Broadcasting.Managers.Bluesky.csproj
@@ -37,7 +37,7 @@
       <!-- Security: override transitive 10.0.2 ΓåÆ 13.0.3 to resolve GHSA-5crp-9r3c-p9vr (High: NU1903) -->
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="idunno.Bluesky" Version="1.8.3" />
+      <PackageReference Include="idunno.Bluesky" Version="3.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
       <PackageReference Include="X.Web.MetaExtractor" Version="2.1.1" />

--- a/src/JosephGuadagno.Broadcasting.Web.Tests/JosephGuadagno.Broadcasting.Web.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.Web.Tests/JosephGuadagno.Broadcasting.Web.Tests.csproj
@@ -35,7 +35,7 @@
     <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
     <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/src/JosephGuadagno.Broadcasting.Web/JosephGuadagno.Broadcasting.Web.csproj
+++ b/src/JosephGuadagno.Broadcasting.Web/JosephGuadagno.Broadcasting.Web.csproj
@@ -46,7 +46,7 @@
         <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.4.6" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.6" />
-        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
+        <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
         <PackageReference Include="AutoMapper" Version="16.1.1" />
         <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />

--- a/src/JosephGuadagno.Broadcasting.YouTubeReader.Tests/JosephGuadagno.Broadcasting.YouTubeReader.Tests.csproj
+++ b/src/JosephGuadagno.Broadcasting.YouTubeReader.Tests/JosephGuadagno.Broadcasting.YouTubeReader.Tests.csproj
@@ -47,7 +47,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Google.Apis.YouTube.v3" Version="1.74.0.4137" />
+        <PackageReference Include="Google.Apis.YouTube.v3" Version="1.75.0.4207" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/JosephGuadagno.Broadcasting.YouTubeReader/JosephGuadagno.Broadcasting.YouTubeReader.csproj
+++ b/src/JosephGuadagno.Broadcasting.YouTubeReader/JosephGuadagno.Broadcasting.YouTubeReader.csproj
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\JosephGuadagno.Broadcasting.Domain\JosephGuadagno.Broadcasting.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.74.0.4137" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.75.0.4207" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Combines all 6 open Dependabot PRs into a single update, resolving merge conflicts and transitive dependency issues.

### Package Updates

| Package | From | To | Project |
|---------|------|----|---------|
| Microsoft.AspNetCore.OpenApi | 10.0.8 | 10.0.10 | Api |
| idunno.Bluesky | 1.8.3 | 3.0.0 | Managers.Bluesky |
| Google.Apis.YouTube.v3 | 1.74.0.4137 | 1.75.0.4207 | YouTubeReader, YouTubeReader.Tests |
| Aspire.Microsoft.EntityFrameworkCore.SqlServer | 13.3.5 | 13.4.6 | Functions, Functions.Tests, Web, Web.Tests |
| Aspire.Azure.Storage.Queues | 13.3.5 | 13.4.6 | Functions |
| actions/setup-dotnet | 5 | 6 | CI workflows |
| OpenTelemetry.Extensions.Hosting | 1.15.3 | 1.16.0 | Functions (required by idunno.Bluesky 3.0.0) |

### Conflict Resolution

- **Functions.csproj**: Both `Aspire.Azure.Storage.Queues` and `Aspire.Microsoft.EntityFrameworkCore.SqlServer` updated to 13.4.6 (separate Dependabot PRs each only bumped one)
- **OpenTelemetry.Extensions.Hosting**: Bumped from 1.15.3 → 1.16.0 to satisfy transitive dependency from `idunno.Bluesky` 3.0.0 → `idunno.AtProto` 3.0.0

### Supersedes

Closes #1032, closes #1031, closes #1030, closes #1029, closes #1028, closes #1027